### PR TITLE
form组件校验模块null值判断优化

### DIFF
--- a/src/lay/modules/form.js
+++ b/src/lay/modules/form.js
@@ -645,6 +645,9 @@ layui.define('layer', function(exports){
           errorText = errorText || verify[thisVer][1];
           
           if(thisVer === 'required'){
+            if(value===null){
+              isTrue=true;
+            }
             errorText = othis.attr('lay-reqText') || errorText;
           }
           


### PR DESCRIPTION
下拉框在接收到数据进行渲染时，若数据的值不在下拉列表中，下拉框渲染完成后的值为null而非''，因而进行表单commit时的require校验会被通过，导致提交数据不正确（为null，而非数据加载时候的原值，也未阻止表单提交）。当然可以通过自定义校验的方式进行处理，但required本身的含义不就应该排除null嘛（苦笑.gif）。。。