### PR TITLE
colorpicker颜色插件，不点击确定按钮，是否还原到原始颜色,添加属性配置

### DIFF
--- a/src/lay/modules/colorpicker.js
+++ b/src/lay/modules/colorpicker.js
@@ -152,6 +152,7 @@ layui.define('jquery', function(exports){
     color: ''  //默认颜色，默认没有
     ,size: null  //选择器大小
     ,alpha: false  //是否开启透明度
+    ,revert:1   //不点击确定按钮，是否还原到原始颜色，默认还原
     ,format: 'hex'  //颜色显示/输入格式，可选 rgb,hex
     ,predefine: false //预定义颜色是否开启
     ,colors: [ //默认预定义颜色列表
@@ -695,8 +696,9 @@ layui.define('jquery', function(exports){
       } else {
         that.elemColorBox.find('.' + PICKER_TRIG_I).removeClass(ICON_PICKER_DOWN).addClass(ICON_PICKER_CLOSE);
       }
-      elemColorBoxSpan[0].style.background = that.color || '';
-      
+      if(that.config.revert){
+        elemColorBoxSpan[0].style.background = that.color || '';
+      }
       that.removePicker();
     });
 


### PR DESCRIPTION

[#362颜色选择器，不点击确定会还原到原来的颜色，但为调用change或done方法！！](https://github.com/sentsin/layui/issues/362)