### PR TITLE
修复表格和下拉菜单的一些问题

### DIFF
--- a/examples/json/table/demo1.json
+++ b/examples/json/table/demo1.json
@@ -15,7 +15,6 @@
     ,"experience": 7
     ,"ip": "192.168.0.8"
     ,"logins": null
-    ,"joinTime": "2016-10-14"
   }, {
     "id": "10002"
     ,"username": "李白"
@@ -57,7 +56,7 @@
     ,"sex": "女"
     ,"city": "浙江杭州"
     ,"sign": "人生恰似一场修行"
-    ,"experience": 64
+    ,"experience": 4
     ,"ip": "192.168.0.8"
     ,"logins": "106"
     ,"joinTime": "2016-10-14"
@@ -68,7 +67,7 @@
     ,"sex": "男"
     ,"city": "浙江杭州"
     ,"sign": "人生恰似一场修行"
-    ,"experience": 65
+    ,"experience": 5
     ,"ip": "192.168.0.8"
     ,"logins": "106"
     ,"joinTime": "2016-10-14"
@@ -79,7 +78,7 @@
     ,"sex": "男"
     ,"city": "浙江杭州"
     ,"sign": "人生恰似一场修行"
-    ,"experience": 49
+    ,"experience": 9
     ,"ip": "192.168.0.8"
     ,"logins": "106"
     ,"joinTime": "2016-10-14"
@@ -95,4 +94,4 @@
     ,"logins": "106"
     ,"joinTime": "2016-10-14"
   }]
-}  
+}

--- a/src/modules/dropdown.js
+++ b/src/modules/dropdown.js
@@ -1,5 +1,5 @@
 /**
- 
+
  @Name：dropdown 下拉菜单组件
  @License：MIT
 
@@ -7,13 +7,13 @@
 
 layui.define(['jquery', 'laytpl', 'lay'], function(exports){
   "use strict";
-  
+
   var $ = layui.$
   ,laytpl = layui.laytpl
   ,hint = layui.hint()
   ,device = layui.device()
   ,clickOrMousedown = (device.mobile ? 'click' : 'mousedown')
-  
+
   //模块名
   ,MOD_NAME = 'dropdown'
   ,MOD_INDEX = 'layui_'+ MOD_NAME +'_index' //模块索引名
@@ -29,7 +29,7 @@ layui.define(['jquery', 'laytpl', 'lay'], function(exports){
       that.config = $.extend({}, that.config, options);
       return that;
     }
-    
+
     //事件
     ,on: function(events, callback){
       return layui.onevent.call(this, MOD_NAME, events, callback);
@@ -56,7 +56,7 @@ layui.define(['jquery', 'laytpl', 'lay'], function(exports){
   //字符常量
   ,STR_ELEM = 'layui-dropdown', STR_HIDE = 'layui-hide', STR_DISABLED = 'layui-disabled', STR_NONE = 'layui-none'
   ,STR_ITEM_UP = 'layui-menu-item-up', STR_ITEM_DOWN = 'layui-menu-item-down', STR_MENU_TITLE = 'layui-menu-body-title', STR_ITEM_GROUP = 'layui-menu-item-group', STR_ITEM_PARENT = 'layui-menu-item-parent', STR_ITEM_DIV = 'layui-menu-item-divider', STR_ITEM_CHECKED = 'layui-menu-item-checked', STR_ITEM_CHECKED2 = 'layui-menu-item-checked2', STR_MENU_PANEL = 'layui-menu-body-panel', STR_MENU_PANEL_L = 'layui-menu-body-panel-left'
-  
+
   ,STR_GROUP_TITLE = '.'+ STR_ITEM_GROUP + '>.'+ STR_MENU_TITLE
 
   //构造器
@@ -79,10 +79,10 @@ layui.define(['jquery', 'laytpl', 'lay'], function(exports){
     ,data: [] //菜单数据结构
     ,delay: 300 //延迟关闭的毫秒数，若 trigger 为 hover 时才生效
   };
-  
+
   //重载实例
   Class.prototype.reload = function(options){
-    var that = this;
+    var that = thisModule.getThis(this.config.id);
     that.config = $.extend({}, that.config, options);
     that.init(true);
   };
@@ -92,7 +92,7 @@ layui.define(['jquery', 'laytpl', 'lay'], function(exports){
     var that = this
     ,options = that.config
     ,elem = options.elem = $(options.elem);
-    
+
     //若 elem 非唯一
     if(elem.length > 1){
       layui.each(elem, function(){
@@ -107,23 +107,24 @@ layui.define(['jquery', 'laytpl', 'lay'], function(exports){
     if(!rerender && elem[0] && elem.data(MOD_INDEX)){;
       var newThat = thisModule.getThis(elem.data(MOD_INDEX));
       if(!newThat) return;
-
-      return newThat.reload(options);
+      // 支持重复render采用reload模式，那么返回的对象信息也继承历史的实例
+      return $.extend(this, newThat, dropdown.reload(newThat.config.id, options));
     };
-    
+
     //初始化 id 参数
     options.id = ('id' in options) ? options.id : that.index;
-    
+    elem.data(MOD_INDEX, options.id);
+
     if(options.show) that.render(rerender); //初始即显示
     that.events(); //事件
   };
-  
+
   //渲染
   Class.prototype.render = function(rerender){
-    var that = this
+    var that = thisModule.getThis(this.config.id) // 支持重复render采用reload模式，通过id获取确保是最新实例
     ,options = that.config
     ,elemBody = $('body')
-    
+
     //默认菜单内容
     ,getDefaultView = function(){
       var elemUl = $('<ul class="layui-menu layui-dropdown-menu"></ul>');
@@ -134,7 +135,7 @@ layui.define(['jquery', 'laytpl', 'lay'], function(exports){
       }
       return elemUl;
     }
-    
+
     //遍历菜单项
     ,eachItemView = function(views, data){
       //var views = [];
@@ -142,10 +143,10 @@ layui.define(['jquery', 'laytpl', 'lay'], function(exports){
         //是否存在子级
         var isChild = item.child && item.child.length > 0
         ,isSpreadItem = ('isSpreadItem' in item) ? item.isSpreadItem : options.isSpreadItem
-        ,title = item.templet 
-          ? laytpl(item.templet).render(item) 
+        ,title = item.templet
+          ? laytpl(item.templet).render(item)
         : (options.templet ? laytpl(options.templet).render(item) : item.title)
-        
+
         //初始类型
         ,type = function(){
           if(isChild){
@@ -162,7 +163,7 @@ layui.define(['jquery', 'laytpl', 'lay'], function(exports){
         }();
 
         if(type !== '-' && (!item.title && !item.id && !isChild)) return;
-        
+
         //列表元素
         var viewLi = $(['<li'+ function(){
           var className = {
@@ -179,14 +180,14 @@ layui.define(['jquery', 'laytpl', 'lay'], function(exports){
           }
           return '';
         }() +'>'
-        
+
           //标题区
           ,function(){
             //是否超文本
             var viewText = ('href' in item) ? (
               '<a href="'+ item.href +'" target="'+ (item.target || '_self') +'">'+ title +'</a>'
             ) : title;
-            
+
             //是否存在子级
             if(isChild){
               return '<div class="'+ STR_MENU_TITLE +'">'+ viewText + function(){
@@ -198,14 +199,14 @@ layui.define(['jquery', 'laytpl', 'lay'], function(exports){
                   return '';
                 }
               }() +'</div>'
-              
+
             }
             return '<div class="'+ STR_MENU_TITLE +'">'+ viewText +'</div>';
           }()
         ,'</li>'].join(''));
-        
+
         viewLi.data('item', item);
-        
+
         //子级区
         if(isChild){
           var elemPanel = $('<div class="layui-panel layui-menu-body-panel"></div>')
@@ -223,39 +224,39 @@ layui.define(['jquery', 'laytpl', 'lay'], function(exports){
       });
       return views;
     }
-    
+
     //主模板
     ,TPL_MAIN = ['<div class="layui-dropdown layui-border-box layui-panel layui-anim layui-anim-downbit">'
     ,'</div>'].join('');
-    
+
     //如果是右键事件，则每次触发事件时，将允许重新渲染
     if(options.trigger === 'contextmenu' || lay.isTopElem(options.elem[0])) rerender = true;
-    
+
     //判断是否已经打开了下拉菜单面板
     if(!rerender && options.elem.data(MOD_INDEX +'_opened')) return;
 
     //记录模板对象
     that.elemView = $(TPL_MAIN);
     that.elemView.append(options.content || getDefaultView());
-    
+
     //初始化某些属性
     if(options.className) that.elemView.addClass(options.className);
     if(options.style) that.elemView.attr('style', options.style);
-    
-    
+
+
     //记录当前执行的实例索引
     dropdown.thisId = options.id;
-    
+
     //插入视图
     that.remove(); //移除非当前绑定元素的面板
     elemBody.append(that.elemView);
     options.elem.data(MOD_INDEX +'_opened', true);
-    
+
     //坐标定位
     that.position();
     thisModule.prevElem = that.elemView; //记录当前打开的元素，以便在下次关闭
     thisModule.prevElem.data('prevElem', options.elem); //将当前绑定的元素，记录在打开元素的 data 对象中
-    
+
     //阻止全局事件
     that.elemView.find('.layui-menu').on(clickOrMousedown, function(e){
       layui.stope(e);
@@ -266,24 +267,24 @@ layui.define(['jquery', 'laytpl', 'lay'], function(exports){
       var othis = $(this)
       ,data = othis.data('item') || {}
       ,isChild = data.child && data.child.length > 0;
-      
+
       if(!isChild && data.type !== '-'){
         that.remove();
         typeof options.click === 'function' && options.click(data, othis);
       }
     });
-    
+
     //触发菜单组展开收缩
     that.elemView.find(STR_GROUP_TITLE).on('click', function(e){
       var othis = $(this)
       ,elemGroup = othis.parent()
       ,data = elemGroup.data('item') || {}
-      
+
       if(data.type === 'group' && options.isAllowSpread){
         thisModule.spread(elemGroup);
       }
     });
-    
+
     //如果是鼠标移入事件，则鼠标移出时自动关闭
     if(options.trigger === 'mouseenter'){
       that.elemView.on('mouseenter', function(){
@@ -294,12 +295,12 @@ layui.define(['jquery', 'laytpl', 'lay'], function(exports){
     }
 
   };
-  
+
   //位置定位
   Class.prototype.position = function(obj){
     var that = this
     ,options = that.config;
-    
+
     lay.position(options.elem[0], that.elemView[0], {
       position: options.position
       ,e: that.e
@@ -307,13 +308,13 @@ layui.define(['jquery', 'laytpl', 'lay'], function(exports){
       ,align: options.align || null
     });
   };
-  
+
   //删除视图
   Class.prototype.remove = function(){
     var that = this
     ,options = that.config
     ,elemPrev = thisModule.prevElem;
-    
+
     //若存在已打开的面板元素，则移除
     if(elemPrev){
       elemPrev.data('prevElem') && (
@@ -322,7 +323,7 @@ layui.define(['jquery', 'laytpl', 'lay'], function(exports){
       elemPrev.remove();
     }
   };
-  
+
   //延迟删除视图
   Class.prototype.delayRemove = function(){
     var that = this
@@ -333,18 +334,18 @@ layui.define(['jquery', 'laytpl', 'lay'], function(exports){
       that.remove();
     }, options.delay);
   };
-  
+
   //事件
   Class.prototype.events = function(){
     var that = this
     ,options = that.config;
-    
+
     //如果传入 hover，则解析为 mouseenter
     if(options.trigger === 'hover') options.trigger = 'mouseenter';
 
     //解除上一个事件
     if(that.prevElem) that.prevElem.off(options.trigger, that.prevElemCallback);
-    
+
     //记录被绑定的元素及回调
     that.prevElem = options.elem;
     that.prevElemCallback = function(e){
@@ -352,14 +353,14 @@ layui.define(['jquery', 'laytpl', 'lay'], function(exports){
       that.e = e;
       that.render();
       e.preventDefault();
-      
+
       //组件打开完毕的时间
       typeof options.ready === 'function' && options.ready(that.elemView, options.elem, that.e.target);
     };
 
     //触发元素事件
     options.elem.on(options.trigger, that.prevElemCallback);
-    
+
     //如果是鼠标移入事件
     if(options.trigger === 'mouseenter'){
       //直行鼠标移出事件
@@ -368,17 +369,17 @@ layui.define(['jquery', 'laytpl', 'lay'], function(exports){
       });
     }
   };
-  
+
   //记录所有实例
   thisModule.that = {}; //记录所有实例对象
-  
+
   //获取当前实例对象
   thisModule.getThis = function(id){
     var that = thisModule.that[id];
     if(!that) hint.error(id ? (MOD_NAME +' instance with ID \''+ id +'\' not found') : 'ID argument required');
     return that;
   };
-  
+
   //设置菜单组展开和收缩状态
   thisModule.spread = function(othis){
     //菜单组展开和收缩
@@ -391,55 +392,55 @@ layui.define(['jquery', 'laytpl', 'lay'], function(exports){
       elemIcon.removeClass('layui-icon-up').addClass('layui-icon-down')
     }
   };
-  
+
   //全局事件
   ;!function(){
     var _WIN = $(window)
     ,_DOC = $(document);
-    
+
     //自适应定位
     _WIN.on('resize', function(){
       if(!dropdown.thisId) return;
       var that = thisModule.getThis(dropdown.thisId);
       if(!that) return;
-      
+
       if(!that.elemView[0] || !$('.'+ STR_ELEM)[0]){
         return false;
       }
-      
+
       var options = that.config;
-      
+
       if(options.trigger === 'contextmenu'){
         that.remove();
       } else {
         that.position();
       }
     });
-    
-    
-      
+
+
+
     //点击任意处关闭
     _DOC.on(clickOrMousedown, function(e){
       if(!dropdown.thisId) return;
       var that = thisModule.getThis(dropdown.thisId)
       if(!that) return;
-      
+
       var options = that.config;
-      
+
       //如果触发的是绑定的元素，或者属于绑定元素的子元素，则不关闭
       //满足条件：当前绑定的元素不是 body document，或者不是鼠标右键事件
       if(!(lay.isTopElem(options.elem[0]) || options.trigger === 'contextmenu')){
         if(
-          e.target === options.elem[0] || 
+          e.target === options.elem[0] ||
           options.elem.find(e.target)[0] ||
           e.target === that.elemView[0] ||
           (that.elemView && that.elemView.find(e.target)[0])
         ) return;
       }
-      
+
       that.remove();
     });
-    
+
     //基础菜单的静态元素事件
     var ELEM_LI = '.layui-menu:not(.layui-dropdown-menu) li';
     _DOC.on('click', ELEM_LI, function(e){
@@ -448,7 +449,7 @@ layui.define(['jquery', 'laytpl', 'lay'], function(exports){
       ,isChild = othis.hasClass(STR_ITEM_GROUP) || othis.hasClass(STR_ITEM_PARENT)
       ,filter = parent.attr('lay-filter') || parent.attr('id')
       ,options = lay.options(this);
-      
+
       //非触发元素
       if(othis.hasClass(STR_ITEM_DIV)) return;
 
@@ -459,12 +460,12 @@ layui.define(['jquery', 'laytpl', 'lay'], function(exports){
         parent.find('.'+ STR_ITEM_CHECKED2).removeClass(STR_ITEM_CHECKED2); //清除父级菜单选中样式
         othis.addClass(STR_ITEM_CHECKED); //添加选中样式
         othis.parents('.'+ STR_ITEM_PARENT).addClass(STR_ITEM_CHECKED2); //添加父级菜单选中样式
-        
+
         //触发事件
         layui.event.call(this, MOD_NAME, 'click('+ filter +')', options);
       }
     });
-    
+
     //基础菜单的展开收缩事件
     _DOC.on('click', (ELEM_LI + STR_GROUP_TITLE), function(e){
       var othis = $(this)
@@ -475,7 +476,7 @@ layui.define(['jquery', 'laytpl', 'lay'], function(exports){
         thisModule.spread(elemGroup);
       };
     });
-    
+
     //判断子级菜单是否超出屏幕
     var ELEM_LI_PAR = '.layui-menu .'+ STR_ITEM_PARENT
     _DOC.on('mouseenter', ELEM_LI_PAR, function(e){
@@ -484,7 +485,7 @@ layui.define(['jquery', 'laytpl', 'lay'], function(exports){
 
       if(!elemPanel[0]) return;
       var rect = elemPanel[0].getBoundingClientRect();
-      
+
       //是否超出右侧屏幕
       if(rect.right > _WIN.width()){
         elemPanel.addClass(STR_MENU_PANEL_L);
@@ -494,7 +495,7 @@ layui.define(['jquery', 'laytpl', 'lay'], function(exports){
           elemPanel.removeClass(STR_MENU_PANEL_L);
         }
       }
-      
+
       //是否超出底部屏幕
       if(rect.bottom > _WIN.height()){
         elemPanel.eq(0).css('margin-top', -(rect.bottom - _WIN.height()));
@@ -502,13 +503,13 @@ layui.define(['jquery', 'laytpl', 'lay'], function(exports){
     }).on('mouseleave', ELEM_LI_PAR, function(e){
       var othis = $(this)
       ,elemPanel = othis.children('.'+ STR_MENU_PANEL);
-      
+
       elemPanel.removeClass(STR_MENU_PANEL_L);
       elemPanel.css('margin-top', 0);
     });
-    
+
   }();
-  
+
   //重载实例
   dropdown.reload = function(id, options){
     var that = thisModule.getThis(id);
@@ -517,6 +518,33 @@ layui.define(['jquery', 'laytpl', 'lay'], function(exports){
     that.reload(options);
     return thisModule.call(that);
   };
+
+  // 通过节点或id获取实例
+  dropdown.getInst = function (domOrId) {
+    var inst;
+    if (layui._typeof(domOrId) === 'number') {
+      inst = thisModule.getThis(domOrId);
+    } else if (layui._typeof(domOrId) === 'string') {
+      var elem = $(domOrId);
+      if (elem.length) {
+        // 如果有多个仅返回第一个找到的节点
+        inst = thisModule.getThis(elem.eq(0).data(MOD_INDEX));
+      } else {
+        inst = thisModule.getThis(domOrId);
+      }
+    } else {
+      inst = thisModule.getThis($(domOrId).eq(0).data(MOD_INDEX));
+    }
+    // return inst ? thisModule.call(inst) : inst;
+    return {
+      config: inst.config
+      //重置实例
+      ,reload: function(options){
+        // debugger;
+        inst.reload.call(inst, options);
+      }
+    }
+  }
 
   //核心入口
   dropdown.render = function(options){

--- a/src/modules/table.js
+++ b/src/modules/table.js
@@ -1,12 +1,12 @@
 
 /*!
- * layui.table 
+ * layui.table
  * 数据表格组件
  */
 
 layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
   "use strict";
-  
+
   var $ = layui.$
   ,laytpl = layui.laytpl
   ,laypage = layui.laypage
@@ -24,31 +24,31 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
     } //全局配置项
     ,cache: {} //数据缓存
     ,index: layui.table ? (layui.table.index + 10000) : 0
-    
+
     //设置全局项
     ,set: function(options){
       var that = this;
       that.config = $.extend({}, that.config, options);
       return that;
     }
-    
+
     //事件
     ,on: function(events, callback){
       return layui.onevent.call(this, MOD_NAME, events, callback);
     }
   }
-  
+
   //操作当前实例
   ,thisTable = function(){
     var that = this
     ,options = that.config
     ,id = options.id || options.index;
-    
+
     if(id){
       thisTable.that[id] = that; //记录当前实例对象
       thisTable.config[id] = options; //记录当前实例配置项
     }
-    
+
     return {
       config: options
       ,reload: function(options, deep){
@@ -62,39 +62,56 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
       }
     }
   }
-  
+
   //获取当前实例配置项
   ,getThisTableConfig = function(id){
     var config = thisTable.config[id];
     if(!config) hint.error(id ? ('The table instance with ID \''+ id +'\' not found') : 'ID argument required');
     return config || null;
   }
-  
+
   //解析自定义模板数据
   ,parseTempData = function(item3, content, tplData, text){ //表头数据、原始内容、表体数据、是否只返回文本
     var options = this.config || {};
-    
+
     //是否防 xss
     if(options.escape) content = util.escape(content);
-    
+
     //获取内容
-    var str = item3.templet ? function(){
-      return typeof item3.templet === 'function' 
-        ? item3.templet(tplData)
-      : laytpl($(item3.templet).html() || String(content)).render(tplData) 
+    var templetTemp = (item3.templet || item3.toolbar);
+    templetTemp = text ? (item3.exportTemplet || templetTemp) : templetTemp;
+    var str = templetTemp ? function(){
+      return typeof templetTemp === 'function'
+        ? templetTemp(tplData)
+      : laytpl($(templetTemp).html() || String(content)).render(tplData)
     }() : content;
-    return text ? $('<div>'+ str +'</div>').text() : str;
+    // return text ? $('<div>'+ str +'</div>').text() : str;
+    if (text) {
+      // 简单处理td中是input和select拿不到正确的text内容，如果td中内容比较复杂，建议用exportTemplet生成导出结果的模板
+      var elemTemp = $('<div>'+ str +'</div>');
+      var selectElem = elemTemp.find('select');
+      if (selectElem.length) {
+        return selectElem.find('option:selected').text();
+      }
+      var inputElem = elemTemp.find('input');
+      if (inputElem.length) {
+        return inputElem.val();
+      }
+      return elemTemp.text();
+    } else {
+      return str;
+    }
   }
-  
+
   //字符常量
   ,MOD_NAME = 'table', ELEM = '.layui-table', THIS = 'layui-this', SHOW = 'layui-show', HIDE = 'layui-hide', DISABLED = 'layui-disabled', NONE = 'layui-none'
-  
+
   ,ELEM_VIEW = 'layui-table-view', ELEM_TOOL = '.layui-table-tool', ELEM_BOX = '.layui-table-box', ELEM_INIT = '.layui-table-init', ELEM_HEADER = '.layui-table-header', ELEM_BODY = '.layui-table-body', ELEM_MAIN = '.layui-table-main', ELEM_FIXED = '.layui-table-fixed', ELEM_FIXL = '.layui-table-fixed-l', ELEM_FIXR = '.layui-table-fixed-r', ELEM_TOTAL = '.layui-table-total', ELEM_PAGE = '.layui-table-page', ELEM_SORT = '.layui-table-sort', ELEM_EDIT = 'layui-table-edit', ELEM_HOVER = 'layui-table-hover'
-  
+
   //thead区域模板
   ,TPL_HEADER = function(options){
     var rowCols = '{{#if(item2.colspan){}} colspan="{{item2.colspan}}"{{#} if(item2.rowspan){}} rowspan="{{item2.rowspan}}"{{#}}}';
-    
+
     options = options || {};
     return ['<table cellspacing="0" cellpadding="0" border="0" class="layui-table" '
       ,'{{# if(d.data.skin){ }}lay-skin="{{d.data.skin}}"{{# } }} {{# if(d.data.size){ }}lay-size="{{d.data.size}}"{{# } }} {{# if(d.data.even){ }}lay-even{{# } }}>'
@@ -142,13 +159,13 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
       ,'</thead>'
     ,'</table>'].join('');
   }
-  
+
   //tbody区域模板
   ,TPL_BODY = ['<table cellspacing="0" cellpadding="0" border="0" class="layui-table" '
     ,'{{# if(d.data.skin){ }}lay-skin="{{d.data.skin}}"{{# } }} {{# if(d.data.size){ }}lay-size="{{d.data.size}}"{{# } }} {{# if(d.data.even){ }}lay-even{{# } }}>'
     ,'<tbody></tbody>'
   ,'</table>'].join('')
-  
+
   //主模板
   ,TPL_MAIN = ['<div class="layui-form layui-border-box {{d.VIEW_CLASS}}{{# if(d.data.className){ }} {{ d.data.className }}{{# } }}" lay-filter="LAY-table-{{d.index}}" lay-id="{{ d.data.id }}" style="{{# if(d.data.width){ }}width:{{d.data.width}}px;{{# } }} {{# if(d.data.height){ }}height:{{d.data.height}}px;{{# } }}">'
 
@@ -158,14 +175,14 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
       ,'<div class="layui-table-tool-self"></div>'
     ,'</div>'
     ,'{{# } }}'
-    
+
     ,'<div class="layui-table-box">'
       ,'{{# if(d.data.loading){ }}'
       ,'<div class="layui-table-init" style="background-color: #fff;">'
         ,'<i class="layui-icon layui-icon-loading layui-anim layui-anim-rotate layui-anim-loop"></i>'
       ,'</div>'
       ,'{{# } }}'
-      
+
       ,'{{# var left, right; }}'
       ,'<div class="layui-table-header">'
         ,TPL_HEADER()
@@ -173,18 +190,18 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
       ,'<div class="layui-table-body layui-table-main">'
         ,TPL_BODY
       ,'</div>'
-      
+
       ,'{{# if(left){ }}'
       ,'<div class="layui-table-fixed layui-table-fixed-l">'
         ,'<div class="layui-table-header">'
-          ,TPL_HEADER({fixed: true}) 
+          ,TPL_HEADER({fixed: true})
         ,'</div>'
         ,'<div class="layui-table-body">'
           ,TPL_BODY
-        ,'</div>'      
+        ,'</div>'
       ,'</div>'
       ,'{{# }; }}'
-      
+
       ,'{{# if(right){ }}'
       ,'<div class="layui-table-fixed layui-table-fixed-r">'
         ,'<div class="layui-table-header">'
@@ -197,7 +214,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
       ,'</div>'
       ,'{{# }; }}'
     ,'</div>'
-    
+
     ,'{{# if(d.data.totalRow){ }}'
       ,'<div class="layui-table-total">'
         ,'<table cellspacing="0" cellpadding="0" border="0" class="layui-table" '
@@ -206,13 +223,13 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
       , '</table>'
       ,'</div>'
     ,'{{# } }}'
-    
+
     ,'{{# if(d.data.page){ }}'
     ,'<div class="layui-table-page">'
       ,'<div id="layui-table-page{{d.index}}"></div>'
     ,'</div>'
     ,'{{# } }}'
-    
+
     ,'<style>'
     ,'{{# layui.each(d.data.cols, function(i1, item1){'
       ,'layui.each(item1, function(i2, item2){ }}'
@@ -225,10 +242,10 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
     ,'}); }}'
     ,'</style>'
   ,'</div>'].join('')
-  
+
   ,_WIN = $(window)
   ,_DOC = $(document)
-  
+
   //构造器
   ,Class = function(options){
     var that = this;
@@ -236,7 +253,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
     that.config = $.extend({}, that.config, table.config, options);
     that.render();
   };
-  
+
   //初始默认配置
   Class.prototype.config = {
     limit: 10 //每页显示的数量
@@ -263,7 +280,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
       pageName: 'page'
       ,limitName: 'limit'
     }, options.request)
-    
+
     //响应数据的自定义格式
     options.response = $.extend({
       statusName: 'code' //规定数据状态的字段名称
@@ -273,7 +290,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
       ,totalRowName: 'totalRow' //规定数据统计的字段名称
       ,countName: 'count'
     }, options.response);
-    
+
     //如果 page 传入 laypage 对象
     if(typeof options.page === 'object'){
       options.limit = options.page.limit || options.limit;
@@ -282,36 +299,36 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
       delete options.page.elem;
       delete options.page.jump;
     }
-    
+
     if(!options.elem[0]) return that;
-    
+
     //高度铺满：full-差距值
     if(options.height && /^full-\d+$/.test(options.height)){
       that.fullHeightGap = options.height.split('-')[1];
       options.height = _WIN.height() - that.fullHeightGap;
     }
-    
+
     //初始化一些参数
     that.setInit();
-    
+
     //开始插入替代元素
     var othis = options.elem
     ,hasRender = othis.next('.' + ELEM_VIEW)
-    
+
     //主容器
     ,reElem = that.elem = $(laytpl(TPL_MAIN).render({
       VIEW_CLASS: ELEM_VIEW
       ,data: options
       ,index: that.index //索引
     }));
-    
+
     options.index = that.index;
     that.key = options.id || options.index;
-    
+
     //生成替代元素
     hasRender[0] && hasRender.remove(); //如果已经渲染，则Rerender
     othis.after(reElem);
-    
+
     //各级容器
     that.layTool = reElem.find(ELEM_TOOL);
     that.layBox = reElem.find(ELEM_BOX);
@@ -323,24 +340,24 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
     that.layFixRight = reElem.find(ELEM_FIXR);
     that.layTotal = reElem.find(ELEM_TOTAL);
     that.layPage = reElem.find(ELEM_PAGE);
-    
+
     //初始化工具栏
     that.renderToolbar();
-    
+
     //让表格平铺
     that.fullSize();
-    
+
     //如果多级表头，则填补表头高度
     if(options.cols.length > 1){
       //补全高度
       var th = that.layFixed.find(ELEM_HEADER).find('th');
       th.height(that.layHeader.height() - 1 - parseFloat(th.css('padding-top')) - parseFloat(th.css('padding-bottom')));
     }
-    
+
     that.pullData(that.page); //请求数据
     that.events(); //事件
   };
-  
+
   //根据列类型，定制化参数
   Class.prototype.initOpts = function(item){
     var that = this
@@ -351,7 +368,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
       ,space: 15
       ,numbers: 40
     };
-    
+
     //让 type 参数兼容旧版本
     if(item.checkbox) item.type = "checkbox";
     if(item.space) item.type = "space";
@@ -362,12 +379,12 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
       item.width = item.width || initWidth[item.type];
     }
   };
-  
+
   //初始化一些参数
   Class.prototype.setInit = function(type){
     var that = this
     ,options = that.config;
-    
+
     options.clientWidth = options.width || function(){ //获取容器宽度
       //如果父元素宽度为0（一般为隐藏元素），则继续查找上层元素，直到找到真实宽度为止
       var getWidth = function(parent){
@@ -382,19 +399,19 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
       };
       return getWidth();
     }();
-    
+
     if(type === 'width') return options.clientWidth;
 
     //初始化列参数
     layui.each(options.cols, function(i1, item1){
       layui.each(item1, function(i2, item2){
-        
+
         //如果列参数为空，则移除
         if(!item2){
           item1.splice(i2, 1);
           return;
         }
-        
+
         item2.key = i1 + '-' + i2;
         item2.hide = item2.hide || false;
 
@@ -405,7 +422,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
           layui.each(options.cols[i1 + 1], function(i22, item22){
             //如果子列已经被标注为{HAS_PARENT}，或者子列累计 colspan 数等于父列定义的 colspan，则跳出当前子列循环
             if(item22.HAS_PARENT || (childIndex > 1 && childIndex == item2.colspan)) return;
-            
+
             item22.HAS_PARENT = true;
             item22.parentKey = i1 + '-' + i2;
 
@@ -418,14 +435,14 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
         that.initOpts(item2);
       });
     });
-    
+
   };
-  
+
   //初始工具栏
   Class.prototype.renderToolbar = function(){
     var that = this
     ,options = that.config
-    
+
     //添加工具栏左侧模板
     var leftDefaultTemp = [
       '<div class="layui-inline" lay-event="add"><i class="layui-icon layui-icon-add-1"></i></div>'
@@ -433,7 +450,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
       ,'<div class="layui-inline" lay-event="delete"><i class="layui-icon layui-icon-delete"></i></div>'
     ].join('')
     ,elemToolTemp = that.layTool.find('.layui-table-tool-temp');
-    
+
     if(options.toolbar === 'default'){
       elemToolTemp.html(leftDefaultTemp);
     } else if(typeof options.toolbar === 'string'){
@@ -442,7 +459,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
         laytpl(toolbarHtml).render(options)
       );
     }
-    
+
     //添加工具栏右侧面板
     var layout = {
       filter: {
@@ -461,7 +478,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
         ,icon: 'layui-icon-print'
       }
     }, iconElem = [];
-    
+
     if(typeof options.defaultToolbar === 'object'){
       layui.each(options.defaultToolbar, function(i, item){
         var thisItem = typeof item === 'string' ? layout[item] : item;
@@ -474,15 +491,15 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
     }
     that.layTool.find('.layui-table-tool-self').html(iconElem.join(''));
   }
-  
+
   //同步表头父列的相关值
   Class.prototype.setParentCol = function(hide, parentKey){
     var that = this
     ,options = that.config
-    
+
     ,parentTh = that.layHeader.find('th[data-key="'+ options.index +'-'+ parentKey +'"]') //获取父列元素
     ,parentColspan = parseInt(parentTh.attr('colspan')) || 0;
-    
+
     if(parentTh[0]){
       var arrParentKey = parentKey.split('-')
       ,getThisCol = options.cols[arrParentKey[0]][arrParentKey[1]];
@@ -491,16 +508,16 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
 
       parentTh.attr('colspan', parentColspan);
       parentTh[parentColspan < 1 ? 'addClass' : 'removeClass'](HIDE);
-      
+
       getThisCol.colspan = parentColspan; //同步 colspan 参数
       getThisCol.hide = parentColspan < 1; //同步 hide 参数
-      
+
       //递归，继续往上查询是否有父列
       var nextParentKey = parentTh.data('parentkey');
       nextParentKey && that.setParentCol(hide, nextParentKey);
     }
   };
-  
+
   //多级表头补丁
   Class.prototype.setColsPatch = function(){
     var that = this
@@ -515,7 +532,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
       });
     });
   };
-  
+
   //动态分配列宽
   Class.prototype.setColsWidth = function(){
     var that = this
@@ -525,7 +542,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
     ,autoWidth = 0 //自动列分配的宽度
     ,countWidth = 0 //所有列总宽度和
     ,cntrWidth = that.setInit('width');
-    
+
     //统计列个数
     that.eachCols(function(i, item){
       item.hide || colNums++;
@@ -564,7 +581,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
             autoColNums--;
             width = minWidth;
           }
-          
+
           if(item2.hide) width = 0;
           countWidth = countWidth + width;
         });
@@ -575,25 +592,25 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
         autoWidth = (cntrWidth - countWidth) / autoColNums
       );
     }
-    
+
     getAutoWidth();
     getAutoWidth(true); //重新检测分配的宽度是否低于最小列宽
-    
+
     //记录自动列数
     that.autoColNums = autoColNums;
-    
+
     //设置列宽
     that.eachCols(function(i3, item3){
       var minWidth = item3.minWidth || options.cellMinWidth;
       if(item3.colGroup || item3.hide) return;
-      
+
       //给位分配宽的列平均分配宽
       if(item3.width === 0){
         that.getCssRule(options.index +'-'+ item3.key, function(item){
           item.style.width = Math.floor(autoWidth >= minWidth ? autoWidth : minWidth) + 'px';
         });
       }
-      
+
       //给设定百分比的列分配列宽
       else if(/\d+%$/.test(item3.width)){
         that.getCssRule(options.index +'-'+ item3.key, function(item){
@@ -601,7 +618,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
         });
       }
     });
-    
+
     //填补 Math.floor 造成的数差
     var patchNums = that.layMain.width() - that.getScrollWidth(that.layMain[0])
     - that.layMain.children('table').outerWidth();
@@ -622,17 +639,17 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
       that.getCssRule(key, function(item){
         var width = item.style.width || th.outerWidth();
         item.style.width = (parseFloat(width) + patchNums) + 'px';
-        
+
         //二次校验，如果仍然出现横向滚动条（通常是 1px 的误差导致）
         if(that.layMain.height() - that.layMain.prop('clientHeight') > 0){
           item.style.width = (parseFloat(item.style.width) - 1) + 'px';
         }
       });
     }
-    
+
     that.loading(!0);
   };
-  
+
   //重置表格尺寸/结构
   Class.prototype.resize = function(){
     var that = this;
@@ -640,48 +657,48 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
     that.setColsWidth(); //自适应列宽
     that.scrollPatch(); //滚动条补丁
   };
-  
+
   //表格重载
   Class.prototype.reload = function(options, deep){
     var that = this;
-    
+
     options = options || {};
     delete that.haveInit;
-    
+
     //防止数组深度合并
     layui.each(options, function(key, item){
       if(layui._typeof(item) === 'array') delete that.config[key];
     });
-    
+
     //对参数进行深度或浅扩展
     that.config = $.extend(deep, {}, that.config, options);
 
     //执行渲染
     that.render();
   };
-  
+
   //异常提示
   Class.prototype.errorView = function(html){
     var that = this
     ,elemNone = that.layMain.find('.'+ NONE)
     ,layNone = $('<div class="'+ NONE +'">'+ (html || 'Error') +'</div>');
-    
+
     if(elemNone[0]){
       that.layNone.remove();
       elemNone.remove();
     }
-    
+
     that.layFixed.addClass(HIDE);
     that.layMain.find('tbody').html('');
-    
+
     that.layMain.append(that.layNone = layNone);
-    
+
     table.cache[that.key] = []; //格式化缓存数据
   };
-  
+
   //页码
   Class.prototype.page = 1;
-  
+
   //获得数据
   Class.prototype.pullData = function(curr){
     var that = this
@@ -693,20 +710,20 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
         that.sort(options.initSort.field, options.initSort.type);
       }
     };
-    
+
     that.startTime = new Date().getTime(); //渲染开始时间
-        
+
     if(options.url){ //Ajax请求
       var params = {};
       params[request.pageName] = curr;
       params[request.limitName] = options.limit;
-      
+
       //参数
       var data = $.extend(params, options.where);
       if(options.contentType && options.contentType.indexOf("application/json") == 0){ //提交 json 格式
         data = JSON.stringify(data);
       }
-      
+
       that.loading();
 
       $.ajax({
@@ -740,17 +757,17 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
 
           that.renderForm();
           that.setColsWidth();
-          
+
           typeof options.error === 'function' && options.error(e, msg);
         }
       });
     } else if(layui._typeof(options.data) === 'array'){ //已知数据
       var res = {}
       ,startLimit = curr*options.limit - options.limit
-      
+
       res[response.dataName] = options.data.concat().splice(startLimit, options.limit);
       res[response.countName] = options.data.length;
-      
+
       //记录合计行数据
       if(typeof options.totalRow === 'object'){
         res[response.totalRowName] = $.extend({}, options.totalRow);
@@ -761,7 +778,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
       typeof options.done === 'function' && options.done(res, curr, res[response.countName]);
     }
   };
-  
+
   //遍历表头
   Class.prototype.eachCols = function(callback){
     var that = this;
@@ -774,11 +791,11 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
     var that = this
     ,options = that.config
     ,data = res[options.response.dataName] || [] //列表数据
-    ,totalRowData = res[options.response.totalRowName] //合计行数据
+    ,totalRowData = that.totalRowData = res[options.response.totalRowName] //合计行数据
     ,trs = []
     ,trs_fixed = []
     ,trs_fixed_r = []
-    
+
     //渲染视图
     ,render = function(){ //后续性能提升的重点
       var thisCheckedRowIndex;
@@ -788,21 +805,21 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
       layui.each(data, function(i1, item1){
         var tds = [], tds_fixed = [], tds_fixed_r = []
         ,numbers = i1 + options.limit*(curr - 1) + 1; //序号
-        
+
         //若数据项为空数组，则不往下执行（因为删除数据时，会将原有数据设置为 []）
         if(layui._typeof(item1) === 'array' && item1.length === 0) return;
-        
+
         //记录下标索引，用于恢复排序
         if(!sort){
           item1[table.config.indexName] = i1;
         }
-        
+
         //遍历表头
         that.eachCols(function(i3, item3){
           var field = item3.field || i3
           ,key = options.index + '-' + item3.key
           ,content = item1[field];
-          
+
           if(content === undefined || content === null) content = '';
           if(item3.colGroup) return;
 
@@ -824,7 +841,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
             return classNames.join(' ');
           }() +'">'
             ,'<div class="layui-table-cell laytable-cell-'+ function(){ //返回对应的CSS类标识
-              return item3.type === 'normal' ? key 
+              return item3.type === 'normal' ? key
               : (key + ' laytable-cell-' + item3.type);
             }() +'">' + function(){
               var tplData = $.extend(true, {
@@ -832,7 +849,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
                 ,LAY_COL: item3
               }, item1)
               ,checkName = table.config.checkName;
-              
+
               //渲染不同风格的列
               switch(item3.type){
                 case 'checkbox':
@@ -856,20 +873,20 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
                   return numbers;
                 break;
               };
-              
+
               //解析工具列模板
-              if(item3.toolbar){
-                return laytpl($(item3.toolbar).html()||'').render(tplData);
-              }
+              // if(item3.toolbar){ // toolbar和templet的处理应该没有本质的区别
+              //   return laytpl($(item3.toolbar).html()||'').render(tplData);
+              // }
               return parseTempData.call(that, item3, content, tplData);
             }()
           ,'</div></td>'].join('');
-          
+
           tds.push(td);
           if(item3.fixed && item3.fixed !== 'right') tds_fixed.push(td);
           if(item3.fixed === 'right') tds_fixed_r.push(td);
         });
-        
+
         trs.push('<tr data-index="'+ i1 +'">'+ tds.join('') + '</tr>');
         trs_fixed.push('<tr data-index="'+ i1 +'">'+ tds_fixed.join('') + '</tr>');
         trs_fixed_r.push('<tr data-index="'+ i1 +'">'+ tds_fixed_r.join('') + '</tr>');
@@ -884,25 +901,25 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
       that.renderForm();
       typeof thisCheckedRowIndex === 'number' && that.setThisRowChecked(thisCheckedRowIndex);
       that.syncCheckAll();
-      
+
       //滚动条补丁
       that.haveInit ? that.scrollPatch() : setTimeout(function(){
         that.scrollPatch();
       }, 50);
       that.haveInit = true;
-      
+
       layer.close(that.tipsIndex);
-      
+
       //同步表头父列的相关值
       options.HAS_SET_COLS_PATCH || that.setColsPatch();
       options.HAS_SET_COLS_PATCH = true;
     };
-    
+
     table.cache[that.key] = data; //记录数据
-    
+
     //显示隐藏分页栏
     that.layPage[(count == 0 || (data.length === 0 && curr == 1)) ? 'addClass' : 'removeClass'](HIDE);
-    
+
     //如果无数据
     if(data.length === 0){
       that.renderForm();
@@ -910,12 +927,12 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
     } else {
       that.layFixed.removeClass(HIDE);
     }
-    
+
     //如果执行初始排序
     if(sort){
       return render();
     }
-    
+
     //正常初始化数据渲染
     render(); //渲染数据
     that.renderTotal(data, totalRowData); //数据合计
@@ -946,107 +963,138 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
       laypage.render(options.page);
     }
   };
-  
-  //数据合计行
-  Class.prototype.renderTotal = function(data, totalRowData){
+
+  //数据合计行 fields:[] 指定重新计算的字段
+  Class.prototype.renderTotal = function(data, totalRowData, fields){
     var that = this
     ,options = that.config
     ,totalNums = {};
-    
+    var isLimitRender = layui._typeof(fields) === 'array' && fields.length;
+
     if(!options.totalRow) return;
-    
+
     layui.each(data, function(i1, item1){
       //若数据项为空数组，则不往下执行（因为删除数据时，会将原有数据设置为 []）
       if(layui._typeof(item1) === 'array' && item1.length === 0) return;
-      
+
       that.eachCols(function(i3, item3){
         var field = item3.field || i3
         ,content = item1[field];
 
-        if(item3.totalRow){ 
+        if(item3.totalRow){
+          if (isLimitRender && fields.indexOf(field) === -1) {
+            return;
+          }
           totalNums[field] = (totalNums[field] || 0) + (parseFloat(content) || 0);
         }
       });
     });
-    
-    that.dataTotal = {};
 
-    var tds = [];
-    that.eachCols(function(i3, item3){
-      var field = item3.field || i3;
-      
-      //td 内容
-      var content = function(){
-        var text = item3.totalRowText || ''
-        ,thisTotalNum = parseFloat(totalNums[field]).toFixed(2)
-        ,tplData = {}
-        ,getContent;
-        
-        tplData[field] = thisTotalNum;
-        
-        //获取自动计算的合并内容
-        getContent = item3.totalRow ? (parseTempData.call(that, item3, thisTotalNum, tplData) || text) : text;
-        
-        //如果直接传入了合计行数据，则不输出自动计算的结果
-        return totalRowData ? (totalRowData[item3.field] || getContent) : getContent;
-      }()
-      ,td = ['<td data-field="'+ field +'" data-key="'+ options.index + '-'+ item3.key +'" '+ function(){
-        var attr = [];
-        if(item3.align) attr.push('align="'+ item3.align +'"'); //对齐方式
-        if(item3.style) attr.push('style="'+ item3.style +'"'); //自定义样式
-        if(item3.minWidth) attr.push('data-minwidth="'+ item3.minWidth +'"'); //单元格最小宽度
-        return attr.join(' ');
-      }() +' class="'+ function(){ //追加样式
-        var classNames = [];
-        if(item3.hide) classNames.push(HIDE); //插入隐藏列样式
-        if(!item3.field) classNames.push('layui-table-col-special'); //插入特殊列样式
-        return classNames.join(' ');
-      }() +'">'
-        ,'<div class="layui-table-cell laytable-cell-'+ function(){ //返回对应的CSS类标识
-          var str = (options.index + '-' + item3.key);
-          return item3.type === 'normal' ? str 
-          : (str + ' laytable-cell-' + item3.type);
-        }() +'">' + function(){
-          var totalRow = item3.totalRow || options.totalRow;
-          //如果 totalRow 参数为字符类型，则解析为自定义模版
-          if(typeof totalRow === 'string'){
-            return laytpl(totalRow).render($.extend({
-              TOTAL_NUMS: content
-            }, item3))
-          }
-          return content;
+    if (!isLimitRender) {
+      that.dataTotal = {};
+
+      var tds = [];
+      that.eachCols(function (i3, item3) {
+        var field = item3.field || i3;
+
+        //td 内容
+        var content = function () {
+          var text = item3.totalRowText || ''
+            , thisTotalNum = parseFloat(totalNums[field]).toFixed(2)
+            , tplData = {}
+            , getContent;
+
+          tplData[field] = thisTotalNum;
+
+          //获取自动计算的合并内容
+          getContent = item3.totalRow ? (parseTempData.call(that, item3, thisTotalNum, tplData) || text) : text;
+
+          //如果直接传入了合计行数据，则不输出自动计算的结果
+          return totalRowData ? (totalRowData[item3.field] || getContent) : getContent;
         }()
-      ,'</div></td>'].join('');
-      
-      item3.field && (that.dataTotal[field] = content);
-      tds.push(td);
-    });
+          , td = ['<td data-field="' + field + '" data-key="' + options.index + '-' + item3.key + '" ' + function () {
+          var attr = [];
+          if (item3.align) attr.push('align="' + item3.align + '"'); //对齐方式
+          if (item3.style) attr.push('style="' + item3.style + '"'); //自定义样式
+          if (item3.minWidth) attr.push('data-minwidth="' + item3.minWidth + '"'); //单元格最小宽度
+          return attr.join(' ');
+        }() + ' class="' + function () { //追加样式
+          var classNames = [];
+          if (item3.hide) classNames.push(HIDE); //插入隐藏列样式
+          if (!item3.field) classNames.push('layui-table-col-special'); //插入特殊列样式
+          return classNames.join(' ');
+        }() + '">'
+          , '<div class="layui-table-cell laytable-cell-' + function () { //返回对应的CSS类标识
+            var str = (options.index + '-' + item3.key);
+            return item3.type === 'normal' ? str
+              : (str + ' laytable-cell-' + item3.type);
+          }() + '">' + function () {
+            var totalRow = item3.totalRow || options.totalRow;
+            //如果 totalRow 参数为字符类型，则解析为自定义模版
+            if (typeof totalRow === 'string') {
+              return laytpl(totalRow).render($.extend({
+                TOTAL_NUMS: content
+              }, item3))
+            }
+            return content;
+          }()
+          , '</div></td>'].join('');
 
-    that.layTotal.find('tbody').html('<tr>' + tds.join('') + '</tr>');
+        item3.field && (that.dataTotal[field] = content);
+        tds.push(td);
+
+        that.layTotal.find('tbody').html('<tr>' + tds.join('') + '</tr>');
+      });
+    } else {
+      that.eachCols(function (i3, item3) {
+        var field = item3.field || i3;
+        if (fields.indexOf(field) !== -1) {
+          if(item3.totalRow){
+            var text = item3.totalRowText || ''
+              , thisTotalNum = parseFloat(totalNums[field]).toFixed(2)
+              , tplData = {}
+              , getContent;
+
+            tplData[field] = thisTotalNum;
+            //获取自动计算的合并内容
+            getContent = parseTempData.call(that, item3, thisTotalNum, tplData) || text;
+            var totalRow = item3.totalRow || options.totalRow;
+            //如果 totalRow 参数为字符类型，则解析为自定义模版
+            if (typeof totalRow === 'string') {
+              getContent = laytpl(totalRow).render($.extend({
+                TOTAL_NUMS: getContent
+              }, item3))
+            }
+            that.layTotal.find('tbody tr>td[data-field="'+field+'"]>.layui-table-cell')
+              .html(totalRowData ? (totalRowData[item3.field] || getContent) : getContent);
+          }
+        }
+      });
+    }
   };
-  
+
   //找到对应的列元素
   Class.prototype.getColElem = function(parent, key){
     var that = this
     ,options = that.config;
     return parent.eq(0).find('.laytable-cell-'+ (options.index + '-' + key) + ':eq(0)');
   };
-  
+
   //渲染表单
   Class.prototype.renderForm = function(type){
     form.render(type, 'LAY-table-'+ this.index);
   };
-  
+
   //标记当前行选中状态
   Class.prototype.setThisRowChecked = function(index){
     var that = this
     ,options = that.config
     ,ELEM_CLICK = 'layui-table-click'
     ,tr = that.layBody.find('tr[data-index="'+ index +'"]');
-    
+
     tr.addClass(ELEM_CLICK).siblings('tr').removeClass(ELEM_CLICK);
   };
-  
+
   //数据排序
   Class.prototype.sort = function(th, type, pull, formEvent){
     var that = this
@@ -1055,7 +1103,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
     ,options = that.config
     ,filter = options.elem.attr('lay-filter')
     ,data = table.cache[that.key], thisData;
-    
+
     //字段匹配
     if(typeof th === 'string'){
       field = th;
@@ -1073,7 +1121,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
     try {
       var field = field || th.data('field')
       ,key = th.data('key');
-      
+
       //如果欲执行的排序已在状态中，则不执行渲染
       if(that.sortKey && !pull){
         if(field === that.sortKey.field && type === that.sortKey.sort){
@@ -1088,13 +1136,13 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
     } catch(e){
       hint.error('Table modules: sort field \''+ field +'\' not matched');
     }
-    
+
     //记录排序索引和类型
     that.sortKey = {
       field: field
       ,sort: type
     };
-    
+
     //默认为前端自动排序。如果否，则需自主排序（通常为服务端处理好排序）
     if(options.autoSort){
       if(type === 'asc'){ //升序
@@ -1106,10 +1154,10 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
         delete that.sortKey;
       }
     }
-    
+
     res[options.response.dataName] = thisData || data;
     that.renderData(res, that.page, that.count, true);
-    
+
     if(formEvent){
       layui.event.call(th, MOD_NAME, 'sort('+ filter +')', {
         field: field
@@ -1117,7 +1165,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
       });
     }
   };
-  
+
   //请求loading
   Class.prototype.loading = function(hide){
     var that = this
@@ -1135,7 +1183,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
       }
     }
   };
-  
+
   //同步选中值状态
   Class.prototype.setCheckData = function(index, checked){
     var that = this
@@ -1145,7 +1193,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
     if(layui._typeof(thisData[index]) === 'array') return;
     thisData[index][options.checkName] = checked;
   };
-  
+
   //同步全选按钮状态
   Class.prototype.syncCheckAll = function(){
     var that = this
@@ -1159,7 +1207,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
       });
       return checked;
     };
-    
+
     if(!checkAllElem[0]) return;
 
     if(table.checkStatus(that.key).isAll){
@@ -1176,7 +1224,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
       syncColsCheck(false);
     }
   };
-  
+
   //获取cssRule
   Class.prototype.getCssRule = function(key, callback){
     var that = this
@@ -1189,7 +1237,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
       }
     });
   };
-  
+
   //让表格铺满
   Class.prototype.fullSize = function(){
     var that = this
@@ -1201,30 +1249,30 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
       if(height < 135) height = 135;
       that.elem.css('height', height);
     }
-    
+
     if(!height) return;
 
     //减去列头区域的高度
     bodyHeight = parseFloat(height) - (that.layHeader.outerHeight() || 38); //此处的数字常量是为了防止容器处在隐藏区域无法获得高度的问题，暂时只对默认尺寸的表格做支持。
-    
+
     //减去工具栏的高度
     if(options.toolbar){
       bodyHeight = bodyHeight - (that.layTool.outerHeight() || 50);
     }
-    
+
     //减去统计朗的高度
     if(options.totalRow){
       bodyHeight = bodyHeight - (that.layTotal.outerHeight() || 40);
     }
-    
+
     //减去分页栏的高度
     if(options.page){
       bodyHeight = bodyHeight - (that.layPage.outerHeight() || 41);
     }
-    
+
     that.layMain.css('height', bodyHeight - 2);
   };
-  
+
   //获取滚动条宽度
   Class.prototype.getScrollWidth = function(elem){
     var width = 0;
@@ -1242,7 +1290,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
     }
     return width;
   };
-  
+
   //滚动条补丁
   Class.prototype.scrollPatch = function(){
     var that = this
@@ -1251,7 +1299,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
     ,scollHeight = that.layMain.height() - that.layMain.prop('clientHeight') //横向滚动条高度
     ,getScrollWidth = that.getScrollWidth(that.layMain[0]) //获取主容器滚动条宽度，如果有的话
     ,outWidth = layMainTable.outerWidth() - that.layMain.width() //表格内容器的超出宽度
-    
+
     //添加补丁
     ,addPatch = function(elem){
       if(scollWidth && scollHeight){
@@ -1267,20 +1315,20 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
         elem.find('.layui-table-patch').remove();
       }
     }
-    
+
     addPatch(that.layHeader);
     addPatch(that.layTotal);
-    
+
     //固定列区域高度
     var mainHeight = that.layMain.height()
     ,fixHeight = mainHeight - scollHeight;
     that.layFixed.find(ELEM_BODY).css('height', layMainTable.height() >= fixHeight ? fixHeight : 'auto');
 
     //表格宽度小于容器宽度时，隐藏固定列
-    that.layFixRight[outWidth > 0 ? 'removeClass' : 'addClass'](HIDE); 
-    
+    that.layFixRight[outWidth > 0 ? 'removeClass' : 'addClass'](HIDE);
+
     //操作栏
-    that.layFixRight.css('right', scollWidth - 1); 
+    that.layFixRight.css('right', scollWidth - 1);
   };
 
   //事件处理
@@ -1293,7 +1341,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
     ,resizing
     ,ELEM_CELL = '.layui-table-cell'
     ,filter = options.elem.attr('lay-filter');
-    
+
     //工具栏操作事件
     that.layTool.on('click', '*[lay-event]', function(e){
       var othis = $(this)
@@ -1301,37 +1349,37 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
       ,openPanel = function(sets){
         var list = $(sets.list)
         ,panel = $('<ul class="layui-table-tool-panel"></ul>');
-        
+
         panel.html(list);
-        
+
         //限制最大高度
         if(options.height){
           panel.css('max-height', options.height - (that.layTool.outerHeight() || 50));
         }
-        
+
         //插入元素
         othis.find('.layui-table-tool-panel')[0] || othis.append(panel);
         that.renderForm();
-        
+
         panel.on('click', function(e){
           layui.stope(e);
         });
-        
+
         sets.done && sets.done(panel, list)
       };
-      
+
       layui.stope(e);
       _DOC.trigger('table.tool.panel.remove');
       layer.close(that.tipsIndex);
-      
+
       switch(events){
         case 'LAYTABLE_COLS': //筛选列
           openPanel({
             list: function(){
               var lis = [];
-              that.eachCols(function(i, item){ 
-                if(item.field && item.type == 'normal'){
-                  lis.push('<li><input type="checkbox" name="'+ item.field +'" data-key="'+ item.key +'" data-parentkey="'+ (item.parentKey||'') +'" lay-skin="primary" '+ (item.hide ? '' : 'checked') +' title="'+ (item.title || item.field) +'" lay-filter="LAY_TABLE_TOOL_COLS"></li>');
+              that.eachCols(function(i, item){
+                if(item.field && item.type == 'normal' && !item.toolbar){
+                  lis.push('<li><input type="checkbox" name="'+ item.field +'" data-key="'+ item.key +'" data-parentkey="'+ (item.parentKey||'') +'" lay-skin="primary" '+ (item.hide ? '' : 'checked') +' title="'+ $('<div>' + (item.title || item.field) + '</div>').text() +'" lay-filter="LAY_TABLE_TOOL_COLS"></li>');
                 }
               });
               return lis.join('');
@@ -1342,9 +1390,9 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
                 ,checked = this.checked
                 ,key = othis.data('key')
                 ,parentKey = othis.data('parentkey');
-                
+
                 layui.each(options.cols, function(i1, item1){
-                  layui.each(item1, function(i2, item2){ 
+                  layui.each(item1, function(i2, item2){
                     if(i1+ '-'+ i2 === key){
                       var hide = item2.hide;
 
@@ -1352,12 +1400,12 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
                       item2.hide = !checked;
                       that.elem.find('*[data-key="'+ options.index +'-'+ key +'"]')
                       [checked ? 'removeClass' : 'addClass'](HIDE);
-                      
+
                       //根据列的显示隐藏，同步多级表头的父级相关属性值
                       if(hide != item2.hide){
                         that.setParentCol(!checked, parentKey);
                       }
-                      
+
                       //重新适配尺寸
                       that.resize();
                     }
@@ -1399,27 +1447,27 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
             ,'*.layui-hide{display: none}'
           ,'</style>'].join('')
           ,html = $(that.layHeader.html()); //输出表头
-          
+
           html.append(that.layMain.find('table').html()); //输出表体
           html.append(that.layTotal.find('table').html()) //输出合计行
-          
+
           html.find('th.layui-table-patch').remove(); //移除补丁
           html.find('.layui-table-col-special').remove(); //移除特殊列
-          
+
           printWin.document.write(style + html.prop('outerHTML'));
           printWin.document.close();
           printWin.print();
           printWin.close();
         break;
       }
-      
+
       layui.event.call(this, MOD_NAME, 'toolbar('+ filter +')', $.extend({
         event: events
         ,config: options
       },{}));
     });
-    
-    //拖拽调整宽度    
+
+    //拖拽调整宽度
     th.on('mousemove', function(e){
       var othis = $(this)
       ,oLeft = othis.offset().left
@@ -1440,7 +1488,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
         e.preventDefault();
         dict.resizeStart = true; //开始拖拽
         dict.offset = [e.clientX, e.clientY]; //记录初始坐标
-        
+
         that.getCssRule(key, function(item){
           var width = item.style.width || othis.outerWidth();
           dict.rule = item;
@@ -1449,7 +1497,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
         });
       }
     });
-    
+
     //拖拽中
     _DOC.on('mousemove', function(e){
       if(dict.resizeStart){
@@ -1472,7 +1520,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
         resizing = null;
       }
     });
-    
+
     //排序
     th.on('click', function(e){
       var othis = $(this)
@@ -1480,8 +1528,8 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
       ,nowType = elemSort.attr('lay-sort')
       ,type;
 
-      if(!elemSort[0] || resizing === 1) return resizing = 2;      
-      
+      if(!elemSort[0] || resizing === 1) return resizing = 2;
+
       if(nowType === 'asc'){
         type = 'desc';
       } else if(nowType === 'desc'){
@@ -1501,46 +1549,52 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
         that.sort(field, 'desc', null, true);
       }
     });
-    
+
     //数据行中的事件返回的公共对象成员
     var commonMember = function(sets){
       var othis = $(this)
       ,index = othis.parents('tr').eq(0).data('index')
       ,tr = that.layBody.find('tr[data-index="'+ index +'"]')
       ,data = table.cache[that.key] || [];
-      
+
 
       data = data[index] || {};
-      
+
       return $.extend({
         tr: tr //行元素
         ,data: table.clearCacheKey(data) //当前行数据
         ,del: function(){ //删除行数据
-          table.cache[that.key][index] = []; 
+          table.cache[that.key][index] = [];
           tr.remove();
           that.scrollPatch();
         }
         ,update: function(fields){ //修改行数据
           fields = fields || {};
+          var fieldsArr = [];
+          $.extend(data, {}, fields); // 一次性全部更新到缓存
           layui.each(fields, function(key, value){
-            if(key in data){
-              var templet, td = tr.children('td[data-field="'+ key +'"]');
-              data[key] = value;
-              that.eachCols(function(i, item2){
-                if(item2.field == key && item2.templet){
-                  templet = item2.templet;
-                }
-              });
-              td.children(ELEM_CELL).html(parseTempData.call(that, {
-                templet: templet
-              }, value, data));
-              td.data('content', value);
-            }
+            fieldsArr.push(key);
+            // if(key in data){ // 会导致update之前如果不存在要更新的字段信息的话无法实现更新
+            var templet, td = tr.children('td[data-field="'+ key +'"]');
+            // data[key] = value; // 提到外面处理,避免后面遍历的时候如果一个字段需要例外一个字段的值，但是还没便利到导致结果错误
+            that.eachCols(function(i, item2){
+              var templetTemp = item2.templet || item2.toolbar;
+              if(item2.field == key && templetTemp){
+                templet = templetTemp;
+              }
+            });
+            td.children(ELEM_CELL).html(parseTempData.call(that, {
+              templet: templet
+            }, value, data));
+            td.data('content', value);
+            // }
           });
+          // 根据需要更新统计行信息
+          that.renderTotal((table.cache[that.key] || []), that.totalRowData, fieldsArr)
         }
       }, sets);
     };
-    
+
     //复选框选择
     that.elem.on('click', 'input[name="layTableCheckbox"]+', function(){ //替代元素的 click 事件
       var checkbox = $(this).prev()
@@ -1561,20 +1615,20 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
         that.setCheckData(index, checked);
         that.syncCheckAll();
       }
-      
+
       layui.event.call(checkbox[0], MOD_NAME, 'checkbox('+ filter +')', commonMember.call(checkbox[0], {
         checked: checked
         ,type: isAll ? 'all' : 'one'
       }));
     });
-    
+
     //单选框选择
     that.elem.on('click', 'input[lay-type="layTableRadio"]+', function(){
       var radio = $(this).prev()
       ,checked = radio[0].checked
       ,thisData = table.cache[that.key]
       ,index = radio.parents('tr').eq(0).data('index');
-      
+
       //重置数据单选属性
       layui.each(thisData, function(i, item){
         if(index === i){
@@ -1584,12 +1638,12 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
         }
       });
       that.setThisRowChecked(index);
-      
+
       layui.event.call(this, MOD_NAME, 'radio('+ filter +')', commonMember.call(this, {
         checked: checked
       }));
     });
-    
+
     //行事件
     that.layBody.on('mouseenter', 'tr', function(){ //鼠标移入行
       var othis = $(this)
@@ -1606,7 +1660,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
     }).on('dblclick', 'tr', function(){ //双击行
       setRowEvent.call(this, 'rowDouble');
     });
-    
+
     //创建行单击、双击事件
     var setRowEvent = function(eventType){
       var othis = $(this);
@@ -1616,7 +1670,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
         ,commonMember.call(othis.children('td')[0])
       );
     };
-    
+
     //单元格编辑
     that.layBody.on('change', '.'+ELEM_EDIT, function(){
       var othis = $(this)
@@ -1624,9 +1678,9 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
       ,field = othis.parent().data('field')
       ,index = othis.parents('tr').eq(0).data('index')
       ,data = table.cache[that.key][index];
-      
+
       data[field] = value; //更新缓存中的值
-      
+
       layui.event.call(this, MOD_NAME, 'edit('+ filter +')', commonMember.call(this, {
         value: value
         ,field: field
@@ -1651,16 +1705,16 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
       othis.parent().data('content', thisElem.value);
       othis.remove();
     });
-    
+
     //单元格单击事件
     that.layBody.on('click', 'td', function(e){
       var othis = $(this)
       ,field = othis.data('field')
       ,editType = othis.data('edit')
       ,elemCell = othis.children(ELEM_CELL);
-      
+
       if(othis.data('off')) return; //不触发事件
-      
+
       //显示编辑表单
       if(editType){
         var input = $('<input class="layui-input '+ ELEM_EDIT +'">');
@@ -1675,15 +1729,15 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
     }).on('mouseleave', 'td', function(){
        gridExpand.call(this, 'hide');
     });
-    
+
     //单元格展开图标
     var ELEM_GRID = 'layui-table-grid', ELEM_GRID_DOWN = 'layui-table-grid-down', ELEM_GRID_PANEL = 'layui-table-grid-panel'
     ,gridExpand = function(hide){
       var othis = $(this)
       ,elemCell = othis.children(ELEM_CELL);
-      
+
       if(othis.data('off')) return; //不触发事件
-      
+
       if(hide){
         othis.find('.layui-table-grid-down').remove();
       } else if(elemCell.prop('scrollWidth') > elemCell.outerWidth()){
@@ -1691,7 +1745,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
         othis.append('<div class="'+ ELEM_GRID_DOWN +'"><i class="layui-icon layui-icon-down"></i></div>');
       }
     };
-    
+
     //单元格展开事件
     that.layBody.on('click', '.'+ ELEM_GRID_DOWN, function(e){
       var othis = $(this)
@@ -1724,10 +1778,10 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
           });
         }
       });
-      
+
       layui.stope(e);
     });
-    
+
     //行工具条操作事件
     that.layBody.on('click', '*[lay-event]', function(){
       var othis = $(this)
@@ -1737,17 +1791,17 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
       }));
       that.setThisRowChecked(index);
     });
-    
+
     //同步滚动条
     that.layMain.on('scroll', function(){
       var othis = $(this)
       ,scrollLeft = othis.scrollLeft()
       ,scrollTop = othis.scrollTop();
-      
+
       that.layHeader.scrollLeft(scrollLeft);
       that.layTotal.scrollLeft(scrollLeft);
       that.layFixed.find(ELEM_BODY).scrollTop(scrollTop);
-      
+
       layer.close(that.tipsIndex);
     });
 
@@ -1756,20 +1810,20 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
       that.resize();
     });
   };
-  
+
   //一次性事件
   ;(function(){
     //全局点击
     _DOC.on('click', function(){
       _DOC.trigger('table.remove.tool.panel');
     });
-    
+
     //工具面板移除事件
     _DOC.on('table.remove.tool.panel', function(){
       $('.layui-table-tool-panel').remove();
     });
   })();
-  
+
   //初始化
   table.init = function(filter, settings){
     settings = settings || {};
@@ -1781,13 +1835,13 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
     //遍历数据表格
     elemTable.each(function(){
       var othis = $(this), tableData = othis.attr('lay-data');
-      
+
       try {
         tableData = new Function('return '+ tableData)();
       } catch(e) {
         hint.error(errorTips + tableData, 'error')
       }
-      
+
       var cols = [], options = $.extend({
         elem: this
         ,cols: []
@@ -1796,21 +1850,21 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
         ,size: othis.attr('lay-size') //尺寸
         ,even: typeof othis.attr('lay-even') === 'string' //偶数行背景
       }, table.config, settings, tableData);
-      
+
       filter && othis.hide();
-      
+
       //获取表头数据
       othis.find('thead>tr').each(function(i){
         options.cols[i] = [];
         $(this).children().each(function(ii){
           var th = $(this), itemData = th.attr('lay-data');
-          
+
           try{
             itemData = new Function('return '+ itemData)();
           } catch(e){
             return hint.error(errorTips + itemData)
           }
-          
+
           var row = $.extend({
             title: th.text()
             ,colspan: th.attr('colspan') || 0 //列单元格
@@ -1840,46 +1894,46 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
         });
         options.data[i1] = row;
       });
-      
+
       //执行渲染
       table.render(options);
     });
 
     return that;
   };
-  
+
   //记录所有实例
   thisTable.that = {}; //记录所有实例对象
   thisTable.config = {}; //记录所有实例配置项
-  
+
   //遍历表头
   table.eachCols = function(id, callback, cols){
     var config = thisTable.config[id] || {}
     ,arrs = [], index = 0;
-    
+
     cols = $.extend(true, [], cols || config.cols);
 
     //重新整理表头结构
     layui.each(cols, function(i1, item1){
       layui.each(item1, function(i2, item2){
-        
+
         //如果是组合列，则捕获对应的子列
         if(item2.colGroup){
           var childIndex = 0;
           index++
           item2.CHILD_COLS = [];
-          
+
           layui.each(cols[i1 + 1], function(i22, item22){
             //如果子列已经被标注为{PARENT_COL_INDEX}，或者子列累计 colspan 数等于父列定义的 colspan，则跳出当前子列循环
             if(item22.PARENT_COL_INDEX || (childIndex > 1 && childIndex == item2.colspan)) return;
-            
+
             item22.PARENT_COL_INDEX = index;
-            
+
             item2.CHILD_COLS.push(item22);
             childIndex = childIndex + parseInt(item22.colspan > 1 ? item22.colspan : 1);
           });
         }
-        
+
         if(item2.PARENT_COL_INDEX) return; //如果是子列，则不进行追加，因为已经存储在父列中
         arrs.push(item2)
       });
@@ -1892,10 +1946,10 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
         typeof callback === 'function' && callback(i, item);
       });
     };
-    
+
     eachArrs();
   };
-  
+
   //表格选中状态
   table.checkStatus = function(id){
     var nums = 0
@@ -1918,7 +1972,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
       ,isAll: data.length ? (nums === (data.length - invalidNum)) : false //是否全选
     };
   };
-  
+
   //获取表格当前页的所有行数据
   table.getData = function(id){
     var arr = []
@@ -1931,14 +1985,14 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
     });
     return arr;
   };
-  
+
   //表格导出
   table.exportFile = function(id, data, type){
     var that = this;
-    
+
     data = data || table.clearCacheKey(table.cache[id]);
     type = type || 'csv';
-    
+
     var thatTable = thisTable.that[id]
     ,config = thisTable.config[id] || {}
     ,textType = ({
@@ -1946,16 +2000,17 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
       ,xls: 'application/vnd.ms-excel'
     })[type]
     ,alink = document.createElement("a");
-    
+
     if(device.ie) return hint.error('IE_NOT_SUPPORT_EXPORTS');
-    
+
     alink.href = 'data:'+ textType +';charset=utf-8,\ufeff'+ encodeURIComponent(function(){
-      var dataTitle = [], dataMain = [], dataTotal = [];
-      
+      var dataTitle = [], dataMain = [], dataTotal = [], fieldIsHide = {};
+
       //表头和表体
       layui.each(data, function(i1, item1){
         var vals = [];
         if(typeof id === 'object'){ //如果 id 参数直接为表头数据
+
           layui.each(id, function(i, item){
             i1 == 0 && dataTitle.push(item || '');
           });
@@ -1964,65 +2019,66 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
           });
         } else {
           table.eachCols(id, function(i3, item3){
+            i1 == 0 && item3.field && item3.type == 'normal' && (fieldIsHide[item3.field] = item3.hide);
             if(item3.field && item3.type == 'normal' && !item3.hide){
               var content = item1[item3.field];
               if(content === undefined || content === null) content = '';
-              
-              i1 == 0 && dataTitle.push(item3.title || '');
+
+              i1 == 0 && dataTitle.push($('<div>' + (item3.title || '') + '</div>').text());
               vals.push('"'+ parseTempData.call(thatTable, item3, content, item1, 'text') + '"');
             }
           });
         }
         dataMain.push(vals.join(','));
       });
-      
+
       //表合计
       layui.each(that.dataTotal, function(key, value){
-        dataTotal.push(value);
+        fieldIsHide[key] || dataTotal.push(value);
       });
-      
+
       return dataTitle.join(',') + '\r\n' + dataMain.join('\r\n') + '\r\n' + dataTotal.join(',');
     }());
-    
-    alink.download = (config.title || 'table_'+ (config.index || '')) + '.' + type; 
+
+    alink.download = (config.title || 'table_'+ (config.index || '')) + '.' + type;
     document.body.appendChild(alink);
     alink.click();
-    document.body.removeChild(alink); 
+    document.body.removeChild(alink);
   };
-  
+
   //重置表格尺寸结构
   table.resize = function(id){
     //如果指定表格唯一 id，则只执行该 id 对应的表格实例
     if(id){
       var config = getThisTableConfig(id); //获取当前实例配置项
       if(!config) return;
-      
+
       thisTable.that[id].resize();
-      
+
     } else { //否则重置所有表格实例尺寸
       layui.each(thisTable.that, function(){
         this.resize();
       });
     }
   };
-  
+
   //表格重载
   table.reload = function(id, options, deep){
     var config = getThisTableConfig(id); //获取当前实例配置项
     if(!config) return;
-    
+
     var that = thisTable.that[id];
     that.reload(options, deep);
-    
+
     return thisTable.call(that);
   };
- 
+
   //核心入口
   table.render = function(options){
     var inst = new Class(options);
     return thisTable.call(inst);
   };
-  
+
   //清除临时Key
   table.clearCacheKey = function(data){
     data = $.extend({}, data);
@@ -2030,13 +2086,13 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
     delete data[table.config.indexName];
     return data;
   };
-  
+
   //自动完成渲染
   $(function(){
     table.init();
   });
-  
+
   exports(MOD_NAME, table);
 });
 
- 
+


### PR DESCRIPTION
表格：
1、导出数据表格中带有input或者select控件结果内容异常问题
2、新增exportTemplet支持在有复杂td内容的时候自定义导出的效果的模板配置
3、tool监听中的update方法更新加强，如果是自动统计列将会重新计算出结果
4、修复导出数据表格的时候如果存在隐藏列统计行错误问题
下拉菜单：
1、修复多次render一个节点无法更新为最新配置的问题
2、新增dropdown.getInst，通过dom节点或者实例的id返回对应的实例