### PR TITLE
修复 layui-tab 设置带删除的Tab属性为任意值

### DIFF
--- a/src/lay/modules/element.js
+++ b/src/lay/modules/element.js
@@ -160,7 +160,7 @@ layui.define('jquery', function(exports){
         }
         
         //允许关闭
-        if(othis.attr('lay-allowClose')){
+        if(othis.attr('lay-allowClose') === 'true'){
           title.find('li').each(function(){
             var li = $(this);
             if(!li.find('.'+CLOSE)[0]){


### PR DESCRIPTION
在使用 layui-tab 的时候，设置带删除的Tab属性时，发现 lay-allowClose 可以为任意值，因此加上一层判断，与官方文档保持一致