### PR TITLE
增加curr配置参数，使表格render时，可设置初始页数，默认值为1

### DIFF
--- a/src/lay/modules/table.js
+++ b/src/lay/modules/table.js
@@ -22,6 +22,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
     config: {
       checkName: 'LAY_CHECKED' //是否选中状态的字段名
       ,indexName: 'LAY_TABLE_INDEX' //下标索引名
+      ,curr:1
     } //全局配置项
     ,cache: {} //数据缓存
     ,index: layui.table ? (layui.table.index + 10000) : 0
@@ -246,8 +247,8 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
       var th = that.layFixed.find(ELEM_HEADER).find('th');
       th.height(that.layHeader.height() - 1 - parseFloat(th.css('padding-top')) - parseFloat(th.css('padding-bottom')));
     }
-    
-    that.pullData(1);
+
+    that.pullData(that.config.curr);
     that.events();
   };
   


### PR DESCRIPTION
业务场景：
用户在数据表格的第10页进行某项操作修改数据后，需要reload数据表格，但是reload之后会重新回到第1页，这样用户不得不重新切换至第10页继续后续操作，使用起来很麻烦。

而本次pr就是解决这个问题，在reload或者render时，传入curr配置，即可设置显示第几页，如：
var tableIns = table.render({......});
tableIns.reload({curr:5});
table.reload('demoTable',{curr:5});


