### PR TITLE
修复拖拽上传data参数丢失

### DIFF
--- a/src/modules/upload.js
+++ b/src/modules/upload.js
@@ -522,18 +522,32 @@ layui.define('layer' , function(exports){
         othis.removeAttr('lay-over');
       })
       .off('upload.drop').on('upload.drop', function(e, param){
-        var othis = $(this), files = param.originalEvent.dataTransfer.files || [];
-        
+        var othis = $(this), data = othis.attr('lay-data'), files = param.originalEvent.dataTransfer.files || [];
         othis.removeAttr('lay-over');
+        if(data){
+          try{
+            data = new Function('return '+ data)();
+            that.config = $.extend({}, options, data);
+          } catch(e){
+            hint.error('Upload element property lay-data configuration item has a syntax error: ' + data)
+          }
+        }
         setChooseFile(files);
-
         options.auto ? that.upload() : setChooseText(files); //是否自动触发上传
       });
     }
     
     //文件选择
     that.elemFile.off('upload.change').on('upload.change', function(){
-      var files = this.files || [];
+      var othis = $(this), data = othis.attr('lay-data'), files = this.files || [];
+      if(data){
+        try{
+          data = new Function('return '+ data)();
+          that.config = $.extend({}, options, data);
+        } catch(e){
+          hint.error('Upload element property lay-data configuration item has a syntax error: ' + data)
+        }
+      }
       setChooseFile(files);
       options.auto ? that.upload() : setChooseText(files); //是否自动触发上传
     });


### PR DESCRIPTION

### 😃 本次 PR 的变化性质

> 请至少勾选一项（即 [ ] 内填写 x ）

- [ ] 功能新增
- [ ] 问题修复
- [x] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- 当自定义data参数放在lay-data中，直接拖拽上传不会添加到请求中


### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选（即 [ ] 内填写 x ）

- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明

