### PR TITLE
fix bug: table默认工具栏打印在ie8下无法使用

### DIFF
--- a/src/lay/modules/table.js
+++ b/src/lay/modules/table.js
@@ -1350,7 +1350,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
           }
         break;
         case 'LAYTABLE_PRINT': //打印
-          var printWin = window.open('打印窗口', '_blank')
+          var printWin = window.open('about:blank', '打印窗口', '_blank')
           ,style = ['<style>'
             ,'body{font-size: 12px; color: #666;}'
             ,'table{width: 100%; border-collapse: collapse; border-spacing: 0;}'


### PR DESCRIPTION
主要原因是window.open在ie8下第一个参数是url，而不是windowName.

Fix #574