### PR TITLE
位置计算逻辑完备性处理，可以解决在frame中底部laydate下端被遮挡的问题。

### DIFF
--- a/src/modules/lay.js
+++ b/src/modules/lay.js
@@ -175,6 +175,8 @@
         if(obj.clickType === 'right'){
           top = winArea() - elemHeight - margin*2;
           if(top < 0) top = 0; //不能溢出窗口顶部
+        } else {
+          top = margin; // 位置计算逻辑完备性处理
         }
       }
     }


### PR DESCRIPTION
位置计算逻辑完备性处理，可以解决在frame中底部laydate下端被遮挡的问题。