### PR TITLE
修改 upload 组件表单域的顺序

### DIFF
--- a/src/modules/upload.js
+++ b/src/modules/upload.js
@@ -194,13 +194,14 @@ layui.define('layer' , function(exports){
       layui.each(items, function(index, file){
         var formData = new FormData();
         
-        formData.append(options.field, file);
-        
         //追加额外的参数
         layui.each(options.data, function(key, value){
           value = typeof value === 'function' ? value() : value;
           formData.append(key, value);
         });
+        
+        //最后添加 file 到表单域
+        formData.append(options.field, file);
         
         //提交文件
         var opts = {


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项（即 [ ] 内填写 x ）

- [ ] 功能新增
- [ ] 问题修复
- [x] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

使用 upload 组件 POST 上传到阿里云、腾讯云、华为云时，file 参数必须在表单域的最后一个。

所以，修改了 upload 表单域的追加顺序。

[阿里云说明](https://help.aliyun.com/document_detail/31988.html#section-0lu-03w-2z6)

[腾讯云说明](https://cloud.tencent.com/document/product/436/14690)

[华为云说明](https://support.huaweicloud.com/api-obs/obs_04_0081.html#section6)


### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选（即 [ ] 内填写 x ）

- [ ] 已提供在线演示地址（如：[codepen](https://codepen.io/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明

