### PR TITLE
修复Bug: 日期范围选择时，如果先选择结束日期，且选择的结束日期早于今天的话，再选择开始日期，则开始日期的初始值变为1900-01-01

### DIFF
--- a/src/layui.js
+++ b/src/layui.js
@@ -7,7 +7,6 @@
  
 ;!function(win){
   "use strict";
-  var lzh = 0;
   var doc = win.document, config = {
     modules: {} //记录模块物理路径
     ,status: {} //记录模块加载状态

--- a/src/layui.js
+++ b/src/layui.js
@@ -7,7 +7,7 @@
  
 ;!function(win){
   "use strict";
-
+  var lzh = 0;
   var doc = win.document, config = {
     modules: {} //记录模块物理路径
     ,status: {} //记录模块加载状态

--- a/src/layui.js
+++ b/src/layui.js
@@ -7,6 +7,7 @@
  
 ;!function(win){
   "use strict";
+
   var doc = win.document, config = {
     modules: {} //记录模块物理路径
     ,status: {} //记录模块加载状态

--- a/src/modules/laydate.js
+++ b/src/modules/laydate.js
@@ -738,8 +738,10 @@
       return that.newDate(obj).getTime();
     };
     
-    //校验主面板是否在可选日期区间
-    if(getDateTime(dateTime) > getDateTime(options.max) || getDateTime(dateTime) < getDateTime(options.min)){
+     //校验主面板是否在可选日期区间
+     if(getDateTime(dateTime) > getDateTime(options.max)){
+      dateTime = options.dateTime = lay.extend({}, options.max);
+    } else if(getDateTime(dateTime) < getDateTime(options.min)){
       dateTime = options.dateTime = lay.extend({}, options.min);
     }
     


### PR DESCRIPTION
修复Bug: 日期范围选择时，如果先选择结束日期，且选择的结束日期早于今天的话，再选择开始日期，则开始日期的初始值变为1900-01-01