### PR TITLE
修复laydate在初始值的时分秒存在00的情况下无法情况的问题

### DIFF
--- a/src/modules/laydate.js
+++ b/src/modules/laydate.js
@@ -621,10 +621,10 @@
     ,checkValid = function(dateTime){
       if(dateTime.year > LIMIT_YEAR[1]) dateTime.year = LIMIT_YEAR[1], error = true; //不能超过20万年
       if(dateTime.month > 11) dateTime.month = 11, error = true;
-      if(dateTime.hours > 23) dateTime.hours = 0, error = true;
-      if(dateTime.minutes > 59) dateTime.minutes = 0, dateTime.hours++, error = true;
       if(dateTime.seconds > 59) dateTime.seconds = 0, dateTime.minutes++, error = true;
-      
+      if(dateTime.minutes > 59) dateTime.minutes = 0, dateTime.hours++, error = true;
+      if(dateTime.hours > 23) dateTime.hours = 0, error = true;
+
       //计算当前月的最后一天
       thisMaxDate = laydate.getEndDate(dateTime.month + 1, dateTime.year);
       if(dateTime.date > thisMaxDate) dateTime.date = thisMaxDate, error = true;
@@ -652,15 +652,18 @@
           if(thisv < 1) thisv = 1, error = true;
           dateTime.date = thisv;
         } else if(/HH|H/.test(item)){ //时
-          if(thisv < 1) thisv = 0, error = true;
+          if (thisv < 0) thisv = 0, error = true;
+          if (thisv > 23) thisv = 23, error = true;
           dateTime.hours = thisv;
           options.range && (that[startEnd[index]].hours = thisv);
         } else if(/mm|m/.test(item)){ //分
-          if(thisv < 1) thisv = 0, error = true;
+          if (thisv < 0) thisv = 0, error = true;
+          if (thisv > 59) thisv = 59, error = true;
           dateTime.minutes = thisv;
           options.range && (that[startEnd[index]].minutes = thisv);
         } else if(/ss|s/.test(item)){ //秒
-          if(thisv < 1) thisv = 0, error = true;
+          if (thisv < 0) thisv = 0, error = true;
+          if (thisv > 59) thisv = 59, error = true;
           dateTime.seconds = thisv;
           options.range && (that[startEnd[index]].seconds = thisv);
         }


### PR DESCRIPTION
laydate 在初始化值的时候时分秒存在00的情况下无法清空 [I5GC4U](https://gitee.com/sentsim/layui/issues/I5GC4U)
    修改checkValid的一处细节，时分秒判断如果超过最大值进位，那么应该是从小到大进行验证，不然有可能前面验证正常之后小单位的验证失败进位了导致大单位异常；
    修改initDate关于时分秒值的判断细节修复I5GC4U提到的问题