### PR TITLE
修正 table 样式在 ie8 无法正常显示

### DIFF
--- a/src/css/layui.css
+++ b/src/css/layui.css
@@ -813,10 +813,11 @@ hr, .layui-timeline-item:before{background-color: #e6e6e6;}
 .layui-table-total tr,
 .layui-table-patch,
 .layui-table-mend,
-.layui-table[lay-even] tr:nth-child(even),
 .layui-table tbody tr:hover,
 .layui-table-hover,
 .layui-table-click{background-color: #f2f2f2;}
+
+.layui-table[lay-even] tr:nth-child(even){background-color: #f2f2f2;}
 
 .layui-table th,
 .layui-table td,


### PR DESCRIPTION
因 ie8 不支持 `nth-child(even)` 造成那一段样式都在 ie8 无法正常显示

现将其单独出来，互相不影响。

这样，在 ie8 下除了偶数行这个样式外，都可以正常显示其他样式。