### PR TITLE
table组件支持自适应父元素高度：#父元素ID-差距值

### DIFF
--- a/src/modules/table.js
+++ b/src/modules/table.js
@@ -347,6 +347,11 @@ layui.define(['laytpl', 'laypage', 'form', 'util'], function(exports){
     if(options.height && /^full-\d+$/.test(options.height)){
       that.fullHeightGap = options.height.split('-')[1];
       options.height = _WIN.height() - that.fullHeightGap;
+    } else if (options.height && /^#\w+-{1}\d+$/.test(options.height)) {
+      var parentDiv = options.height.split("-");
+      that.parentHeightGap = parentDiv.pop();
+      that.parentDiv = parentDiv.join("-");
+      options.height = $(that.parentDiv).height() - that.parentHeightGap;
     }
     
     //初始化一些参数
@@ -1479,6 +1484,10 @@ layui.define(['laytpl', 'laypage', 'form', 'util'], function(exports){
       height = _WIN.height() - that.fullHeightGap;
       if(height < 135) height = 135;
       that.elem.css('height', height);
+    } else if (that.parentDiv && that.parentHeightGap) {
+      height = $(that.parentDiv).height() - that.parentHeightGap;
+      if (height < 135) height = 135;
+      that.elem.css("height", height);
     }
     
     if(!height) return;


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项（即 [ ] 内填写 x ）

- [x] 功能新增
- [ ] 问题修复
- [ ] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- table组件 height参数 - 设定容器高度 支持 #父元素ID-差值 的方式自适应父元素高度
示例: height: '#div-20'

### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选（即 [ ] 内填写 x ）

- [ ] 已提供在线演示地址（如：[codepen](https://codepen.io/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明

