### PR TITLE
此PR解决了response选项定义的字段别名不支持多层级的情况

### DIFF
--- a/src/lay/modules/table.js
+++ b/src/lay/modules/table.js
@@ -268,6 +268,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
 
   //获取响应数据
   Class.prototype.fetchResponse = function(res, key){
+    if (res[key] != undefined) return res[key];
     var separator = this.config.response.separator || '.';
     if (key.indexOf(separator) != -1) {
       var keys = key.split(separator);

--- a/src/lay/modules/table.js
+++ b/src/lay/modules/table.js
@@ -3,12 +3,12 @@
  @Name：layui.table 表格操作
  @Author：贤心
  @License：MIT
-    
+
  */
- 
+
 layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
   "use strict";
-  
+
   var $ = layui.$
   ,laytpl = layui.laytpl
   ,laypage = layui.laypage
@@ -25,28 +25,28 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
     } //全局配置项
     ,cache: {} //数据缓存
     ,index: layui.table ? (layui.table.index + 10000) : 0
-    
+
     //设置全局项
     ,set: function(options){
       var that = this;
       that.config = $.extend({}, that.config, options);
       return that;
     }
-    
+
     //事件监听
     ,on: function(events, callback){
       return layui.onevent.call(this, MOD_NAME, events, callback);
     }
   }
-  
+
   //操作当前实例
   ,thisTable = function(){
     var that = this
     ,options = that.config
     ,id = options.id;
-    
+
     id && (thisTable.config[id] = options);
-    
+
     return {
       reload: function(options){
         that.reload.call(that, options);
@@ -54,12 +54,12 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
       ,config: options
     }
   }
-  
+
   //字符常量
   ,MOD_NAME = 'table', ELEM = '.layui-table', THIS = 'layui-this', SHOW = 'layui-show', HIDE = 'layui-hide', DISABLED = 'layui-disabled', NONE = 'layui-none'
-  
+
   ,ELEM_VIEW = 'layui-table-view', ELEM_HEADER = '.layui-table-header', ELEM_BODY = '.layui-table-body', ELEM_MAIN = '.layui-table-main', ELEM_FIXED = '.layui-table-fixed', ELEM_FIXL = '.layui-table-fixed-l', ELEM_FIXR = '.layui-table-fixed-r', ELEM_TOOL = '.layui-table-tool', ELEM_SORT = '.layui-table-sort', ELEM_EDIT = 'layui-table-edit', ELEM_HOVER = 'layui-table-hover'
-  
+
   //thead区域模板
   ,TPL_HEADER = function(options){
     options = options || {};
@@ -107,13 +107,13 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
       ,'</thead>'
     ,'</table>'].join('');
   }
-  
+
   //tbody区域模板
   ,TPL_BODY = ['<table cellspacing="0" cellpadding="0" border="0" class="layui-table" '
     ,'{{# if(d.data.skin){ }}lay-skin="{{d.data.skin}}"{{# } }} {{# if(d.data.size){ }}lay-size="{{d.data.size}}"{{# } }} {{# if(d.data.even){ }}lay-even{{# } }}>'
     ,'<tbody></tbody>'
   ,'</table>'].join('')
-  
+
   //主模板
   ,TPL_MAIN = ['<div class="layui-form layui-border-box {{d.VIEW_CLASS}}" lay-filter="LAY-table-{{d.index}}" style="{{# if(d.data.width){ }}width:{{d.data.width}}px;{{# } }} {{# if(d.data.height){ }}height:{{d.data.height}}px;{{# } }}">'
     ,'{{# var left, right; }}'
@@ -123,18 +123,18 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
     ,'<div class="layui-table-body layui-table-main">'
       ,TPL_BODY
     ,'</div>'
-    
+
     ,'{{# if(left){ }}'
     ,'<div class="layui-table-fixed layui-table-fixed-l">'
       ,'<div class="layui-table-header">'
-        ,TPL_HEADER({fixed: true}) 
+        ,TPL_HEADER({fixed: true})
       ,'</div>'
       ,'<div class="layui-table-body">'
         ,TPL_BODY
-      ,'</div>'      
+      ,'</div>'
     ,'</div>'
     ,'{{# }; }}'
-    
+
     ,'{{# if(right){ }}'
     ,'<div class="layui-table-fixed layui-table-fixed-r">'
       ,'<div class="layui-table-header">'
@@ -146,13 +146,13 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
       ,'</div>'
     ,'</div>'
     ,'{{# }; }}'
-    
+
     ,'{{# if(d.data.page){ }}'
     ,'<div class="layui-table-tool">'
       ,'<div class="layui-inline layui-table-page" id="layui-table-page{{d.index}}"></div>'
     ,'</div>'
     ,'{{# } }}'
-    
+
     ,'<style>'
     ,'{{# layui.each(d.data.cols, function(i1, item1){'
       ,'layui.each(item1, function(i2, item2){ }}'
@@ -161,10 +161,10 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
     ,'}); }}'
     ,'</style>'
   ,'</div>'].join('')
-  
+
   ,_WIN = $(window)
   ,_DOC = $(document)
-  
+
   //构造器
   ,Class = function(options){
     var that = this;
@@ -172,7 +172,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
     that.config = $.extend({}, that.config, table.config, options);
     that.render();
   };
-  
+
   //默认配置
   Class.prototype.config = {
     limit: 30 //每页显示的数量
@@ -182,19 +182,19 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
   //表格渲染
   Class.prototype.render = function(sets){
     var that = this, options;
-    
+
     if(sets) that.config = sets;
     options = that.config;
-    
+
     options.elem = $(options.elem);
     options.where = options.where || {};
-    
+
     //请求参数的自定义格式
     options.request = $.extend({
       pageName: 'page'
       ,limitName: 'limit'
     }, options.request)
-    
+
     //响应数据的自定义格式
     options.response = $.extend({
       statusName: 'code'
@@ -202,13 +202,14 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
       ,msgName: 'msg'
       ,dataName: 'data'
       ,countName: 'count'
+      ,separator: '.'
     }, options.response);
-    
+
     if(!options.elem[0]) return that;
 
     var othis = options.elem
     ,hasRender = othis.next('.' + ELEM_VIEW);
-    
+
     if(options.height && /^full-\d+$/.test(options.height)){ //full-差距值
       that.fullHeightGap = options.height.split('-')[1];
       options.height = _WIN.height() - that.fullHeightGap;
@@ -220,13 +221,13 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
       ,data: options
       ,index: that.index //索引
     }));
-    
+
     options.index = that.index;
-    
+
     //生成替代元素
     hasRender[0] && hasRender.remove(); //如果已经渲染，则Rerender
     othis.after(reElem);
-    
+
     //各级容器
     that.layHeader = reElem.find(ELEM_HEADER);
     that.layMain = reElem.find(ELEM_MAIN);
@@ -235,29 +236,44 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
     that.layFixLeft = reElem.find(ELEM_FIXL);
     that.layFixRight = reElem.find(ELEM_FIXR);
     that.layTool = reElem.find(ELEM_TOOL);
-    
+
     //设置body区域高度
     if(options.height){
       that.fullSize();
     }
-    
+
     //如果多级表头，则填补表头高度
     if(options.cols.length > 1){
       var th = that.layFixed.find(ELEM_HEADER).find('th');
       th.height(that.layHeader.height() - 1 - parseFloat(th.css('padding-top')) - parseFloat(th.css('padding-bottom')));
     }
-    
+
     that.pullData(1);
     that.events();
   };
-  
+
   //表格重载
   Class.prototype.reload = function(options){
     var that = this;
     that.config = $.extend({}, that.config, options);
     that.render();
   };
-  
+
+  //获取响应数据
+  Class.prototype.fetchResponse = function(res, key){
+    var separator = this.config.response.separator || '.';
+    if (key.indexOf(separator) != -1) {
+      var keys = key.split(separator);
+      do {
+        res = res[keys.shift()];
+      } while (keys.length > 0);
+      return res;
+    }
+    else {
+      return res[key];
+    }
+  };
+
   //获得数据
   Class.prototype.pullData = function(curr, loadIndex){
     var that = this
@@ -269,7 +285,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
         that.sort(options.initSort.field, options.initSort.type);
       }
     };
-    
+
     if(options.url){ //Ajax请求
       var params = {};
       params[request.pageName] = curr;
@@ -280,13 +296,13 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
         ,data: $.extend(params, options.where)
         ,dataType: 'json'
         ,success: function(res){
-          if(res[response.statusName] != response.statusCode){
+          if(that.fetchResponse(res, response.statusName) != response.statusCode){
             that.renderForm();
-            return that.layMain.html('<div class="'+ NONE +'">'+ (res[response.msgName] || '返回的数据状态异常') +'</div>');
+            return that.layMain.html('<div class="'+ NONE +'">'+ (that.fetchResponse(res, response.msgName) || '返回的数据状态异常') +'</div>');
           }
-          that.renderData(res, curr, res[response.countName]), sort();
+          that.renderData(res, curr, that.fetchResponse(res, response.countName)), sort();
           loadIndex && layer.close(loadIndex);
-          typeof options.done === 'function' && options.done(res, curr, res[response.countName]);
+          typeof options.done === 'function' && options.done(res, curr, that.fetchResponse(res, response.countName));
         }
         ,error: function(e, m){
           that.layMain.html('<div class="'+ NONE +'">数据接口请求异常</div>');
@@ -297,7 +313,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
     } else if(options.data && options.data.constructor === Array){ //已知数据
       var res = {}
       ,startLimit = curr*options.limit - options.limit
-      
+
       res[response.dataName] = options.data.concat().splice(startLimit, options.limit);
       res[response.countName] = options.data.length;
 
@@ -305,10 +321,10 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
       typeof options.done === 'function' && options.done(res, curr, res[response.countName]);
     }
   };
-  
+
   //页码
   Class.prototype.page = 1;
-  
+
   //遍历表头
   Class.prototype.eachCols = function(callback){
     var cols = $.extend(true, [], this.config.cols)
@@ -341,19 +357,19 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
         callback(i, item);
       });
     };
-    
+
     eachArrs();
   };
-  
+
   //数据渲染
   Class.prototype.renderData = function(res, curr, count, sort){
     var that = this
     ,options = that.config
-    ,data = res[options.response.dataName] || []
+    ,data = that.fetchResponse(res, options.response.dataName) || []
     ,trs = []
     ,trs_fixed = []
     ,trs_fixed_r = []
-    
+
     //渲染视图
     ,render = function(){
       if(!sort && that.sortKey){
@@ -369,7 +385,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
           var content = item1[item3.field||i3];
           if(content === undefined || content === null) content = '';
           if(item3.colspan > 1) return;
-          
+
           var td = ['<td data-field="'+ (item3.field||i3) +'"'+ function(){
             var attr = [];
             if(item3.edit) attr.push(' data-edit="true"'); //是否允许单元格编辑
@@ -390,9 +406,9 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
                   var checkName = table.config.checkName;
                   if(item3[checkName]){
                     item1[checkName] = item3[checkName];
-                    return item3[checkName] ? 'checked' : ''; 
+                    return item3[checkName] ? 'checked' : '';
                   }
-                  return item1[checkName] ? 'checked' : '';                   
+                  return item1[checkName] ? 'checked' : '';
                 }() +'>';
               }
               if(item3.toolbar){
@@ -401,7 +417,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
               return item3.templet ? laytpl($(item3.templet).html() || String(content)).render(item1) : content;
             }()
           ,'</div></td>'].join('');
-          
+
           tds.push(td);
           if(item3.fixed && item3.fixed !== 'right') tds_fixed.push(td);
           if(item3.fixed === 'right') tds_fixed_r.push(td);
@@ -410,13 +426,13 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
         trs_fixed.push('<tr data-index="'+ i1 +'">'+ tds_fixed.join('') + '</tr>');
         trs_fixed_r.push('<tr data-index="'+ i1 +'">'+ tds_fixed_r.join('') + '</tr>');
       });
-      
+
       that.layBody.scrollTop(0);
       that.layMain.find('.'+ NONE).remove();
       that.layMain.find('tbody').html(trs.join(''));
       that.layFixLeft.find('tbody').html(trs_fixed.join(''));
       that.layFixRight.find('tbody').html(trs_fixed_r.join(''));
-      
+
       that.renderForm();
       that.syncCheckAll();
       that.haveInit ? that.scrollPatch() : setTimeout(function(){
@@ -425,15 +441,15 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
       that.haveInit = true;
       layer.close(that.tipsIndex);
     };
-    
+
     that.key = options.id || options.index;
     table.cache[that.key] = data; //记录数据
-    
+
     //排序
     if(sort){
       return render();
     }
-    
+
     if(data.length === 0){
       that.renderForm();
       that.layFixed.remove();
@@ -443,7 +459,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
     }
 
     render();
-    
+
     //分页
     if(options.page){
       that.page = curr;
@@ -469,12 +485,12 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
       that.layTool.find('.layui-table-count span').html(count)
     }
   };
-  
+
   //渲染表单
   Class.prototype.renderForm = function(type){
     form.render((type || 'checkbox'), 'LAY-table-'+ this.index);
   }
-  
+
   //数据排序
   Class.prototype.sort = function(th, type, pull, formEvent){
     var that = this
@@ -483,7 +499,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
     ,config = that.config
     ,filter = config.elem.attr('lay-filter')
     ,data = table.cache[that.key], thisData;
-    
+
     //字段匹配
     if(typeof th === 'string'){
       that.layHeader.find('th').each(function(i, item){
@@ -499,14 +515,14 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
 
     try {
       var field = field || th.data('field');
-      
+
       //如果欲执行的排序已在状态中，则不执行渲染
       if(that.sortKey && !pull){
         if(field === that.sortKey.field && type === that.sortKey.sort){
           return;
         }
       }
-      
+
       var elemSort = that.layHeader.find('th .laytable-cell-'+ config.index +'-'+ field).find(ELEM_SORT);
       that.layHeader.find('th').find(ELEM_SORT).removeAttr('lay-sort'); //清除其它标题排序状态
       elemSort.attr('lay-sort', type || null);
@@ -514,7 +530,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
     } catch(e){
       return hint.error('Table modules: Did not match to field');
     }
-    
+
     //记录排序索引和类型
     that.sortKey = {
       field: field
@@ -529,11 +545,11 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
       thisData = layui.sort(data, table.config.indexName);
       delete that.sortKey;
     }
-    
+
     res[config.response.dataName] = thisData;
     that.renderData(res, that.page, that.count, true);
     layer.close(that.tipsIndex);
-    
+
     if(formEvent){
       layui.event.call(th, MOD_NAME, 'sort('+ filter +')', {
         field: field
@@ -541,7 +557,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
       });
     }
   };
-  
+
   //请求loading
   Class.prototype.loading = function(){
     var that = this
@@ -558,7 +574,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
       });
     }
   };
-  
+
   //同步选中值状态
   Class.prototype.setCheckData = function(index, checked){
     var that = this
@@ -567,7 +583,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
     if(!thisData[index]) return;
     thisData[index][config.checkName] = checked;
   };
-  
+
   //同步全选按钮状态
   Class.prototype.syncCheckAll = function(){
     var that = this
@@ -581,7 +597,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
       });
       return checked;
     };
-    
+
     if(!checkAllElem[0]) return
 
     if(table.checkStatus(that.key).isAll){
@@ -598,7 +614,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
       syncColsCheck(false);
     }
   };
-  
+
   //获取cssRule
   Class.prototype.getCssRule = function(field, callback){
     var that = this
@@ -611,13 +627,13 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
       }
     });
   };
-  
+
   //尺寸始终铺满
   Class.prototype.fullSize = function(){
     var that = this
     ,options = that.config
     ,height = options.height, bodyHeight;
-    
+
     if(that.fullHeightGap){
       height = _WIN.height() - that.fullHeightGap;
       if(height < 135) height = 135;
@@ -625,21 +641,21 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
     }
 
     //tbody区域高度
-    bodyHeight = parseFloat(height) - parseFloat(that.layHeader.height()) - 1;  
+    bodyHeight = parseFloat(height) - parseFloat(that.layHeader.height()) - 1;
     if(options.page){
       bodyHeight = bodyHeight - parseFloat(that.layTool.outerHeight() + 1);
     }
     that.layMain.css('height', bodyHeight);
-    
+
   };
-  
+
   //滚动条补丁
   Class.prototype.scrollPatch = function(){
     var that = this
     ,layMainTable = that.layMain.children('table')
     ,scollWidth = that.layMain.width() - that.layMain.prop('clientWidth') //纵向滚动条宽度
     ,scollHeight = that.layMain.height() - that.layMain.prop('clientHeight'); //横向滚动条高度
-    
+
     if(scollWidth && scollHeight){
       if(!that.elem.find('.layui-table-patch')[0]){
         var patchElem = $('<th class="layui-table-patch"><div class="layui-table-cell"></div></th>'); //补丁元素
@@ -651,17 +667,17 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
     } else {
       that.layHeader.eq(0).find('.layui-table-patch').remove();
     }
-    
+
     //固定列区域高度
     var mainHeight = that.layMain.height()
     ,fixHeight = mainHeight - scollHeight;
     that.layFixed.find(ELEM_BODY).css('height', layMainTable.height() > fixHeight ? fixHeight : 'auto');
-    
+
     //表格宽度小于容器宽度时，隐藏固定列
-    that.layFixRight[layMainTable.width() > that.layMain.width() ? 'removeClass' : 'addClass'](HIDE); 
-    
+    that.layFixRight[layMainTable.width() > that.layMain.width() ? 'removeClass' : 'addClass'](HIDE);
+
     //操作栏
-    that.layFixRight.css('right', scollWidth - 1); 
+    that.layFixRight.css('right', scollWidth - 1);
   };
 
   //事件处理
@@ -675,7 +691,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
     ,ELEM_CELL = '.layui-table-cell'
     ,filter = config.elem.attr('lay-filter');
 
-    //拖拽调整宽度    
+    //拖拽调整宽度
     th.on('mousemove', function(e){
       var othis = $(this)
       ,oLeft = othis.offset().left
@@ -695,7 +711,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
         e.preventDefault();
         dict.resizeStart = true; //开始拖拽
         dict.offset = [e.clientX, e.clientY]; //记录初始坐标
-        
+
         that.getCssRule(field, function(item){
           dict.rule = item;
           dict.ruleWidth = parseFloat(item.style.width);
@@ -723,7 +739,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
         resizing = null;
       }
     });
-    
+
     //排序
     th.on('click', function(){
       var othis = $(this)
@@ -731,8 +747,8 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
       ,nowType = elemSort.attr('lay-sort')
       ,type;
 
-      if(!elemSort[0] || resizing === 1) return resizing = 2;      
-      
+      if(!elemSort[0] || resizing === 1) return resizing = 2;
+
       if(nowType === 'asc'){
         type = 'desc';
       } else if(nowType === 'desc'){
@@ -752,7 +768,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
         that.sort(field, 'desc', null, true);
       }
     });
-    
+
     //复选框选择
     that.elem.on('click', 'input[name="layTableCheckbox"]+', function(){
       var checkbox = $(this).prev()
@@ -760,7 +776,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
       ,index = checkbox.parents('tr').eq(0).data('index')
       ,checked = checkbox[0].checked
       ,isAll = checkbox.attr('lay-filter') === 'layTableAllChoose';
-      
+
       //全选
       if(isAll){
         childs.each(function(i, item){
@@ -779,7 +795,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
         ,type: isAll ? 'all' : 'one'
       });
     });
-    
+
     //行事件
     that.layBody.on('mouseenter', 'tr', function(){
       var othis = $(this)
@@ -790,7 +806,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
       ,index = othis.index();
       that.layBody.find('tr:eq('+ index +')').removeClass(ELEM_HOVER)
     });
-    
+
     //单元格编辑
     that.layBody.on('change', '.'+ELEM_EDIT, function(){
       var othis = $(this)
@@ -798,9 +814,9 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
       ,field = othis.parent().data('field')
       ,index = othis.parents('tr').eq(0).data('index')
       ,data = table.cache[that.key][index];
-      
+
       data[field] = value; //更新缓存中的值
-      
+
       layui.event.call(this, MOD_NAME, 'edit('+ filter +')', {
         value: value
         ,data: data
@@ -823,15 +839,15 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
       othis.parent().data('content', this.value);
       othis.remove();
     });
-    
+
     //单元格事件
     that.layBody.on('click', 'td', function(){
       var othis = $(this)
       ,field = othis.data('field')
       ,elemCell = othis.children(ELEM_CELL);
-      
+
       if(othis.data('off')) return;
-      
+
       //显示编辑框
       if(othis.data('edit')){
         var input = $('<input class="'+ ELEM_EDIT +'">');
@@ -839,7 +855,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
         othis.find('.'+ELEM_EDIT)[0] || othis.append(input);
         return input.focus();
       }
-      
+
       //如果出现省略，则可查看更多
       if(Math.round(elemCell.prop('scrollWidth')) > Math.round(elemCell.outerWidth())){
         that.tipsIndex = layer.tips([
@@ -870,7 +886,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
         });
       }
     });
-    
+
     //工具条操作事件
     that.layBody.on('click', '*[lay-event]', function(){
       var othis = $(this)
@@ -878,7 +894,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
       ,tr = that.layBody.find('tr[data-index="'+ index +'"]')
       ,ELEM_CLICK = 'layui-table-click'
       ,data = table.cache[that.key][index];
-      
+
       layui.event.call(this, MOD_NAME, 'tool('+ filter +')', {
         data: table.clearCacheKey(data)
         ,event: othis.attr('lay-event')
@@ -909,25 +925,25 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
       });
       tr.addClass(ELEM_CLICK).siblings('tr').removeClass(ELEM_CLICK);
     });
-    
+
     //同步滚动条
     that.layMain.on('scroll', function(){
       var othis = $(this)
       ,scrollLeft = othis.scrollLeft()
       ,scrollTop = othis.scrollTop();
-      
+
       that.layHeader.scrollLeft(scrollLeft);
       that.layFixed.find(ELEM_BODY).scrollTop(scrollTop);
-      
+
       layer.close(that.tipsIndex);
     });
-    
+
     _WIN.on('resize', function(){ //自适应
        that.fullSize();
        that.scrollPatch();
     });
   };
-  
+
   //初始化
   table.init = function(filter, settings){
     settings = settings || {};
@@ -938,13 +954,13 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
     //遍历数据表格
     elemTable.each(function(){
       var othis = $(this), tableData = othis.attr('lay-data');
-      
+
       try{
         tableData = new Function('return '+ tableData)();
       } catch(e){
         hint.error(errorTips + tableData)
       }
-      
+
       var cols = [], options = $.extend({
         elem: this
         ,cols: []
@@ -953,21 +969,21 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
         ,size: othis.attr('lay-size') //尺寸
         ,even: typeof othis.attr('lay-even') === 'string' //偶数行背景
       }, table.config, settings, tableData);
-      
+
       filter && othis.hide();
-      
+
       //获取表头数据
       othis.find('thead>tr').each(function(i){
         options.cols[i] = [];
         $(this).children().each(function(ii){
           var th = $(this), itemData = th.attr('lay-data');
-          
+
           try{
             itemData = new Function('return '+ itemData)();
           } catch(e){
             return hint.error(errorTips + itemData)
           }
-          
+
           var row = $.extend({
             title: th.text()
             ,colspan: th.attr('colspan') || 0 //列单元格
@@ -1002,7 +1018,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
 
     return that;
   };
-  
+
   //表格选中状态
   table.checkStatus = function(id){
     var nums = 0
@@ -1021,7 +1037,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
       ,isAll: nums === data.length //是否全选
     };
   };
-  
+
   //表格重载
   thisTable.config = {};
   table.reload = function(id, options){
@@ -1029,13 +1045,13 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
     if(!config) return hint.error('The ID option was not found in the table instance');
     return table.render($.extend({}, config, options));
   };
- 
+
   //核心入口
   table.render = function(options){
     var inst = new Class(options);
     return thisTable.call(inst);
   };
-  
+
   //清除临时Key
   table.clearCacheKey = function(data){
     data = $.extend({}, data);
@@ -1043,11 +1059,9 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
     delete data[table.config.indexName];
     return data;
   };
-  
+
   //自动完成渲染
   table.init();
-  
+
   exports(MOD_NAME, table);
 });
-
- 

--- a/src/lay/modules/table.js
+++ b/src/lay/modules/table.js
@@ -173,6 +173,13 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
     that.render();
   };
 
+  function htmlUnescape(s) {
+    if (!s) return '';
+    return s.replace(/&lt;/g, '<')
+            .replace(/&gt;/g, '>')
+            .replace(/&amp;/g, '&');
+  }
+
   //默认配置
   Class.prototype.config = {
     limit: 30 //每页显示的数量
@@ -412,9 +419,9 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
                 }() +'>';
               }
               if(item3.toolbar){
-                return laytpl($(item3.toolbar).html()||'').render(item1);
+                return laytpl(htmlUnescape($(item3.toolbar).html())||'').render(item1);
               }
-              return item3.templet ? laytpl($(item3.templet).html() || String(content)).render(item1) : content;
+              return item3.templet ? laytpl(htmlUnescape($(item3.templet).html()) || String(content)).render(item1) : content;
             }()
           ,'</div></td>'].join('');
 
@@ -834,7 +841,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
         }
       });
       othis.siblings(ELEM_CELL).html(
-        templet ? laytpl($(templet).html() || this.value).render(data) : this.value
+        templet ? laytpl(htmlUnescape($(templet).html()) || this.value).render(data) : this.value
       );
       othis.parent().data('content', this.value);
       othis.remove();
@@ -916,7 +923,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
                 }
               });
               td.children(ELEM_CELL).html(
-                templet ? laytpl($(templet).html() || value).render(data) : value
+                templet ? laytpl(htmlUnescape($(templet).html()) || value).render(data) : value
               );
               td.data('content', value);
             }


### PR DESCRIPTION
后端返回的数据很有可能是这种情况，现有的逻辑没办法获取列表数据和总数：
```
{
  code:0,
  msg: "",
  data: {
    count: 8,
    list: []
  }
}
```
之后只要如此定义response即可：
```
response: {
  separator: '.' // “.”为默认值
  , countName: 'data.count'
  , dataName: 'data.list'
}
```

详见这个问题：http://fly.layui.com/jie/16110/
