### PR TITLE
Add ajax sort for table module

### DIFF
--- a/examples/table.html
+++ b/examples/table.html
@@ -21,7 +21,7 @@ body{padding: 20px;}
   <button class="layui-btn" data-type="isAll">验证是否全选</button>
 </div>
 
-<table class="layui-table" lay-data="{width:900, height:'full-100', url:'json/table/demo1.json', page:true, id:'test'}" lay-filter="test">
+<table class="layui-table" lay-data="{width:900, ajaxSort: true, height:'full-100', url:'json/table/demo1.json', page:true, id:'test'}" lay-filter="test">
   <thead>
     <tr>
       <th lay-data="{checkbox:true, fixed: true}"></th>
@@ -350,11 +350,12 @@ layui.use('table', function(){
     }
   });
   
-  //监听排序
+  //监听排序,
+  // id=test 使用服务器端排序，设置 ajaxSort 为 true
   table.on('sort(test)', function(obj){
     console.log(this, obj.field, obj.type)
     
-    return;
+    // return;
     table.reload('test', {
       initSort: obj
       ,where: { //重新请求服务端

--- a/src/lay/modules/table.js
+++ b/src/lay/modules/table.js
@@ -521,14 +521,20 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
       ,sort: type
     };
 
-    if(type === 'asc'){ //升序
-      thisData = layui.sort(data, field);
-    } else if(type === 'desc'){ //降序
-      thisData = layui.sort(data, field, true);
-    } else { //清除排序
-      thisData = layui.sort(data, table.config.indexName);
-      delete that.sortKey;
+    // 此处添加服务端排序判断 ajaxSort 参数，如果如果为 true, 则不用排序，排序数据由服务端返回。
+    if(config.ajaxSort === true){
+      thisData = data;
+    } else {
+      if(type === 'asc'){ //升序
+        thisData = layui.sort(data, field);
+      } else if(type === 'desc'){ //降序
+        thisData = layui.sort(data, field, true);
+      } else { //清除排序
+        thisData = layui.sort(data, table.config.indexName);
+        delete that.sortKey;
+      }
     }
+    
     
     res[config.response.dataName] = thisData;
     that.renderData(res, that.page, that.count, true);


### PR DESCRIPTION
目前点击排序图标都是前端排序，对于这种异步获取数据并带翻页的表格来说，是毫无意义的，虽然目前可以实现服务器点重新请求，但是前端还是会排序，但是有些特殊字符排序结果跟后端不一致的情况。所以添加了点击排序按钮后直接请求后端接口，并不进行前端排序的参数 `ajaxSort`, 示例如下：

```html
<table class="layui-table" lay-data="{width:900, ajaxSort: true, height:'full-100', url:'json/table/demo1.json', page:true, id:'test'}" lay-filter="test">
  <thead>
    <tr>
      <th lay-data="{checkbox:true, fixed: true}"></th>
      <th lay-data="{field:'id', width:80, fixed: true, sort: true}">ID</th>
      <th lay-data="{field:'username', width:120, sort: true, edit: 'text', templet: '#usernameTpl'}">用户名</th>
      <th lay-data="{field:'email', width:150}">邮箱</th>
      <th lay-data="{field:'sex', width:80}">性别</th>
      <th lay-data="{field:'city', width:100}">城市</th>
      <th lay-data="{field:'sign', width:150}">签名</th>
      <th lay-data="{field:'experience', width:80, sort: true, edit: 'text'}">积分</th>
      <th lay-data="{field:'ip', width:120}">IP</th>
      <th lay-data="{field:'logins', width:100}">登入次数</th>
      <th lay-data="{field:'joinTime', width:120}">加入时间</th>
      <th lay-data="{fixed: 'right', toolbar: '#barDemo', width:150, align:'center'}">操作</th>
    </tr>
  </thead>
</table>
```

已在 `example/table.html` 中修改了示例。

当然也可以在初始化 `table` 的时候配置参数 `ajaxSort` 为 `true`。