### PR TITLE
修复穿梭框内容溢出问题

### DIFF
--- a/src/modules/transfer.js
+++ b/src/modules/transfer.js
@@ -171,7 +171,7 @@ layui.define(['laytpl', 'form'], function(exports){
     });
     that.layData.css({
       height: function(){
-        return options.height - that.layHeader.outerHeight() - that.laySearch.outerHeight() - 2
+        return options.height.substr(0, (options.height.length-2)) - that.layHeader.outerHeight() - that.laySearch.outerHeight() - 2
       }()
     });
     


### PR DESCRIPTION
- `options.height` 值为 `123px`(string)，无法进行数值运算
- https://github.com/sentsin/layui/issues/502