### PR TITLE
laydate修复bug以及调整预览文本颜色变化的细节效果

### DIFF
--- a/src/modules/laydate.js
+++ b/src/modules/laydate.js
@@ -1605,14 +1605,14 @@
     var oldValue = elemPreview.html();
     elemPreview.html(value);
     oldValue && // 如果一开始有内容的时候才需要有一个变化过程
-    elemPreview.css({
+    (elemPreview.css({
       'color': '#5FB878'
     }),
     setTimeout(function(){
       elemPreview.css({
         'color': '#666'
       });
-    }, 300);
+    }, 300));
   };
 
   // 附加的渲染处理，在 ready 和 change 的时候调用

--- a/src/modules/laydate.js
+++ b/src/modules/laydate.js
@@ -1602,9 +1602,12 @@
     ,value = options.range ? ((that.rangeLinked ? that.endState : that.endDate) ? that.parse() : '') : that.parse();
     
     //显示预览
-    elemPreview.html(value).css({
+    var oldValue = elemPreview.html();
+    elemPreview.html(value);
+    oldValue && // 如果一开始有内容的时候才需要有一个变化过程
+    elemPreview.css({
       'color': '#5FB878'
-    });
+    }),
     setTimeout(function(){
       elemPreview.css({
         'color': '#666'

--- a/src/modules/laydate.js
+++ b/src/modules/laydate.js
@@ -977,7 +977,7 @@
 
     that.startDate = that.startDate || value && lay.extend({}, options.dateTime); // 有默认值才初始化startDate
     that.autoCalendarModel.auto && that.autoCalendarModel();
-    that.endState = !that.rangeLinked || !!(that.startDate && that.endDate); // 初始化选中范围状态
+    that.endState = !options.range || !that.rangeLinked || !!(that.startDate && that.endDate); // 初始化选中范围状态
 
     fn && fn();
     return that;
@@ -1401,7 +1401,6 @@
           }
         } else {
           that.checkDate('limit').calendar(dateTime, index, 'init'); // 重新渲染一下两个面板
-          that.rangeLinked || that.choose(lay(elemCont).find('td.layui-this'), index);
           that.closeList();
         }
 
@@ -1415,8 +1414,8 @@
             that.setValue(that.parse()).done().remove();
           }
         }
-        
-        that.done(null, 'change');
+
+        (that.autoCalendarModel.auto && !that.rangeLinked) ? that.choose(lay(elemCont).find('td.layui-this'), index) : (that.endState && that.done(null, 'change'));
         lay(that.footer).find('.'+ ELEM_TIME_BTN).removeClass(DISABLED);
       });
     } else { //时间选择面板 - 选择事件
@@ -1946,8 +1945,8 @@
         } else {
           dateTime.year--;
           that.checkDate('limit').calendar(null, index);
-          that.choose(lay(elemCont).find('td.layui-this'), index);
-          that.done(null, 'change');
+          // 面板自动切换的模式下重新判定是否发生模式转换等细节处理
+          that.autoCalendarModel.auto ? that.choose(lay(elemCont).find('td.layui-this'), index) : that.done(null, 'change');
         }
       }
       ,prevMonth: function(){
@@ -1962,8 +1961,7 @@
 
         that.checkDate('limit').calendar(null, null, 'init');
         if (!that.rangeLinked) {
-          that.choose(lay(elemCont).find('td.layui-this'), index);
-          that.done(null, 'change');
+          that.autoCalendarModel.auto ? that.choose(lay(elemCont).find('td.layui-this'), index) : that.done(null, 'change');
         }
       }
       ,nextMonth: function(){
@@ -1978,8 +1976,7 @@
 
         that.checkDate('limit').calendar(null, null, 'init');
         if (!that.rangeLinked) {
-          that.choose(lay(elemCont).find('td.layui-this'), index);
-          that.done(null, 'change');
+          that.autoCalendarModel.auto ? that.choose(lay(elemCont).find('td.layui-this'), index) : that.done(null, 'change');
         }
       }
       ,nextYear: function(){
@@ -1990,8 +1987,7 @@
         } else {
           dateTime.year++;
           that.checkDate('limit').calendar(null, index);
-          that.choose(lay(elemCont).find('td.layui-this'), index);
-          that.done(null, 'change');
+          that.autoCalendarModel.auto ? that.choose(lay(elemCont).find('td.layui-this'), index) : that.done(null, 'change');
         }
       }
     };


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项（即 [ ] 内填写 x ）

- [ ] 功能新增
- [x] 问题修复
- [x] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- laydate 修复点击日历面板头部的上下月上下年或者选择年月转换日历直接确认而不是跳转到对应面板的问题 [I65PMD](https://gitee.com/layui/layui/issues/I65PMD) [测试链接](https://codepen.io/sunxiaobin89/full/MWVByKx)
   该问题主要是因为新增的自动切换模式的时候将判断是否需要切换模式以及是否反选等处理逻辑放在了选择日期的事件中，通过头部或者年月份面板切换年月之后默认触发了一次日期选择的事件，之前因为忘记设定一些触发条件限制导致非range模式的比如日期选择面板在点击上下月或者上下年之后直接就确认选中了而不是之前的跳转到对应的年月日期面板上待用户自定选择是否确认，同时也出现重复触发change事件的问题，以上问题已经处理完毕。
- laydate 调整选择预览的文本颜色变化细节 [I65PMD](https://gitee.com/layui/layui/issues/I65PMD) [测试链接](https://codepen.io/sunxiaobin89/full/MWVByKx)
   让从无到有变化的时候文本颜色不变，文本的颜色变化初衷是让用户对于内容变化更有感，但是初始化的时候也加了一个变化的过程显得有点“多余”，会吸引掉一部分的注意力，另外一种情况比如时间范围一开始没有初始值选中之后形成一个范围的时候从无到有的变化本身就很明显了这个时候一般也不需要颜色的变换，故调整细节逻辑只有一开始有内容发生替换的时候再执行文本颜色的切换效果。

### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选（即 [ ] 内填写 x ）

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明

