### PR TITLE
动态渲染upload组件，input change事件丢失问题

### DIFF
--- a/src/lay/modules/upload.js
+++ b/src/lay/modules/upload.js
@@ -484,13 +484,17 @@ layui.define('layer' , function(exports){
     options.bindAction.off('upload.action').on('upload.action', function(){
       that.upload();
     });
+
+    that.elemFile.off('change').on('change', function () {
+        $(this).trigger('upload.change');
+    });
+
+    options.bindAction.off('click').on('click', function () {
+        $(this).trigger('upload.action');
+    });
     
     //防止事件重复绑定
     if(options.elem.data('haveEvents')) return;
-    
-    that.elemFile.on('change', function(){
-      $(this).trigger('upload.change');
-    });
     
     options.elem.on('click', function(){
       if(that.isFile()) return;


### PR DESCRIPTION
在使用Vue v-if组件动态渲染upload组件时，多次渲染无法监听input change事件，在layui社区中找到解决方法，并提交分支