### PR TITLE
修复一些问题以及新增一些功能

### DIFF
--- a/src/modules/table.js
+++ b/src/modules/table.js
@@ -934,10 +934,10 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
         });
       }
     };
-    var done = function(res){
+    var done = function(res, isRenderData){
       that.setColsWidth();
       typeof options.done === 'function' && options.done(
-        res, curr, res[response.countName]
+        res, curr, res[response.countName], isRenderData
       );
     };
 
@@ -964,7 +964,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
         curr: curr,
         count: res[response.countName],
         type: opts.type,
-      }), sort(), done(res);
+      }), sort(), done(res, true);
     } else if(options.url){ // Ajax请求
       var params = {};
       // 当 page 开启，默认自动传递 page、limit 参数

--- a/src/modules/table.js
+++ b/src/modules/table.js
@@ -919,6 +919,9 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
   Class.prototype.pullData = function(curr, opts){
     var that = this;
     var options = that.config;
+    // 同步表头父列的相关值
+    options.HAS_SET_COLS_PATCH || that.setColsPatch();
+    options.HAS_SET_COLS_PATCH = true;
     var request = options.request;
     var response = options.response;
     var sort = function(){
@@ -1229,10 +1232,6 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
 
     // 渲染视图
     var render = function(){ // 后续性能提升的重点
-      // 同步表头父列的相关值
-      options.HAS_SET_COLS_PATCH || that.setColsPatch();
-      options.HAS_SET_COLS_PATCH = true;
-
       if(!sort && that.sortKey){
         return that.sort({
           field: that.sortKey.field,

--- a/src/modules/table.js
+++ b/src/modules/table.js
@@ -84,6 +84,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
     var options = this.config || {};
     var item3 = obj.item3; // 表头数据
     var content = obj.content; // 原始内容
+    if (item3.type === 'numbers') content = obj.tplData[table.config.numbersName];
 
     // 是否编码 HTML
     var escaped = 'escape' in item3 ? item3.escape : options.escape;
@@ -2741,7 +2742,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
           });
         } else {
           table.eachCols(id, function(i3, item3){
-            if(item3.field && item3.type == 'normal'){
+            if(item3.ignoreExport === false || item3.field && item3.type == 'normal'){
               // 不导出隐藏列
               if(item3.hide || item3.ignoreExport){
                 if(i1 == 0) fieldsIsHide[item3.field] = true; // 记录隐藏列

--- a/src/modules/table.js
+++ b/src/modules/table.js
@@ -2444,6 +2444,9 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
       var othis = $(this);
       var td = othis.closest('td');
       var index = othis.parents('tr').eq(0).data('index');
+      // 标记当前活动行
+      that.setRowActive(index);
+
       // 执行事件
       layui.event.call(
         this,
@@ -2456,8 +2459,6 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
           }
         })
       );
-      // 标记当前活动行
-      that.setRowActive(index);
     };
 
      // 行工具条单击事件

--- a/src/modules/treeTable.js
+++ b/src/modules/treeTable.js
@@ -54,11 +54,6 @@ layui.define(['table'], function (exports) {
     return that || null;
   }
 
-  // 获取当前实例配置项
-  var getThisTableConfig = function (id) {
-    return getThisTable(id).config;
-  }
-
   // 字符
   var MOD_NAME = 'treeTable';
   var HIDE = 'layui-hide';
@@ -1856,12 +1851,9 @@ layui.define(['table'], function (exports) {
   // 重载
   treeTable.reload = function (id, options, deep, type) {
     deep = deep !== false; // 默认采用深拷贝
-    var config = getThisTableConfig(id); // 获取当前实例配置项
-    if (!config) return;
-
     var that = getThisTable(id);
+    if (!that) return;
     that.reload(options, deep, type);
-
     return thisTreeTable.call(that);
   };
 

--- a/src/modules/treeTable.js
+++ b/src/modules/treeTable.js
@@ -161,9 +161,6 @@ layui.define(['table'], function (exports) {
       if (treeOptions.data.isSimpleData) {
         options.data = that.flatToTree(options.data);
       }
-      if (options.initSort && options.initSort.type) {
-        layui.sort(options.data, options.initSort.field, options.initSort.type === 'desc', true)
-      }
       that.initData(options.data);
     }
 
@@ -171,7 +168,6 @@ layui.define(['table'], function (exports) {
       options.done = function () {
         var args = arguments;
         var doneThat = this;
-        that.initSort = doneThat.initSort;
         var isRenderData = args[3]; // 是否是 renderData
         if (!isRenderData) {
           delete that.isExpandAll;
@@ -899,9 +895,7 @@ layui.define(['table'], function (exports) {
             d[idKey] !== undefined && (that.status.expand[d[idKey]] = true);
           }
         });
-        if (options.initSort && options.initSort.type &&
-          (!that.initSort || options.initSort.type !== that.initSort.type && options.initSort.field !== that.initSort.field) &&
-          (!options.url || options.autoSort)) {
+        if (options.initSort && options.initSort.type && (!options.url || options.autoSort)) {
           return treeTable.sort(id);
         }
         var trAll = table.getTrHtml(id, tableDataFlat);
@@ -1073,7 +1067,7 @@ layui.define(['table'], function (exports) {
     });
 
     // 根据需要处理options中的一些参数
-    updateOptions(that.config.id, options, type || true);
+    updateOptions(that.getOptions().id, options, type || true);
 
     // 对参数进行深度或浅扩展
     that.config = $.extend(deep, {}, that.config, options);
@@ -1137,26 +1131,9 @@ layui.define(['table'], function (exports) {
     if(!that) return;
 
     var options = that.getOptions();
-    var initSort = options.initSort;
-
-    if (!options.url) {
-      if (initSort.type) {
-        layui.sort(options.data, initSort.field, initSort.type === 'desc', true);
-      } else {
-        layui.sort(options.data, table.config.indexName, null, true);
-      }
-      that.initData(options.data);
-      treeTable.reloadData(id);
-    } else {
-      // url异步取数的表格一般需要自己添加监听之后进行reloadData并且把排序参数加入到where中
-      if (options.autoSort) {
-        var tableData = that.initData();
-        var res = {};
-        res[options.response.dataName] = tableData;
-        typeof options.done === 'function' && options.done(
-          res, that.page, that.count
-        );
-      }
+    if (!options.url || options.autoSort) {
+      that.initData();
+      treeTable.renderData(id);
     }
   }
 

--- a/src/modules/treeTable.js
+++ b/src/modules/treeTable.js
@@ -230,6 +230,7 @@ layui.define(['table'], function (exports) {
         id: "id", // 唯一标识的属性名称
         pid: "parentId", // 父节点唯一标识的属性名称
         icon: "icon", // 图标的属性名称
+        expandAllDefault: false, // 默认展开所有节点
       },
       view: {
         indent: 14, // 层级缩进量
@@ -738,6 +739,7 @@ layui.define(['table'], function (exports) {
         }
       }
     } else {
+      treeTableThat.isExpandAll = false;
       // 关闭
       if (sonSign && !isToggle) { // 非状态切换的情况下
         layui.each(childNodes, function (i1, item1) {
@@ -812,8 +814,9 @@ layui.define(['table'], function (exports) {
     }
 
     var that = getThisTable(id);
-    if(!that) return;
+    if (!that) return;
 
+    that.isExpandAll = expandFlag;
     var options = that.getOptions();
     var treeOptions = options.tree;
     var tableView = options.elem.next();
@@ -1013,6 +1016,10 @@ layui.define(['table'], function (exports) {
         expandNode({trElem}, null, null, null, true);
       });
     });
+
+    if (!level && treeOptions.view.expandAllDefault && that.isExpandAll === undefined) {
+      return treeTable.expandAll(tableId, true); // 默认展开全部
+    }
 
     // 当前层的数据看看是否需要展开
     if (sonSign !== false && dataExpand) {

--- a/src/modules/treeTable.js
+++ b/src/modules/treeTable.js
@@ -171,6 +171,11 @@ layui.define(['table'], function (exports) {
       options.done = function () {
         var args = arguments;
         var doneThat = this;
+        that.initSort = doneThat.initSort;
+        var isRenderData = args[3]; // 是否是 renderData
+        if (!isRenderData) {
+          delete that.isExpandAll;
+        }
 
         var tableView = this.elem.next();
         that.updateStatus(null, {
@@ -891,7 +896,9 @@ layui.define(['table'], function (exports) {
             d[idKey] !== undefined && (that.status.expand[d[idKey]] = true);
           }
         });
-        if (options.initSort && options.initSort.type && (!options.url || options.autoSort)) {
+        if (options.initSort && options.initSort.type &&
+          (!that.initSort || options.initSort.type !== that.initSort.type && options.initSort.field !== that.initSort.field) &&
+          (!options.url || options.autoSort)) {
           return treeTable.sort(id);
         }
         var trAll = table.getTrHtml(id, tableDataFlat);


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项（[ ] 内填写 x ）

- [x] 功能新增
- [x] 问题修复
- [x] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- 新增 treeTable `expandAllDefault` 是否默认展开全部节点
  > `tree.view` 新增 `expandAllDefault` 用于设置是否默认展开全部节点，参数的名称和位置是否合适？
- 修复 treeTable 开启了排序并且在 `done` 回调中执行了 `expandAll` 展开全部导致死循环问题
- 修复 treeTable `reload(id)` 如果找不到 id 对应实例的时候出现报错问题 [I7CXLN](https://gitee.com/layui/layui/issues/I7CXLN)
- 修复 table 复杂表头部分字段为 `hide` 在数据异常的情况下出现表头错位的问题 
  >之前的版本只有在数据正常的情况下才会对数据的表头信息进行调整导致无数据或者请求异常的时候没有更新父列的 hide 和列合并数值导致表头错位，重新调整了关键代码的执行时机修复该问题
- 加强 table `ignoreExport` 的配置支持，允许指定不排除哪些字段
  >不少小伙伴提过如何导出的时候带上序号列这个问题，虽然可以自定义一个 normal 字段然后templet输出当前数据行的 LAY_NUM 但是总归不是很方便，调整之后的设置 ignoreExport 默认为 undefined 即根据表格字段是否是普通字段决定是否导出，如果为 TRUE 则会忽略，即使是一个普通的字段，如果为 false 则表示强制导致内容，对 numbers 列做了特殊处理，可以导出序号信息，其他的比如工具列也可以加上这个配置去导出所需要的内容。
- 优化 table 调整行内点击设置活动行的和执行事件的调用顺序
   >修改前的调用顺序是先进入对应的事件回调，然后再设置行的选中样式，这导致在一些场合需要再事件中处理行选中信息但是被组件内部后续的逻辑给覆盖掉的问题
- 优化 table `done` 回调新增一个参数 `isRenderData` 区分重载和重新渲染数据
   >因为新加了一个 renderData 方法来重新渲染表格数据，绝大部情况下它跟render、reload、reloadData或者跳页进入done的时候应该是没有区别的，但是在一些极限场景下还是有需要区分的重新渲染和重新请求


### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选（[ ] 内填写 x ）

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明

