### PR TITLE
修复table的height配置#divid-差值的设定中如果divid出现横杆的话无法命中的问题

### DIFF
--- a/src/modules/table.js
+++ b/src/modules/table.js
@@ -376,7 +376,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
     if(options.height && /^full-\d+$/.test(options.height)){
       that.fullHeightGap = options.height.split('-')[1];
       options.height = _WIN.height() - that.fullHeightGap;
-    } else if (options.height && /^#\w+-{1}\d+$/.test(options.height)) {
+    } else if (options.height && /^#\w+\S*-\d+$/.test(options.height)) {
       var parentDiv = options.height.split("-");
       that.parentHeightGap = parentDiv.pop();
       that.parentDiv = parentDiv.join("-");


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项（即 [ ] 内填写 x ）

- [ ] 功能新增
- [x] 问题修复
- [ ] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- table 修复height配置为#divid-差值的情形中如果divid出现横杆的话无法命中正则表达式验证导致结果跟预期不一致的问题 [I5Y0SM](https://gitee.com/layui/layui/issues/I5Y0SM)

### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选（即 [ ] 内填写 x ）

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明

