### PR TITLE
table单元格存在多行文本时支持点击“...”展开

### DIFF
--- a/src/modules/table.js
+++ b/src/modules/table.js
@@ -1722,7 +1722,7 @@ layui.define(['laytpl', 'laypage', 'layer', 'form', 'util'], function(exports){
       
       if(hide){
         othis.find('.layui-table-grid-down').remove();
-      } else if(elemCell.prop('scrollWidth') > elemCell.outerWidth()){
+      } else if(elemCell.prop('scrollWidth') > elemCell.outerWidth() || elemCell.find("br").size() > 0){
         if(elemCell.find('.'+ ELEM_GRID_DOWN)[0]) return;
         othis.append('<div class="'+ ELEM_GRID_DOWN +'"><i class="layui-icon layui-icon-down"></i></div>');
       }


### PR DESCRIPTION
通常情况下一些数据是有多行的，比如“备注”等，多行数据在后端是\n，返回到前端时由于table单元格无法处理\n换行，那么就需要手动处理问<br>，这个时候虽然支持换行了，但是如果第一行数据的长度未超过限制，就不会显示“...”展开按钮，也就无法查看完整数据。