### PR TITLE
fix:土耳其语isInput判断

### DIFF
--- a/src/modules/laydate.js
+++ b/src/modules/laydate.js
@@ -1524,7 +1524,7 @@
   
   //是否输入框
   Class.prototype.isInput = function(elem){
-    return /input|textarea/.test(elem.tagName.toLocaleLowerCase());
+    return /input|textarea/.test(elem.tagName.toLocaleLowerCase()) || /INPUT|TEXTAREA/.test(elem.tagName);
   };
 
   //绑定的元素事件处理


### PR DESCRIPTION
input元素，土耳其语toLocaleLowerCase导致正则匹配不成功，直接使用tagName进行判断。实际上在原有逻辑上进行了扩展。