### PR TITLE
优化 `util.toDateString`， 更多格式化占位符支持

### DIFF
--- a/docs/util/index.md
+++ b/docs/util/index.md
@@ -100,11 +100,34 @@ var result = util.timeAgo(1672531200000); // 2023-01-01 00:00:00
 `var result = util.toDateString(time, format);`
 
 - 参数 `time` : 毫秒数或日期对象
-- 参数 `format` : 日期字符格式。默认格式：`yyyy-MM-dd HH:mm:ss` 。可自定义，如： `yyyy年MM月dd日`
+- 参数 `format` : 日期字符格式。默认格式：`yyyy-MM-dd HH:mm:ss` 。可自定义，如： `yyyy年MM月dd日`。
 
 ```
 var result = util.toDateString(1672531200000, 'yyyy-MM-dd'); // 2023-01-01
+
+// 中括号中的字符会原样保留 2.8.13+
+var result2 = util.toDateString(new Date('2023-01-01 11:35:25'), 'ss[s]'); // 25s
 ```
+
+所有可用格式列表
+
+| 格式 | 示例 | 描述 |
+| --- | --- | --- |
+| yy <sup>2.8.13+</sup> | 23 | 年，两位数 |
+| yyyy | 2023 | 年，四位数 |
+| M <sup>2.8.13+</sup> | 1-12 | 月 |
+| MM | 01-12 | 月，两位数 |
+| d <sup>2.8.13+</sup> | 1-31 | 日 |
+| dd | 01-31 | 日，两位数 |
+| H <sup>2.8.13+</sup> | 0-23 | 小时 |
+| HH | 00-23 | 小时，两位数 |
+| h <sup>2.8.13+</sup> | 1-12 | 小时，12 小时制 |
+| hh <sup>2.8.13+</sup> | 01-12 | 小时，12 小时制，两位数 |
+| m <sup>2.8.13+</sup> | 0-59 | 分钟 |
+| mm | 00-59 | 分钟，两位数 |
+| s <sup>2.8.13+</sup> | 0-59 | 秒 |
+| ss | 00-59 | 秒，两位数 |
+| SSS <sup>2.8.13+</sup> | 000-999 | 毫秒，三位数 |
 
 <h3 id="digit" class="ws-anchor ws-bold">数字前置补零</h3>
 

--- a/docs/util/index.md
+++ b/docs/util/index.md
@@ -97,19 +97,36 @@ var result = util.timeAgo(1672531200000); // 2023-01-01 00:00:00
 
 <h3 id="toDateString" class="ws-anchor ws-bold">转换日期格式字符</h3>
 
-`var result = util.toDateString(time, format);`
+`var result = util.toDateString(time, format, options);`
 
 - 参数 `time` : 毫秒数或日期对象
 - 参数 `format` : 日期字符格式。默认格式：`yyyy-MM-dd HH:mm:ss` 。可自定义，如： `yyyy年MM月dd日`
+- 参数 `options` <sup>2.8.13+</sup> : 该方法的属性可选项，详见下表：
+
+| 属性名 | 描述 | 类型 | 默认值 |
+| --- | --- | --- | --- |
+| customMeridiem | 自定义 meridiem 格式 | Function | - |
 
 ```
 var result = util.toDateString(1672531200000, 'yyyy-MM-dd'); // 2023-01-01
 
 // 中括号中的字符会原样保留 2.8.13+
 var result2 = util.toDateString(new Date('2023-01-01 11:35:25'), 'ss[s]'); // 25s
+
+// 自定义 meridiem
+var result3 = util.toDateString(
+  '2023-01-01 11:35:25', 
+  'hh:mm:ss A'
+  {
+    customMeridiem: function(hours, minutes){
+      return (hours < 12 ? 'AM' : 'PM')
+        //.split('').join('.') // 有句点，A.M.
+        //.toLowerCase() // 小写，a.m.
+    }
+); // 11:35:25 AM
 ```
 
-所有可用格式列表
+所有可用的格式列表
 
 | 格式 | 示例 | 描述 |
 | --- | --- | --- |
@@ -123,7 +140,7 @@ var result2 = util.toDateString(new Date('2023-01-01 11:35:25'), 'ss[s]'); // 25
 | HH | 00-23 | 小时，两位数 |
 | h <sup>2.8.13+</sup> | 1-12 | 小时，12 小时制 |
 | hh <sup>2.8.13+</sup> | 01-12 | 小时，12 小时制，两位数 |
-| A <sup>2.8.13+</sup> | 凌晨/早上/上午/中午/下午/晚上 | 时段 |
+| A <sup>2.8.13+</sup> | 凌晨/早上/上午/中午/下午/晚上 | meridiem |
 | m <sup>2.8.13+</sup> | 0-59 | 分钟 |
 | mm | 00-59 | 分钟，两位数 |
 | s <sup>2.8.13+</sup> | 0-59 | 秒 |

--- a/docs/util/index.md
+++ b/docs/util/index.md
@@ -100,7 +100,7 @@ var result = util.timeAgo(1672531200000); // 2023-01-01 00:00:00
 `var result = util.toDateString(time, format);`
 
 - 参数 `time` : 毫秒数或日期对象
-- 参数 `format` : 日期字符格式。默认格式：`yyyy-MM-dd HH:mm:ss` 。可自定义，如： `yyyy年MM月dd日`。
+- 参数 `format` : 日期字符格式。默认格式：`yyyy-MM-dd HH:mm:ss` 。可自定义，如： `yyyy年MM月dd日`
 
 ```
 var result = util.toDateString(1672531200000, 'yyyy-MM-dd'); // 2023-01-01
@@ -123,6 +123,7 @@ var result2 = util.toDateString(new Date('2023-01-01 11:35:25'), 'ss[s]'); // 25
 | HH | 00-23 | 小时，两位数 |
 | h <sup>2.8.13+</sup> | 1-12 | 小时，12 小时制 |
 | hh <sup>2.8.13+</sup> | 01-12 | 小时，12 小时制，两位数 |
+| A <sup>2.8.13+</sup> | 凌晨/早上/上午/中午/下午/晚上 | 时段 |
 | m <sup>2.8.13+</sup> | 0-59 | 分钟 |
 | mm | 00-59 | 分钟，两位数 |
 | s <sup>2.8.13+</sup> | 0-59 | 秒 |

--- a/examples/util.html
+++ b/examples/util.html
@@ -132,7 +132,6 @@ layui.use(['util', 'layer'], function(){
 
   // 转换日期格式
   var timer = null
-  if (timer) clearInterval(timer)
   var toDateString = function (format) {
     var dateString = util.toDateString(new Date(), format);
     $('#test3').html(dateString)

--- a/examples/util.html
+++ b/examples/util.html
@@ -29,6 +29,14 @@ body{padding: 50px;}
 
 <hr>
 
+请编辑格式：
+<div class="layui-inline">
+  <input type="text" value="yyyy-MM-dd HH:mm:ss" class="layui-input" id="test2"/>
+</div>
+<span class="layui-word-aux" id="test3"></span>
+
+<hr>
+
 <div id="target-test" style1="position: relative; height: 300px; overflow: auto;">
   1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>1<br>
 </div>
@@ -121,6 +129,17 @@ layui.use(['util', 'layer'], function(){
       alert(othis.html())
     }
   });
+
+  // 转换日期格式
+  var timer = null
+  if (timer) clearInterval(timer)
+  var toDateString = function (format) {
+    var dateString = util.toDateString(new Date(), format) // 执行转换日期格式的方法
+    $('#test3').html(dateString)
+  }
+  timer = setInterval(() => {
+    toDateString($('#test2').val())
+  }, 50)
   
 });
 </script>

--- a/examples/util.html
+++ b/examples/util.html
@@ -134,11 +134,7 @@ layui.use(['util', 'layer'], function(){
   var timer = null
   if (timer) clearInterval(timer)
   var toDateString = function (format) {
-    var dateString = util.toDateString(new Date(), format, {customMeridiem: function(hours, minutes){
-      return (hours < 12 ? 'AM' : 'PM')
-        //.split('').join('.') // 有句点 '.'
-        //.toLowerCase() // 小写
-    }});
+    var dateString = util.toDateString(new Date(), format);
     $('#test3').html(dateString)
   }
   timer = setInterval(() => {

--- a/examples/util.html
+++ b/examples/util.html
@@ -134,7 +134,11 @@ layui.use(['util', 'layer'], function(){
   var timer = null
   if (timer) clearInterval(timer)
   var toDateString = function (format) {
-    var dateString = util.toDateString(new Date(), format) // 执行转换日期格式的方法
+    var dateString = util.toDateString(new Date(), format, {customMeridiem: function(hours, minutes){
+      return (hours < 12 ? 'AM' : 'PM')
+        //.split('').join('.') // 有句点 '.'
+        //.toLowerCase() // 小写
+    }});
     $('#test3').html(dateString)
   }
   timer = setInterval(() => {

--- a/src/modules/util.js
+++ b/src/modules/util.js
@@ -293,7 +293,7 @@ layui.define('jquery', function(exports){
           return '晚上';
       };
 
-      var meridiem = options.customMeridiem || defaultMeridiem;
+      var meridiem = (options && options.customMeridiem) || defaultMeridiem;
 
       var matches = {
         yy: function(){return String(years).slice(-2);},

--- a/src/modules/util.js
+++ b/src/modules/util.js
@@ -255,9 +255,11 @@ layui.define('jquery', function(exports){
     
     // 转化为日期格式字符
     toDateString: function(time, format){
-      //若 null 或空字符，则返回空字符
+      // 若 null 或空字符，则返回空字符
       if(time === null || time === '') return '';
-      
+
+      // 引用自 dayjs 
+      // https://github.com/iamkun/dayjs/blob/v1.11.9/src/constant.js#L30
       var REGEX_FORMAT = /\[([^\]]+)]|y{1,4}|M{1,2}|d{1,2}|H{1,2}|h{1,2}|m{1,2}|s{1,2}|SSS/g;
       var that = this;
       var date = new Date(function(){

--- a/src/modules/util.js
+++ b/src/modules/util.js
@@ -254,7 +254,7 @@ layui.define('jquery', function(exports){
     },
     
     // 转化为日期格式字符
-    toDateString: function(time, format){
+    toDateString: function(time, format, options){
       // 若 null 或空字符，则返回空字符
       if(time === null || time === '') return '';
 
@@ -277,8 +277,8 @@ layui.define('jquery', function(exports){
       var seconds = date.getSeconds();
       var milliseconds = date.getMilliseconds();
 
-      var meridiem = function(hour, minute){
-          var hm = hour * 100 + minute;
+      var defaultMeridiem = function(hours, minutes){
+          var hm = hours * 100 + minutes;
           if (hm < 600) {
             return '凌晨';
           } else if (hm < 900) {
@@ -292,6 +292,8 @@ layui.define('jquery', function(exports){
           }
           return '晚上';
       };
+
+      var meridiem = options.customMeridiem || defaultMeridiem;
 
       var matches = {
         yy: function(){return String(years).slice(-2);},

--- a/src/modules/util.js
+++ b/src/modules/util.js
@@ -260,7 +260,7 @@ layui.define('jquery', function(exports){
 
       // 引用自 dayjs 
       // https://github.com/iamkun/dayjs/blob/v1.11.9/src/constant.js#L30
-      var REGEX_FORMAT = /\[([^\]]+)]|y{1,4}|M{1,2}|d{1,2}|H{1,2}|h{1,2}|m{1,2}|s{1,2}|SSS/g;
+      var REGEX_FORMAT = /\[([^\]]+)]|y{1,4}|M{1,2}|d{1,2}|H{1,2}|h{1,2}|a|A|m{1,2}|s{1,2}|SSS/g;
       var that = this;
       var date = new Date(function(){
         if(!time) return;
@@ -277,6 +277,22 @@ layui.define('jquery', function(exports){
       var seconds = date.getSeconds();
       var milliseconds = date.getMilliseconds();
 
+      var meridiem = function(hour, minute){
+          var hm = hour * 100 + minute;
+          if (hm < 600) {
+            return '凌晨';
+          } else if (hm < 900) {
+            return '早上';
+          } else if (hm < 1100) {
+            return '上午';
+          } else if (hm < 1300) {
+            return '中午';
+          } else if (hm < 1800) {
+            return '下午';
+          }
+          return '晚上';
+      };
+
       var matches = {
         yy: function(){return String(years).slice(-2);},
         yyyy: function(){return that.digit(years, 4);},
@@ -288,6 +304,7 @@ layui.define('jquery', function(exports){
         HH: function(){return that.digit(hours);},
         h: function(){return String(hours % 12 || 12);},
         hh: function(){return that.digit(hours % 12 || 12);},
+        A: function(){return meridiem(hours, minutes);},
         m: function(){return String(minutes);},
         mm: function(){return that.digit(minutes);},
         s: function(){return String(seconds);},

--- a/src/modules/util.js
+++ b/src/modules/util.js
@@ -258,31 +258,46 @@ layui.define('jquery', function(exports){
       //若 null 或空字符，则返回空字符
       if(time === null || time === '') return '';
       
-      var that = this
-      ,date = new Date(function(){
+      var REGEX_FORMAT = /\[([^\]]+)]|y{1,4}|M{1,2}|d{1,2}|H{1,2}|h{1,2}|m{1,2}|s{1,2}|SSS/g;
+      var that = this;
+      var date = new Date(function(){
         if(!time) return;
         return isNaN(time) ? time : (typeof time === 'string' ? parseInt(time) : time)
       }() || new Date())
-      ,ymd = [
-        that.digit(date.getFullYear(), 4)
-        ,that.digit(date.getMonth() + 1)
-        ,that.digit(date.getDate())
-      ]
-      ,hms = [
-        that.digit(date.getHours())
-        ,that.digit(date.getMinutes())
-        ,that.digit(date.getSeconds())
-      ];
-      
+
       if(!date.getDate()) return hint.error('Invalid Msec for "util.toDateString(Msec)"'), '';
+
+      var years = date.getFullYear();
+      var month = date.getMonth();
+      var days = date.getDate();
+      var hours = date.getHours();
+      var minutes = date.getMinutes();
+      var seconds = date.getSeconds();
+      var milliseconds = date.getMilliseconds();
+
+      var matches = {
+        yy: function(){return String(years).slice(-2);},
+        yyyy: function(){return that.digit(years, 4);},
+        M: function(){return String(month + 1);},
+        MM: function(){return that.digit(month + 1);},
+        d: function(){return String(days);},
+        dd: function(){return that.digit(days);},
+        H: function(){return String(hours);},
+        HH: function(){return that.digit(hours);},
+        h: function(){return String(hours % 12 || 12);},
+        hh: function(){return that.digit(hours % 12 || 12);},
+        m: function(){return String(minutes);},
+        mm: function(){return that.digit(minutes);},
+        s: function(){return String(seconds);},
+        ss: function(){return that.digit(seconds);},
+        SSS: function(){return that.digit(milliseconds, 3);}
+      }
       
       format = format || 'yyyy-MM-dd HH:mm:ss';
-      return format.replace(/yyyy/g, ymd[0])
-      .replace(/MM/g, ymd[1])
-      .replace(/dd/g, ymd[2])
-      .replace(/HH/g, hms[0])
-      .replace(/mm/g, hms[1])
-      .replace(/ss/g, hms[2]);
+
+      return format.replace(REGEX_FORMAT, function(match, $1) {
+        return $1 || (matches[match] && matches[match]()) || match;
+      });
     },
     
     // 转义 html


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项（[ ] 内填写 x ）

- [x] 功能新增
- [ ] 问题修复
- [ ] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- 支持 `yy`, `M`,`d`,`H`,`hh`,`h`,`m`,`s`,`SSS` ,`A`格式化占位符，关闭 [I7QNPR](https://gitee.com/layui/layui/issues/I7QNPR)

**所有可用格式的列表，中括号里的字符会原样保留** 

[playground](https://codepen.io/Sight-wcg/pen/RwqdyBY)

|Format |Output | Description |
| --- | --- | --- |
|yy|23|两位数的年份|
|yyyy|2023|四位数的年份|
|M|1-12|月份，从 1 开始|
|MM|01-12|月份，两位数字|
|d|1-31|月份里的一天
|dd|01-31|月份里的一天，两位数字|
|H|0-23|小时|
|HH|00-23|小时，两位数字|
|h|1-12|小时, 12 小时制
|hh|01-12|小时, 12 小时制, 两位数字|
|A| 凌晨/早上/上午/中午/下午/晚上 | meridiem, 时间术语不太好翻译 |
|m|0-59|分钟|
|mm|00-59|分钟，两位数字|
|s|0-59|秒|
|ss|00-59|秒，两位数字|
|SSS|000-999|毫秒，三位数字|



### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选（[ ] 内填写 x ）

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明

