### PR TITLE
refactor(table): 配置分割符，防止修改laytpl源码默认分隔符导致解析出错

### DIFF
--- a/src/lay/modules/table.js
+++ b/src/lay/modules/table.js
@@ -222,6 +222,12 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
     that.config = $.extend({}, that.config, table.config, options);
     that.render();
   };
+
+  // 配置分割符，防止修改源码默认分隔符导致解析出错
+  laytpl.config({
+    open: '{{',
+    close: '}}'
+  });
   
   //默认配置
   Class.prototype.config = {


### PR DESCRIPTION
### 背景
社区连接：[table渲染错误，直接爆出源码中的tpl模板（layui.table的源码）。](https://fly.layui.com/jie/47058/)

### 修改
table中再次配置分割符，防止修改源码默认分隔符导致解析出错。
