### PR TITLE
修正upload.js模块默认配置中缺少acceptMime

### DIFF
--- a/src/lay/modules/upload.js
+++ b/src/lay/modules/upload.js
@@ -58,6 +58,7 @@ layui.define('layer' , function(exports){
   //默认配置
   Class.prototype.config = {
     accept: 'images' //允许上传的文件类型：images/file/video/audio
+    ,acceptMime: 'image/*' //打开文件选择框时，筛选出的文件类型
     ,exts: '' //允许上传的文件后缀名
     ,auto: true //是否选完文件后自动上传
     ,bindAction: '' //手动上传触发的元素


### PR DESCRIPTION
默认配置缺少acceptMime , 当用户未配置acceptMime时, 文件域的accept属性会为undefined

https://www.layui.com/doc/modules/upload.html#options 文档中acceptMime属性的默认值  应为 image/*  不是 images