### PR TITLE
添加上传进度监听

### DIFF
--- a/src/lay/modules/upload.js
+++ b/src/lay/modules/upload.js
@@ -210,10 +210,11 @@ layui.define('layer' , function(exports){
           ,xhr:function (){
             var xhr = $.ajaxSettings.xhr();
             if(typeof options.progress === 'function' && xhr && xhr.upload){
-              xhr.upload.onprogress = function (event) {
+              $(xhr.upload).one('progress', function (events) {
+                event = events.currentTarget;
                 var schude = Math.round((event.loaded/event.totle) * 100)  + '%';
-                options.progress(schude);
-              };
+                options.progress(schude, events);
+              });
             }
             return xhr;
           }

--- a/src/lay/modules/upload.js
+++ b/src/lay/modules/upload.js
@@ -207,6 +207,16 @@ layui.define('layer' , function(exports){
           ,data: formData
           ,contentType: false 
           ,processData: false
+          ,xhr:function (){
+            var xhr = $.ajaxSettings.xhr();
+            if(typeof options.progress === 'function' && xhr && xhr.upload){
+              xhr.upload.onprogress = function (event) {
+                var schude = Math.round((event.loaded/event.totle) * 100)  + '%';
+                options.progress(schude);
+              };
+            }
+            return xhr;
+          }
           ,dataType: 'json'
           ,headers: options.headers || {}
           ,success: function(res){

--- a/src/lay/modules/upload.js
+++ b/src/lay/modules/upload.js
@@ -210,7 +210,7 @@ layui.define('layer' , function(exports){
           ,xhr:function (){
             var xhr = $.ajaxSettings.xhr();
             if(typeof options.progress === 'function' && xhr && xhr.upload){
-              $(xhr.upload).one('progress', function (events) {
+              $(xhr.upload).on('progress', function (events) {
                 event = events.currentTarget;
                 var schude = Math.round((event.loaded/event.totle) * 100)  + '%';
                 options.progress(schude, events);


### PR DESCRIPTION
> 我在使用的时候需要 监听进度，但是上传方法中没有提供一个 方法来实现，我使用了以下方式实现了，但是相当的麻烦。

```
layui.use(['upload', 'jquery', 'element'], function (){
    var element = layui.element,
        $ = layui.$ || layui.jquery,
        upload = layui.upload,
        xhr = $.ajaxSettings.xhr;
     upload.render({
        elem:'#test',
        before:function (){
            var x = xhr();
            x.upload && x.upload.onprogress = function (e) {
                // 处理进度
            };
            $.ajaxSend({xhr:x});
        },
        done:function () {
            $.ajaxSend({xhr:xhr});
            // 处理完成
        },
        error:function () {
            $.ajaxSend({xhr:xhr});
            // 处理错误
        }
     });
});
```