### PR TITLE
fix(layui.each()): 解决iframe中不能通过constructor判断父窗口对象类型的问题

### DIFF
--- a/src/layui.js
+++ b/src/layui.js
@@ -439,7 +439,8 @@
     ,that = this;
     if(typeof fn !== 'function') return that;
     obj = obj || [];
-    if(obj.constructor === Object){
+	// modified by Vinsea@2019/5/17  解决iframe中不能通过constructor判断父窗口对象类型的问题
+    if(obj.constructor === Object || obj.constructor.name === Object.name){
       for(key in obj){
         if(fn.call(obj[key], key, obj[key])) break;
       }


### PR DESCRIPTION
### bug复现步骤：
1. 通过iframe打开一个图层
2. 在图层中通过parent获取数据，例：var a = parent.layui.table.checkStatus('LAY-app-content-list').data[0]
3. form.val("edit-form-list", a);
4. form中填充数据失败，因为val方法中的each判断a不为Object