### PR TITLE
修复laydate几个问题

### DIFF
--- a/src/modules/laydate.js
+++ b/src/modules/laydate.js
@@ -302,9 +302,9 @@
           year: tDate.getFullYear()
           ,month: tDate.getMonth()
           ,date: tDate.getDate()
-          ,hours: '23'
-          ,minutes: '59'
-          ,seconds: '59'
+          ,hours: i ? 23 : 0
+          ,minutes: i ? 59 : 0
+          ,seconds: i ? 59 : 0
         }).getTime() 
         ,STAMP = 86400000 //代表一天的毫秒数
         ,thisDate = new Date(
@@ -774,16 +774,20 @@
     
     //如果当前日期不在设定的最大小日期区间，则自动纠正在可选区域
     //校验主面板是否在可选日期区间
+    var minMaxError;
     if(that.getDateTime(dateTime) > that.getDateTime(options.max)){ //若超出最大日期
       dateTime = options.dateTime = lay.extend({}, options.max);
+      minMaxError = true;
     } else if(that.getDateTime(dateTime) < that.getDateTime(options.min)){ //若少于最小日期
       dateTime = options.dateTime = lay.extend({}, options.min);
+      minMaxError = true;
     }
     
     //校验右侧面板是否在可选日期区间
     if(options.range){
       if(that.getDateTime(that.endDate) < that.getDateTime(options.min) || that.getDateTime(that.endDate) > that.getDateTime(options.max)){
         that.endDate = lay.extend({}, options.max);
+        minMaxError = true;
       }
       // 有时间范围的情况下初始化startTime和endTime
       that.startTime = {
@@ -797,7 +801,10 @@
         seconds: that.endDate.seconds,
       }
     }
-    
+
+    //初始值不在最大最小范围内
+    minMaxError && that.setValue(that.parse()).hint('初始值' + lang.invalidDate + lang.formatError[1]);
+
     fn && fn();
     return that;
   };


### PR DESCRIPTION
### 😃 修复laydate的几个问题


- [ ] 功能新增
- [x] 问题修复
- [ ] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- laydate 修复min设置为天数的时候开始的时分秒为23:59:59导致设置最小为0天前也就是今天及以后的情况无法选择今天内的时间 [I5ILE8](https://gitee.com/layui/layui/issues/I5ILE8)
- laydate 修复初始化的时候如果值超出了min max的范围，弹出面板没有任何提示，如果设置了isInitValue:true触发的节点中的值跟弹出面板中选中的日期对不上的问题。


### ✅ 本次 PR 的满足条件

- [x] 线演示地址[codepen](https://codepen.io/sunxiaobin89/pen/yLKoyjp)
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明

