### PR TITLE
修复日期范围在联动面板模式下初始点击右边面板的时候面板重新绘制的问题

### DIFF
--- a/src/modules/laydate.js
+++ b/src/modules/laydate.js
@@ -1697,7 +1697,8 @@
     if(td.hasClass(DISABLED)) return;
 
     var that = this
-    ,options = that.config;
+    ,options = that.config
+    ,panelIndex = index; // 记录点击的是哪一个面板的
 
     if (that.rangeLinked) {
       if (that.endState || !that.startDate) {
@@ -1762,7 +1763,7 @@
         if (that.endState && that.autoCalendarModel.auto) {
           isChange = that.autoCalendarModel();
         }
-        if (that.rangeLinked && that.endState && that.newDate(that.startDate) > that.newDate(that.endDate)) {
+        if ((isChange || that.rangeLinked && that.endState) && that.newDate(that.startDate) > that.newDate(that.endDate)) {
           var isSameDate = that.startDate.year === that.endDate.year && that.startDate.month === that.endDate.month && that.startDate.date === that.endDate.date;
           // 判断是否反选
           var startDate = that.startDate;
@@ -1777,7 +1778,21 @@
         }
         isChange && (options.dateTime = lay.extend({}, that.startDate));
       }
-      that.calendar(null, that.rangeLinked ? null : index, isChange || that.rangeLinked ? 'init' : null).done(null, 'change');
+      if (that.rangeLinked) {
+        var dateTimeTemp = lay.extend({}, dateTime);
+        if (panelIndex && !index && !isChange) { // 处理可能出现的联动面板中点击右面板但是判定为开始日期这个时候点击头部的切换上下月第一次没有反应的问题
+          // 选择了右面板但是判断之后作为开始时间
+          var YM = that.getAsYM(dateTime.year, dateTime.month, 'sub');
+          lay.extend(options.dateTime, {
+            year: YM[0]
+            ,month: YM[1]
+          });
+        }
+        that.calendar(dateTimeTemp, panelIndex, isChange ? 'init' : null);
+      } else {
+        that.calendar(null, index, isChange ? 'init' : null);
+      }
+      that.endState && that.done(null, 'change');
     } else if(options.position === 'static'){ //直接嵌套的选中
       that.calendar().done().done(null, 'change'); //同时执行 done 和 change 回调
     } else if(options.type === 'date'){


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项（即 [ ] 内填写 x ）

- [ ] 功能新增
- [x] 问题修复
- [ ] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- laydate 修复日期范围在联动面板的模式下初始右面板中的日期还没有选择结束日期的时候面板就重新绘制的问题 [测试链接](https://codepen.io/sunxiaobin89/full/MWVByKx)


### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选（即 [ ] 内填写 x ）

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明

