### PR TITLE
支持 Laravel 框架通过 composer install 安装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ build/
 rc/
 
 coverage/
+/vendor/
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,40 @@
+{
+    "name": "sentsin/layui",
+    "description": "采用自身模块规范编写的前端 UI 框架，遵循原生 HTML/CSS/JS 的书写形式，极低门槛，拿来即用。",
+    "type": "library",
+    "require": {
+        "laravel/framework": ">5.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": ">4.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Layui\\": "laravel/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Layui\\Test\\": "test/"
+        }
+    },
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Sentsin",
+            "email": "xu@sentsin.com"
+        },
+        {
+            "name": "Xiaohui Lam",
+            "email": "xiaohui.lam@e.hexdata.cn"
+        }
+    ],
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Layui\\LayuiServiceProvider"
+            ]
+        }
+    },
+    "minimum-stability": "stable"
+}

--- a/laravel/LayuiServiceProvider.php
+++ b/laravel/LayuiServiceProvider.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Layui;
+
+use Illuminate\Support\ServiceProvider;
+
+/**
+ * Layui的laravel服务包
+ */
+class LayuiServiceProvider extends ServiceProvider
+{
+    /**
+     * 发布Layui的`dist`到public目录下
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        $this->publishes([
+            'dist/' => public_path('vendor/layui/'),
+        ], 'layui');
+    }
+}

--- a/laravel/LayuiServiceProvider.php
+++ b/laravel/LayuiServiceProvider.php
@@ -17,7 +17,7 @@ class LayuiServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->publishes([
-            'dist/' => public_path('vendor/layui/'),
+            __DIR__ . '/../dist/' => public_path('vendor/layui/'),
         ], 'layui');
     }
 }


### PR DESCRIPTION
针对 Laravel 框架支持 composer 方式安装：
```bash
composer require sendsin/layui
```
针对 **Laravel 5.5 以下** 版本需要加以下指令到 `config/app.php` 的 `providers`。Laravel 5.5 + 版本已支持 `package:discover`，无需添加
```bash
'providers' => [
    ...
    Layui\LayuiServiceProvider::class, // 添加这一行
],
```

安装成功后，运行：
```bash
php artisan vendor:publish --tag=layui
```

即可将 layui 的资源文件( `dist/` 目录 )发布到 `public/vendor/layui` 下以便模板直接调用。
 
如果接受了本 pull request，需要去 [packagist/submit](https://packagist.org/packages/submit) 提交本项目，才可以被 php composer 社区接受。