### PR TITLE
为table.render增加访问接口异常回调

### DIFF
--- a/src/lay/modules/table.js
+++ b/src/lay/modules/table.js
@@ -729,6 +729,9 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
 
           that.renderForm();
           that.setColsWidth();
+		  
+		  //错误处理回调
+		  typeof options.error === 'function' && options.error(e,m);
         }
       });
     } else if(options.data && options.data.constructor === Array){ //已知数据


### PR DESCRIPTION
table组件默认不支持error回调处理，给只有一个table组件的页面的接口调用带来不便，
例如，会话超时等异常返回不好处理。
给table.render增加error回调