### PR TITLE
修复一些问题以及新增一些功能

### DIFF
--- a/src/modules/dropdown.js
+++ b/src/modules/dropdown.js
@@ -10,7 +10,7 @@ layui.define(['jquery', 'laytpl', 'lay'], function(exports){
   ,laytpl = layui.laytpl
   ,hint = layui.hint()
   ,device = layui.device()
-  ,clickOrMousedown = (device.mobile ? 'click' : 'mousedown')
+  ,clickOrMousedown = (device.mobile ? 'touchstart' : 'mousedown')
   
   //模块名
   ,MOD_NAME = 'dropdown'

--- a/src/modules/table.js
+++ b/src/modules/table.js
@@ -1039,7 +1039,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
 
     var thisCheckedRowIndex;
     if(!sort && that.sortKey){
-      return that.sort(that.sortKey.field, that.sortKey.sort, true);
+      return that.sort(that.sortKey.field, that.sortKey.sort, true, null, type);
     }
     layui.each(data, function(i1, item1){
       var tds = [], tds_fixed = [], tds_fixed_r = []
@@ -1382,7 +1382,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
   };
   
   //数据排序
-  Class.prototype.sort = function(th, type, pull, formEvent){
+  Class.prototype.sort = function(th, type, pull, formEvent, reloadType){
     var that = this
     ,field
     ,res = {}
@@ -1449,7 +1449,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
       curr: that.page, 
       count: that.count, 
       sort: true,
-      type: formEvent ? '' : 'reloadData' // 通过按钮触发排序会默认回滚到顶部否则根据情况处理
+      type: formEvent ? '' : reloadType // 通过按钮触发排序会默认回滚到顶部否则根据情况处理
     });
     
     if(formEvent){

--- a/src/modules/table.js
+++ b/src/modules/table.js
@@ -1957,12 +1957,13 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
         }
         ,update: function(fields, related){ //修改行数据
           fields = fields || {};
+          var trThat = this;
           layui.each(fields, function(key, value){
             var td = tr.children('td[data-field="'+ key +'"]');
             var cell = td.children(ELEM_CELL); //获取当前修改的列
 
             // 更新缓存中的数据
-            if(key in data) data[key] = value;
+            if(key in data) trThat.data[key] = data[key] = value;
 
             // 更新相应列视图
             that.eachCols(function(i, item3){


### PR DESCRIPTION
…重新渲染。

### 😃 本次 PR 的变化性质

> 请至少勾选一项（即 [ ] 内填写 x ）

- [x] 功能新增
- [x] 问题修复
- [ ] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- table 修复排序之后执行reloadData时scrollPos为fixed的情况下依旧发生了滚动条回零的情况 [I68MBC](https://gitee.com/layui/layui/issues/I68MBC)
- table 新增refresh方法，支持根据最新的cache数据信息重新渲染视图 [I66U3S](https://gitee.com/layui/layui/issues/I66U3S)
  调整内部方法renderData，将视图渲染部分提取出来作为renderView供内部调用，实现将表格当前的数据信息渲染成视图并且根据情况渲染统计行，目的是提供对外提供一个refresh方法，可以让用户随时调用，将当前的表格在不需要重新请求数据的情况下重新渲染视图，这样方便用户根据自身需要拓展，比如做到数据更新之后将新数据更新到table.cache中之后调用一下table.refresh即可，不需要重新reloadData减少一次请求，同理可以对数据新增删除移动的功能提供多一种实现的方式，可以对cache进行操作之后让它重新渲染视图。
- table 修复表格行修改数据的时候进入edit事件中的参数中data中的字段不是修改后的值问题 [I6A6SL](https://gitee.com/layui/layui/issues/I6A6SL)
   表格update的时候先生成一个params其中的data是将cache信息拷贝一份去除无关字段信息，然后执行属性更新，这时只更新到cache中导致进入edit的事件传入的参数中的data与最新的数据脱节的问题
- dropdown 修复在移动端弹出下拉菜单面板之后点击一些节点没有关闭下拉菜单的问题 [I6A5M1](https://gitee.com/layui/layui/issues/I6A5M1)
   下拉菜单模块中在“点击”事件中关闭已经弹出的下拉菜单，部分节点在click事件中阻止冒泡，下拉菜单模块中采用web端用mousedown规避这个问题，但是移动端用click还是会被阻止，换成touchstart处理这个问题

### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选（即 [ ] 内填写 x ）

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明

