### PR TITLE
fix: 修复table edit时数据值为0 输入框显示的值不正确

### DIFF
--- a/src/modules/table.js
+++ b/src/modules/table.js
@@ -1664,7 +1664,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
       //显示编辑表单
       if(editType){
         var input = $('<input class="layui-input '+ ELEM_EDIT +'">');
-        input[0].value = othis.data('content') || elemCell.text();
+        input[0].value = othis.attr('data-content') || elemCell.text();
         othis.find('.'+ELEM_EDIT)[0] || othis.append(input);
         input.focus();
         layui.stope(e);


### PR DESCRIPTION
**问题描述**
表格开启单元格编辑时，需要展示数据单位，故cols字段使用templet属性自定义单元格。当数据值为0时，点击单元格编辑时会将单位文案也带入输入框。阅读源码后发现是因为把数据存在了html标签的content属性上，通过JQuery.data方法去获取content属性的值得到的是数字0，所以input[0].value读的值是elemCell.text()整个文本的值，换成JQuery.attr("data-content")获取的是字符串0就没有问题了

**问题复现线上地址**
https://codepen.io/wuxunjiee/pen/MWvYVMz