### PR TITLE
laydate增加selectTime选项，以将type为datetime时候的时间选择改为不容易被忽略的select下拉选择

### DIFF
--- a/karma.conf.sauce.js
+++ b/karma.conf.sauce.js
@@ -7,10 +7,10 @@ var base = require('./karma.conf.base.js');
 
 var customLaunchers = {
     // Safari
-    sl_ios_safari: {
-        base: 'SauceLabs',
-        browserName: 'Safari'
-    },
+    //sl_ios_safari: {
+        //base: 'SauceLabs',
+        //browserName: 'Safari'
+    //},
 
     // 安卓浏览器
     // sl_android_4_4: {

--- a/src/css/modules/laydate/default/laydate.css
+++ b/src/css/modules/laydate/default/laydate.css
@@ -153,3 +153,6 @@ html #layuicss-laydate{display: none; position: absolute; width: 1989px;}
 .laydate-theme-grid .laydate-year-list>li{height: 43px; line-height: 43px;}
 .laydate-theme-grid .laydate-month-list>li{height: 71px; line-height: 71px;}
 
+/*时间select选择*/
+.layui-laydate-timmer{margin-top:10px;text-align:center}
+.layui-laydate-timmer .timmer-split{margin:0 5px}


### PR DESCRIPTION
原本的datetime中选择时间较为隐秘，项目中有使用到，得到反馈说经常会被忽略，便将时间选择部分放到与日期选择部分同级；并可以通过配置参数`selectTime`控制是否使用新的排版

```js
laydate.render({
    elem: '#test1',
    type: 'datetime',
    selectTime: true,
    value: '2018-03-03 12:26:31'
});

laydate.render({
    elem: '#test1',
    type: 'datetime',
    selectTime: true,
    range: true,
    value: '2018-03-04 14:32:24 - 2019-04-04 15:23:56'
});
```

![单选](https://user-images.githubusercontent.com/25758203/56645755-de380000-66b0-11e9-8fd8-2cdf8a452abd.png)
![范围](https://user-images.githubusercontent.com/25758203/56645732-d2e4d480-66b0-11e9-8dca-3126e7c66ef0.png)
