### PR TITLE
table模块支持contentType为json

### DIFF
--- a/src/lay/modules/table.js
+++ b/src/lay/modules/table.js
@@ -411,11 +411,13 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
       var params = {};
       params[request.pageName] = curr;
       params[request.limitName] = options.limit;
-      
+	  var dataObj = $.extend(params, options.where);
+      options.contentType = options.contentType || 'application/x-www-form-urlencoded '
       $.ajax({
         type: options.method || 'get'
         ,url: options.url
-        ,data: $.extend(params, options.where)
+		,contentType: options.contentType
+        ,data: options.contentType ==='application/json'?JSON.stringify(dataObj):dataObj
         ,dataType: 'json'
         ,success: function(res){
           if(res[response.statusName] != response.statusCode){

--- a/src/lay/modules/table.js
+++ b/src/lay/modules/table.js
@@ -424,7 +424,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
             that.renderForm();
             that.layMain.html('<div class="'+ NONE +'">'+ (res[response.msgName] || '返回的数据状态异常') +'</div>');
           } else {
-            that.renderData(res, curr, res[response.countName]), sort();
+            that.renderData(res, curr, that.treeToList(res,response.countName)), sort();
             options.time = (new Date().getTime() - that.startTime) + ' ms'; //耗时（接口请求+视图渲染）
           }
           loadIndex && layer.close(loadIndex);
@@ -480,15 +480,24 @@ layui.define(['laytpl', 'laypage', 'layer', 'form'], function(exports){
         callback(i, item);
       });
     };
-    
+
     eachArrs();
   };
-  
+
+    // 循环获取路径下对象
+  Class.prototype.treeToList = function (data, path) {
+      var propList = path.split('.');
+      for (var i = 0; i < propList.length; i++) {
+          data = data[propList[i]];
+      }
+      return data;
+  }
+
   //数据渲染
   Class.prototype.renderData = function(res, curr, count, sort){
     var that = this
     ,options = that.config
-    ,data = res[options.response.dataName] || []
+    ,data = that.treeToList(res, options.response.dataName) || []
     ,trs = []
     ,trs_fixed = []
     ,trs_fixed_r = []


### PR DESCRIPTION
table模块支持contentType为application/json；
使用方法：
render里面增加
 contentType: "application/json",
例如：
 table.render({
            elem: '#table',
            url: '',
            method: 'POST',
            contentType: "application/json"
});
