### PR TITLE
修复 dropdown 菜单(group)展开折叠时重置标题中所有图标的问题

### DIFF
--- a/src/modules/dropdown.js
+++ b/src/modules/dropdown.js
@@ -419,13 +419,14 @@ layui.define(['jquery', 'laytpl', 'lay'], function(exports){
   //设置菜单组展开和收缩状态
   thisModule.spread = function(othis){
     //菜单组展开和收缩
-    var elemIcon = othis.children('.'+ STR_MENU_TITLE).find('.layui-icon');
-    if(othis.hasClass(STR_ITEM_UP)){
+    var needSpread = othis.hasClass(STR_ITEM_UP);
+    var elemIcon = othis.children('.'+ STR_MENU_TITLE).find('.layui-icon-' + (needSpread ? 'down' : 'up'));
+    if(needSpread){
       othis.removeClass(STR_ITEM_UP).addClass(STR_ITEM_DOWN);
       elemIcon.removeClass('layui-icon-down').addClass('layui-icon-up');
     } else {
       othis.removeClass(STR_ITEM_DOWN).addClass(STR_ITEM_UP);
-      elemIcon.removeClass('layui-icon-up').addClass('layui-icon-down')
+      elemIcon.removeClass('layui-icon-up').addClass('layui-icon-down');
     }
   };
   


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项（[ ] 内填写 x ）

- [ ] 功能新增
- [x] 问题修复
- [ ] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- 修复 dropdown 组合收缩菜单展开折叠时重置标题中所有图标的问题，关闭 [I7JAPU](https://gitee.com/layui/layui/issues/I7JAPU) 

  [演示](https://codepen.io/Sight-wcg/pen/wvQrVZd)

### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选（[ ] 内填写 x ）

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明

