### PR TITLE
修复下拉菜单和表格的一些问题

### DIFF
--- a/src/modules/dropdown.js
+++ b/src/modules/dropdown.js
@@ -244,7 +244,7 @@ layui.define(['jquery', 'laytpl', 'lay'], function(exports){
 
     //记录模板对象
     that.elemView = $('.' + STR_ELEM + '[lay-id="' + options.id + '"]');
-    if ('reloadData' === type && that.elemView.length) {
+    if (type === 'reloadData' && that.elemView.length) {
       that.elemView.html(options.content || getDefaultView());
     } else {
       that.elemView = $(TPL_MAIN).attr('lay-id', options.id);
@@ -541,7 +541,7 @@ layui.define(['jquery', 'laytpl', 'lay'], function(exports){
 
     // 重载时，与数据相关的参数
     var dataParams = new RegExp('^('+ [
-      'data', 'templet', 'content'
+      'data', 'templet', 'content', 'show'
     ].join('|') + ')$');
 
     // 过滤与数据无关的参数

--- a/src/modules/table.js
+++ b/src/modules/table.js
@@ -987,10 +987,9 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
         }
       });
     } else if(layui.type(options.data) === 'array'){ //已知数据
-      var res = {}
-      ,startLimit = curr*options.limit - options.limit
+      var res = {};
       
-      res[response.dataName] = options.data.concat().splice(startLimit, options.limit);
+      res[response.dataName] = options.page ? options.data.concat().splice(curr*options.limit - options.limit, options.limit) : options.data.concat();
       res[response.countName] = options.data.length;
       
       //记录合计行数据
@@ -1719,8 +1718,8 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
     ,fixHeight = mainHeight - scollHeight;
     that.layFixed.find(ELEM_BODY).css('height', layMainTable.height() >= fixHeight ? fixHeight : 'auto');
 
-    //表格宽度小于容器宽度时，隐藏固定列
-    that.layFixRight[outWidth > 0 ? 'removeClass' : 'addClass'](HIDE); 
+    //表格宽度小于容器宽度时或者数据异常（包括无数据），隐藏固定列
+    that.layFixRight[table.cache[that.key].length && outWidth > 0 ? 'removeClass' : 'addClass'](HIDE);
     
     //操作栏
     that.layFixRight.css('right', scollWidth - 1); 


### PR DESCRIPTION
…项的时候如果当前实例有历史的菜单面板直接进行内容替换，不会重新去掉旧面板重新创建一个新面板优化reload的体验；表格修复page开启的时候data模式依旧受limit限制的问题；table修复resize导致在无数据或者请求异常的情况下右固定列显示出来的问题。

### 😃 本次 PR 的变化性质

> 请至少勾选一项（即 [ ] 内填写 x ）

- [ ] 功能新增
- [x] 问题修复
- [x] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- 下拉菜单 修复初始化立即显示的时候没有触发ready回调的问题
- 下拉菜单 数据新增disabled属性，支持禁用部分选项点击的功能 [I6GSCD](https://gitee.com/layui/layui/issues/I6GSCD)
- 下拉菜单 优化初始化菜单面板节点的逻辑提升已弹出的菜单更新配置的时候的体验 [I6EHVE](https://gitee.com/layui/layui/issues/I6EHVE)
- 数据表格 修复resize导致在无数据或者请求异常的情况下右固定列显示出来的问题 [I6F72U](https://gitee.com/layui/layui/issues/I6F72U)
- 数据表格 优化page未开启的时候data模式不再受limit参数影响显示出所有的data信息


### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选（即 [ ] 内填写 x ）

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明

