### PR TITLE
新增和修复若干项

### DIFF
--- a/examples/laydate.html
+++ b/examples/laydate.html
@@ -257,13 +257,19 @@ layui.use('laydate', function(laydate){
     }
   });
   
-  //同时绑定多个
+  // 同时绑定多个
+  laydate.render({
+    elem: '.test-item',
+    trigger: 'click'
+  });
+  /*
   lay('.test-item').each(function(){
     laydate.render({
       elem: this
       ,trigger: 'click'
     });
   });
+  */
   
   //自定义重要日
   var ins555 = laydate.render({

--- a/examples/slider.html
+++ b/examples/slider.html
@@ -16,6 +16,8 @@ body{padding:100px 0;}
 
   <div class="layui-container">
     <div id="slideTest1"></div>
+    <br>
+    <div id="slideTest2" style="margin: 45px 30px; display: inline-block;"></div>
   </div>
 
 <script src="../src/layui.js"></script>
@@ -50,6 +52,12 @@ layui.use('slider', function(){
   });
   
   sliderInst.setValue(30);
+
+
+  slider.render({
+    elem: '#slideTest2',
+    type: 'vertical'
+  });
 });
 </script>
 </body>

--- a/src/modules/dropdown.js
+++ b/src/modules/dropdown.js
@@ -495,7 +495,7 @@ layui.define(['jquery', 'laytpl', 'lay'], function(exports){
       
       //是否超出底部屏幕
       if(rect.bottom > _WIN.height()){
-        elemPanel.eq(0).css('margin-top', -(rect.bottom - _WIN.height()));
+        elemPanel.eq(0).css('margin-top', -(rect.bottom - _WIN.height() + 5));
       };
     }).on('mouseleave', ELEM_LI_PAR, function(e){
       var othis = $(this)

--- a/src/modules/element.js
+++ b/src/modules/element.js
@@ -131,9 +131,9 @@ layui.define('jquery', function(exports){
       ,filter = parents.attr('lay-filter');
       
       if(li.hasClass(THIS)){
-        if (li.next()[0] && li.next()[0].tagName === 'LI'){
+        if (li.next()[0] && li.next().is('li')){
           call.tabClick.call(li.next()[0], null, index + 1);
-          } else if (li.prev()[0] && li.prev()[0].tagName === 'LI'){
+        } else if (li.prev()[0] && li.prev().is('li')){
           call.tabClick.call(li.prev()[0], null, index - 1);
         }
       }

--- a/src/modules/laydate.js
+++ b/src/modules/laydate.js
@@ -74,6 +74,17 @@
     var that = this;
     that.index = ++laydate.index;
     that.config = lay.extend({}, that.config, laydate.config, options);
+
+    // 若 elem 非唯一，则拆分为多个实例
+    var elem = lay(options.elem || that.config.elem);
+    if(elem.length > 1){
+      layui.each(elem, function(){
+        laydate.render(lay.extend({}, that.config, {
+          elem: this
+        }));
+      });
+      return that;
+    }
     
     //初始化 id 参数
     options = that.config;
@@ -1292,7 +1303,7 @@
     );
   };
 
-  //获得指定日期时间对象时间戳
+  // 获得指定日期时间对象的毫秒数
   Class.prototype.getDateTime = function(obj){
     return this.newDate(obj).getTime();
   }
@@ -1773,8 +1784,9 @@
 
   // 关闭日期面板
   laydate.close = function(id){
-    var elem = lay('#'+ (id ? ('layui-laydate'+ id) : Class.thisElemDate));
-    elem.remove();
+    var that = thisModule.getThis(id || laydate.thisId);
+    if(!that) return;
+    return that.remove();
   };
   
   //加载方式

--- a/src/modules/layer.js
+++ b/src/modules/layer.js
@@ -850,7 +850,7 @@ layer.style = function(index, options, limit){
   }
   
   layero.css(options);
-  btnHeight = layero.find('.'+doms[6]).outerHeight();
+  btnHeight = layero.find('.'+doms[6]).outerHeight() || 0;
   
   if(type === ready.type[2]){
     layero.find('iframe').css({


### PR DESCRIPTION
- laydate: [新增] laydate.close(id) 方法，用于关闭当前日期或指定的日期面板
- layer: [修复] iframe 层在高版本 jQuery 下点击最大化高度计算有误的问题 # I5GNHN
- slider: [修复] 垂直滑块在非首屏位置点选时，滑块值直接拉满的问题 # I5GFCD
- element: [修复] 当选项卡的宽度溢出时，删除最后一个标签定位异常的问题 #1075