### PR TITLE
修改复数文件上传exts参数有时失效的问题

### DIFF
--- a/src/lay/modules/upload.js
+++ b/src/lay/modules/upload.js
@@ -361,19 +361,34 @@ layui.define('layer' , function(exports){
 
     switch(options.accept){
       case 'file': //一般文件
-        if(exts && !RegExp('\\w\\.('+ exts +')$', 'i').test(escape(value))){
+        layui.each(value, function(i, item){
+          if(exts && !RegExp('\\w\\.('+ exts +')$', 'i').test(escape(item))){
+            check = true;
+          }
+        });
+        if(check){
           that.msg('选择的文件中包含不支持的格式');
           return elemFile.value = '';
         }
       break;
       case 'video': //视频文件
-        if(!RegExp('\\w\\.('+ (exts || 'avi|mp4|wma|rmvb|rm|flash|3gp|flv') +')$', 'i').test(escape(value))){
+        layui.each(value, function(i, item){
+          if(!RegExp('\\w\\.('+ (exts || 'avi|mp4|wma|rmvb|rm|flash|3gp|flv') +')$', 'i').test(escape(item))){
+            check = true;
+          }
+        });
+        if(check){
           that.msg('选择的视频中包含不支持的格式');
           return elemFile.value = '';
         }
       break;
       case 'audio': //音频文件
-        if(!RegExp('\\w\\.('+ (exts || 'mp3|wav|mid') +')$', 'i').test(escape(value))){
+        layui.each(value, function(i, item){
+          if(!RegExp('\\w\\.('+ (exts || 'mp3|wav|mid') +')$', 'i').test(escape(item))){
+            check = true;
+          }
+        });
+        if(check){
           that.msg('选择的音频中包含不支持的格式');
           return elemFile.value = '';
         }


### PR DESCRIPTION
accept：file（所有文件），exts限定文本文件，但是测试发现，复数文件上传时，非文本文件也能上传。
查看了一下源代码，发现验证是对整个数组操作的，但是default中却是逐个验证的。
video（视频）、audio（音频）有同样问题。