### PR TITLE
修复table组件在使用双表头时，固定列表头th行高计算错误导致表格错位的问题

### DIFF
--- a/src/modules/table.js
+++ b/src/modules/table.js
@@ -333,7 +333,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
     //如果多级表头，则填补表头高度
     if(options.cols.length > 1){
       //补全高度
-      var th = that.layFixed.find(ELEM_HEADER).find('th');
+      var th = that.layFixed.find(ELEM_HEADER).find('th[rowspan]');
       th.height(that.layHeader.height() - 1 - parseFloat(th.css('padding-top')) - parseFloat(th.css('padding-bottom')));
     }
     


### PR DESCRIPTION
缺陷场景：
在使用双表头时，如果有两列固定在左边，第一列设置rowspan=2，第二列不设置rowspan，那么表头会错位。

说明：
本此提交只修复了在双表头时错位的情况。