### PR TITLE
调整导航条下小徽章的位置关系

### DIFF
--- a/src/css/layui.css
+++ b/src/css/layui.css
@@ -1044,7 +1044,7 @@ body .layui-table-tips .layui-layer-content{background: none; padding: 0; box-sh
 .layui-btn .layui-badge,
 .layui-btn .layui-badge-dot{margin-left: 5px;}
 .layui-nav .layui-badge,
-.layui-nav .layui-badge-dot{position: absolute; top: 50%; margin: -8px 6px 0;}
+.layui-nav .layui-badge-dot{margin: -8px 6px 0;}
 .layui-tab-title .layui-badge,
 .layui-tab-title .layui-badge-dot{left: 5px; top: -2px;}
 

--- a/src/css/layui.css
+++ b/src/css/layui.css
@@ -916,7 +916,7 @@ body .layui-table-tips .layui-layer-content{background: none; padding: 0; box-sh
 .layui-nav{position: relative; padding: 0 20px; background-color: #393D49; color: #fff; border-radius: 2px; font-size: 0; box-sizing: border-box;}
 .layui-nav *{font-size: 14px;}
 .layui-nav .layui-nav-item{position: relative; display: inline-block; *display: inline; *zoom: 1; vertical-align: middle; line-height: 60px;}
-.layui-nav .layui-nav-item a{display: block; padding: 0 20px; color: #fff; color: rgba(255,255,255,.7); transition: all .3s; -webkit-transition: all .3s;}
+.layui-nav .layui-nav-item a{display: block; padding: 0 20px; color: #fff; color: rgba(255,255,255,.7); transition: all .3s; -webkit-transition: all .3s; position: relative}
 .layui-nav-bar,
 .layui-nav .layui-this:after,
 .layui-nav-tree .layui-nav-itemed:after{position: absolute; left: 0; top: 0; width: 0; height: 5px; background-color: #5FB878; transition: all .2s; -webkit-transition: all .2s;}
@@ -1044,7 +1044,7 @@ body .layui-table-tips .layui-layer-content{background: none; padding: 0; box-sh
 .layui-btn .layui-badge,
 .layui-btn .layui-badge-dot{margin-left: 5px;}
 .layui-nav .layui-badge,
-.layui-nav .layui-badge-dot{margin: -8px 6px 0;}
+.layui-nav .layui-badge-dot{position: absolute; top: 50%; margin: -8px 6px 0; left: calc(100% - 20px)}
 .layui-tab-title .layui-badge,
 .layui-tab-title .layui-badge-dot{left: 5px; top: -2px;}
 


### PR DESCRIPTION
在导航条中，a标签中放置小徽章的时候，如果代码换行了，会导致小徽章位置出现偏差，建议将小徽章的绝对定位修改为相对于a标签的，以避免上述情况。