### PR TITLE
slider: fix input change to initial value while click up/down

### DIFF
--- a/src/lay/modules/slider.js
+++ b/src/lay/modules/slider.js
@@ -345,6 +345,7 @@ layui.define('jquery', function(exports){
     //点击加减输入框
     sliderTxt.children('.' + SLIDER_INPUT_BTN).children('i').each(function(index){
       $(this).on('click', function(){
+        inputValue = sliderTxt.children('.' + SLIDER_INPUT_TXT).children('input').val();
         if(index == 1){
           inputValue = inputValue - options.step < options.min 
             ? options.min 


### PR DESCRIPTION
When the slider value is set in ajax session with setValue,
the input value would be changed to the initial value while
clicking up/down.

Reload the input value before apply click up and down.