### PR TITLE
优化 table 打印

### DIFF
--- a/src/modules/table.js
+++ b/src/modules/table.js
@@ -1904,8 +1904,14 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
 
           printWin.document.write(style + html.prop('outerHTML'));
           printWin.document.close();
-          printWin.print();
-          printWin.close();
+          
+          if(layui.device('edg').edg){
+            printWin.onafterprint = printWin.close;
+            printWin.print();
+          }else{
+            printWin.print();
+            printWin.close();
+          }
         break;
       }
 


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项（即 [ ] 内填写 x ）

- [ ] 功能新增
- [ ] 问题修复
- [x] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- table 打印功能兼容新版 Edge [I6NZJE](https://gitee.com/layui/layui/issues/I6NZJE)

以下是不同浏览器(最新版本)在执行 `window.print()` 时的行为
| 浏览器 | `afterprint` 事件执行时机 |是否在 `window.print()` 后暂停执行代码|
| -|- |- |
| Edge | 打印完成后|  |
| Firefox | 打印开始后| ✅|
| Chrome | 打印完成后| ✅|
| IE | 打印开始后| ✅|

> Safari 因为没有设备不方便测试

在 Edge 和 Chrome 中， `printWin.print()` 后会暂停代码执行，直到打印对话框关闭。这种场景下，可能会在分配 `printWin.onafterprint` 之前引发 `onafterprint` 事件。所以需要把 `printWin.onafterprint = window.close`  放在 `printWin.print()`之前。

以下代码在除 Edge 以外的浏览器中工作良好
```
printWin.print();
printWin.close();
```
以下代码在除 Firefox 以外的浏览器中工作良好，Firefox 中无法自动关闭打印窗口
```
printWin.onafterprint = printWin.close;
printWin.print();
```

因为上述第一段代码在大多数浏览器中工作良好，并且为了避免意外(旧版浏览器不可能做全面测试)，PR 中仅对 Edge 做额外判断处理。


一些相关的信息：
1. [stackoverflow  |  Close window automatically after printing dialog closes](https://stackoverflow.com/questions/6460630/close-window-automatically-after-printing-dialog-closes)
2. [Can i use  |  Window API: afterprint event](https://caniuse.com/?search=afterprint) 
3. [MDN  |  afterprint_event](https://developer.mozilla.org/zh-CN/docs/Web/API/Window/afterprint_event)
4. [Microsoft Edge 开发人员文档 | 从网站检测 Microsoft Edge](https://learn.microsoft.com/zh-cn/microsoft-edge/web-platform/user-agent-guidance#user-agent-strings)

### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选（即 [ ] 内填写 x ）

- [ ] 已提供在线演示地址（如：[codepen](https://codepen.io/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明

