### PR TITLE
新增表单单元格自定义渲染方式，更新表格demo

### DIFF
--- a/examples/table.html
+++ b/examples/table.html
@@ -198,7 +198,13 @@ layui.use('table', function(){
         return '<em>'+ x.email +'</em>'
       }}
       ,{field:'sex', title:'性别', width:80, edit: 'text', sort: true}
-      ,{field:'city', title:'城市', width:100}
+      ,{field:'city', title:'城市', width:100, render: function(value, row) {
+        // 性别为男性时，渲染百搭按钮
+        if (row.sex === '男') return `<a class="layui-btn layui-btn-sm layui-btn-normal">${value}</a>`;
+        // 性别为女性时，渲染暖色按钮
+        if (row.sex === '女') return `<a class="layui-btn layui-btn-sm layui-btn-warm">${value}</a>`;
+        return value;
+      }}
       ,{field:'sign', title:'签名'}
       ,{field:'experience', title:'积分', width:80, sort: true, totalRow: true}
       ,{field:'ip', title:'IP', width:120}

--- a/karma.conf.sauce.js
+++ b/karma.conf.sauce.js
@@ -7,10 +7,10 @@ var base = require('./karma.conf.base.js');
 
 var customLaunchers = {
     // Safari
-    sl_ios_safari: {
-        base: 'SauceLabs',
-        browserName: 'Safari'
-    },
+    // sl_ios_safari: {
+    //     base: 'SauceLabs',
+    //     browserName: 'Safari'
+    // },
 
     // 安卓浏览器
     // sl_android_4_4: {

--- a/src/lay/modules/table.js
+++ b/src/lay/modules/table.js
@@ -795,7 +795,10 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
                   return numbers;
                 break;
               };
-              
+              // 使用render方法渲染单元格数据
+              if(item3.render && typeof item3.render === 'function') {
+                return item3.render(tplData[item3.field], tplData);
+              }
               //解析工具列模板
               if(item3.toolbar){
                 return laytpl($(item3.toolbar).html()||'').render(tplData);


### PR DESCRIPTION
layui数据表格Table现有的单元格自定义渲染方式基于templet，很多场景下，一个简单的自定义渲染也需要在它处定义templet，提高了维护成本。因此提出了新增一个渲染函数`render: (val, row) => {}`作为表头参数，以一种简单直观的方式去渲染单元格数据，甚至在一定程度上可以取代toolbar的功能。
```
{field:'city', title:'城市', width:100, render: function(value, row) {
        // 性别为男性时，渲染百搭按钮
        if (row.sex === '男') return `<a class="layui-btn layui-btn-sm layui-btn-normal">${value}</a>`;
        // 性别为女性时，渲染暖色按钮
        if (row.sex === '女') return `<a class="layui-btn layui-btn-sm layui-btn-warm">${value}</a>`;
        return value;
 }}
```
![渲染效果](https://s2.ax1x.com/2019/04/06/AWmK9P.md.png)