### PR TITLE
修复 lay.clipboard.writeText IE8 下报错的问题

### DIFF
--- a/src/modules/lay.js
+++ b/src/modules/lay.js
@@ -318,13 +318,16 @@
       try {
         navigator.clipboard.writeText(text).then(
           options.done
-        ).['catch'](options.error);
+        )['catch'](options.error);
       } catch(e) {
         var elem = document.createElement('textarea');
 
         elem.value = text;
-        elem.style.position = 'absolute';
+        elem.style.position = 'fixed';
         elem.style.opacity = '0';
+        elem.style.top = '0px';
+        elem.style.left = '0px';
+        
         document.body.appendChild(elem);
         elem.select();
 
@@ -333,9 +336,9 @@
           typeof options.done === 'function' && options.done();
         } catch(err) {
           typeof options.error === 'function' && options.error(err);
+        } finally {
+          elem.remove ? elem.remove() : document.body.removeChild(elem);
         }
-
-        elem.remove();
       }
     }
   };

--- a/src/modules/lay.js
+++ b/src/modules/lay.js
@@ -318,7 +318,7 @@
       try {
         navigator.clipboard.writeText(text).then(
           options.done
-        ).catch(options.error);
+        ).['catch'](options.error);
       } catch(e) {
         var elem = document.createElement('textarea');
 


### PR DESCRIPTION
修复 lay.clipboard.writeText IE8 下报错的问题，catch 是保留字

### 😃 本次 PR 的变化性质

> 请至少勾选一项（[ ] 内填写 x ）

- [ ] 功能新增
- [x] 问题修复
- [ ] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- 修复 lay.clipboard.writeText IE8 下报错的问题


### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选（[ ] 内填写 x ）

- [ ] 已提供在线演示地址（如：[codepen](https://codepen.io/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明

