### PR TITLE
单元格编辑新增编辑选择下拉框/table新增 reload 配置直接载入本地数据

### DIFF
--- a/src/css/layui.css
+++ b/src/css/layui.css
@@ -911,6 +911,7 @@ select.layui-table-edit{padding: 0 0 0 10px; border-color: #C9C9C9;}
 .layui-table-view .layui-form-radio{top: 0; margin: 0; box-sizing: content-box;}
 .layui-table-view .layui-form-checkbox{top: -1px; height: 26px; line-height: 26px;}
 .layui-table-view .layui-form-checkbox i{height: 26px;}
+.layui-table-edit-select{  display: unset !important;}/*显示点击行下拉框编辑的 select (全局默认被隐藏)*/
 
 /* 展开溢出的单元格 */
 .layui-table-grid .layui-table-cell{overflow: visible;}

--- a/src/lay/modules/table.js
+++ b/src/lay/modules/table.js
@@ -1641,27 +1641,28 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
       
       if(othis.data('off')) return; //不触发事件
       
+      //获取当前行数据
+      var editclick=null
+      ,index = othis.parents('tr').eq(0).data('index')
+      ,data = table.cache[that.key][index];
+
+      //获取行 列对应的 编辑控制选项
+      that.eachCols(function(i, item){
+        if(item.field == field && item.editclick&&typeof item.editclick=='function'){
+          editclick = item.editclick;
+        }
+      });
+      //根据传入的可编辑逻辑来确认是否显示编辑按钮
+      if(editclick!=null&&!editclick(data)){
+        layui.stope(e);
+        return;
+      }
+
       //显示编辑表单
       if(editType){
         if(editType=='select')
         {
-          //获取当前行数据
-          var editclick=null
-          ,index = othis.parents('tr').eq(0).data('index')
-          ,data = table.cache[that.key][index];
-
-          //获取行 列对应的 编辑控制选项
-          that.eachCols(function(i, item){
-            if(item.field == field && item.editclick&&typeof item.editclick=='function'){
-              editclick = item.editclick;
-            }
-          });
-          //根据传入的可编辑逻辑来确认是否显示编辑按钮
-          if(editclick!=null&&!editclick(data)){
-            layui.stope(e);
-            return;
-          }
-
+          
           var value = $("input",othis).val();
           var input = $($(selecttemplet).html());
           input.addClass(ELEM_EDIT_SELECT)

--- a/src/lay/modules/table.js
+++ b/src/lay/modules/table.js
@@ -686,7 +686,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
     
     that.startTime = new Date().getTime(); //渲染开始时间
         
-    if(options.url){ //Ajax请求
+    if(options.url&&!options.localdata){ //Ajax请求,localdata 标识从现有数据载入，将不进行数据请求
       var params = {};
       params[request.pageName] = curr;
       params[request.limitName] = options.limit;
@@ -733,6 +733,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
         }
       });
     } else if(options.data && options.data.constructor === Array){ //已知数据
+      if(options.url&&options.localdata)options.localdata=null;//如果url不为空且标识从本地载入数据，则清除标识，避免刷新远程数据失败
       var res = {}
       ,startLimit = curr*options.limit - options.limit
       


### PR DESCRIPTION
**table新增 reload 配置直接载入本地数据**
localdata 标识 pullData 时数据是来源本地还是 url,当需要从本地载入数据时，标记为 true即可（如果配置了 url,则每次reload 数据都要标识为true才会从本地数据载入）

使用方式:

datatable.reload({data:data,localdata:true});

//datatable 是 table.render() 后得到的对象
//data 是数组数据




**单元格编辑新增编辑选择下拉框**

使用方式：

col 需配置如下

templet:'#textName' //需要下拉编辑的场景一般是会有一个字段为显示一个字段是实际值，这里需要提供一个模板，模板包含一个 input 隐藏字段用于保存值，一个span 用于显示内容
,selecttemplet:"#selectEdit" //下拉选择模板，即点击编辑时载入的是那个模板
,selectvaluefield:"DataTypeId"//选中值后需要更新的字段，选中后返回的 value 是 select 的value，而不是select 显示的 text
,edit:"select" //edit 标记为 select 说明是一个下拉编辑框
,editclick:function(d){return true} // 点击单元格触发的回调，可根据情况点击编辑时根据业务处理来控制是否允许编辑，返回 true 则显示编辑框

/*
附模板 demo

    <script type="text/html" id="textName">
      <input type="hidden" value="{{d.DataTypeId}}" />
      <span>{{d.DataTypeName}}</span>
    </script>

    <script  type="text/html" id="selectEdit">
      <select name='' >
        <option value='1'>布尔</option>
        <option value='2'>实体</option>
        <option value='3'>数字</option>
        <option value='4'>字符串</option>
      </select>
    </script>

*/

layui.css //新增 下拉选择编辑的样式控制  .layui-table-edit-select{  display: unset !important;}（table 默认将所有的select 的显示设为了 none）