### PR TITLE
修复 checkbox 开关标题未垂直居中的问题

### DIFF
--- a/src/css/layui.css
+++ b/src/css/layui.css
@@ -851,7 +851,7 @@ a cite{font-style: normal; *cursor:pointer;}
 /* 复选框-开关风格 */
 .layui-form-switch{position: relative; display: inline-block; vertical-align: middle; height: 22px; line-height: 22px; min-width: 35px; padding: 0 5px; margin-top: 8px; border: 1px solid #d2d2d2; border-radius: 20px; cursor: pointer; background-color: #fff; -webkit-transition: .1s linear; transition: .1s linear;}
 .layui-form-switch > i{position: absolute; left: 5px; top: 3px; width: 16px; height: 16px; border-radius: 20px; background-color: #d2d2d2; -webkit-transition: .1s linear; transition: .1s linear;}
-.layui-form-switch > div{position: relative; top: 0; margin-left: 21px; padding: 0!important; text-align: center!important; color: #999!important; font-style: normal!important; font-size: 12px;}
+.layui-form-switch > div{display: inline-block; position: relative; top: 0; margin-left: 21px; padding: 0!important; text-align: center!important; color: #999!important; font-style: normal!important; font-size: 12px;}
 .layui-form-onswitch{border-color: #16b777; background-color: #16b777;}
 .layui-form-onswitch > i{left: 100%; margin-left: -21px; background-color: #fff;}
 .layui-form-onswitch > div{margin-left: 0; margin-right: 21px; color: #fff!important;}

--- a/src/css/layui.css
+++ b/src/css/layui.css
@@ -838,7 +838,7 @@ a cite{font-style: normal; *cursor:pointer;}
 /* 复选框-默认风格 */
 .layui-form-checkbox[lay-skin="primary"]{height: auto!important; line-height: normal!important; min-width: 18px; min-height: 18px; border: none!important; margin-right: 0; padding-left: 24px; padding-right: 0; background: none;}
 .layui-form-checkbox[lay-skin="primary"] > div{margin-top: -1px; padding-left: 0; padding-right: 15px; line-height: 18px; background: none; color: #5F5F5F;}
-.layui-form-checkbox[lay-skin="primary"] > i{right: auto; left: 0; width: 16px; height: 16px; line-height: 16px; border: 1px solid #d2d2d2; font-size: 12px; border-radius: 2px; background-color: #fff; -webkit-transition: .1s linear; transition: .1s linear;}
+.layui-form-checkbox[lay-skin="primary"] > i{right: auto; left: 0; width: 16px; height: 16px; line-height: 14px; border: 1px solid #d2d2d2; font-size: 12px; border-radius: 2px; background-color: #fff; -webkit-transition: .1s linear; transition: .1s linear;}
 .layui-form-checkbox[lay-skin="primary"]:hover > i{border-color: #16b777; color: #fff;}
 .layui-form-checked[lay-skin="primary"] > i{border-color: #16b777 !important; background-color: #16b777; color: #fff;}
 .layui-checkbox-disabled[lay-skin="primary"] > div{background: none!important;}


### PR DESCRIPTION
### 2.8.3 checkbox 开关标题略微偏上一点
![image](https://github.com/layui/layui/assets/26325820/54d05045-dcef-411d-aff1-f7ed5d8f69ec)

### checkbox 默认风格半选图标略微偏下
这是因为添加了 `box-sizing:border-box` 但 `line-height` 仍然和 `height` 一致造成的。
因为图标本身的关系，2.8.3 的选中效果看起来更居中一些，此处应该只修改半选图标的 `line-height` 吗？

![image](https://github.com/layui/layui/assets/26325820/9d6236f2-7cda-4cd7-b90c-6741d9e3f381)


### 😃 本次 PR 的变化性质

> 请至少勾选一项（即 [ ] 内填写 x ）

- [ ] 功能新增
- [x] 问题修复
- [ ] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- 修复 checkbox 开关标题未垂直居中的问题
- 修复 checkbox 默认风格图标未垂直居中的问题


### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选（即 [ ] 内填写 x ）

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明

