### PR TITLE
修复form.js模块中select首个标签为optgroup时导致的问题

### DIFF
--- a/src/lay/modules/form.js
+++ b/src/lay/modules/form.js
@@ -415,14 +415,16 @@ layui.define('layer', function(exports){
             ,'<i class="layui-edge"></i></div>'
             ,'<dl class="layui-anim layui-anim-upbit'+ (othis.find('optgroup')[0] ? ' layui-select-group' : '') +'">'
             ,function(options){
-              var arr = [];
+              var arr = [], tips = true;
               layui.each(options, function(index, item){
-                if(index === 0 && !item.value){
-                  arr.push('<dd lay-value="" class="layui-select-tips">'+ (item.innerHTML || TIPS) +'</dd>');
-                } else if(item.tagName.toLowerCase() === 'optgroup'){
-                  arr.push('<dt>'+ item.label +'</dt>'); 
+                if (item.tagName.toLowerCase() === 'optgroup') {
+                  arr.push('<dt>' + item.label + '</dt>');
+                } else if(tips && !item.value){
+                  arr.push('<dd lay-value="" class="layui-select-tips">' + (item.innerHTML || TIPS) + '</dd>');
+                  tips = false;
                 } else {
                   arr.push('<dd lay-value="'+ item.value +'" class="'+ (value === item.value ?  THIS : '') + (item.disabled ? (' '+DISABLED) : '') +'">'+ item.innerHTML +'</dd>');
+                  tips = false;
                 }
               });
               arr.length === 0 && arr.push('<dd lay-value="" class="'+ DISABLED +'">没有选项</dd>');


### PR DESCRIPTION
修复form.js模块中select首个标签为optgroup时，替换出来的select的DOM结构错误，导致界面上的问题.
使用下面代码重现该问题:
    <select name="test" class="layui-select">
        <optgroup label="group1">
            <option value="1">option1</option>
        </optgroup>
    </select>