### PR TITLE
新增 code 组件 wrapLines 选项

### DIFF
--- a/src/css/modules/code.css
+++ b/src/css/modules/code.css
@@ -66,8 +66,12 @@ html #layuicss-skincodecss{display:none; position: absolute; width:1989px;}
 /* 代码高亮重置 */
 .layui-code-view.layui-code-hl{
   line-height: 20px !important;
+  padding: 0 !important;
 }
 .layui-code-view.layui-code-hl > .layui-code-lines,
 .layui-code-view.layui-code-hl > .layui-code-line-numbers{
   background-color: transparent;
+}
+.layui-code-view.layui-code-hl.layui-code-line-numbers-mode{
+  padding-left: 45px !important;
 }

--- a/src/css/modules/code.css
+++ b/src/css/modules/code.css
@@ -12,6 +12,7 @@ html #layuicss-skincodecss{display:none; position: absolute; width:1989px;}
 /* 基础结构 */
 .layui-code-view{display: block; position: relative; margin: 11px 0; padding: 0; border: 1px solid #eee; border-left-width: 6px; background-color: #fff; color: #333; white-space: pre; overflow: auto;}
 .layui-code-view.layui-code-line-numbers-mode{padding-left: 45px;}
+.layui-code-view.layui-code-wrap-lines-mode{white-space: pre-wrap;}
 .layui-code-title{position: relative; padding: 0 10px; height: 40px; line-height: 40px; border-bottom: 1px solid #eee; font-size: 12px;}
 .layui-code-title > .layui-code-about{position: absolute; right: 10px; top: 0; color: #B7B7B7;}
 .layui-code-line-numbers-mode .layui-code-title{margin-left: -45px;}
@@ -74,4 +75,7 @@ html #layuicss-skincodecss{display:none; position: absolute; width:1989px;}
 }
 .layui-code-view.layui-code-hl.layui-code-line-numbers-mode{
   padding-left: 45px !important;
+}
+.layui-code-view.layui-code-hl.layui-code-wrap-lines-mode{
+  white-space: pre-wrap !important;
 }


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项（[ ] 内填写 x ）

- [ ] 功能新增
- [x] 问题修复
- [x] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

  以下均为 https://github.com/layui/layui/pull/1352 引发的一些问题，[演示](https://codepen.io/Sight-wcg/pen/xxmRxGL)

- 新增 code 组件 wrapLines 选项，控制是否换行显示。
  这和 https://github.com/layui/layui/pull/1352 之前的行为基本一致，考虑到新行号实现下，代码折行显示需要做额外的处理，默认关闭该选项
- ~~修复使用 skin:dark 时行号右边框颜色错误的问题，[ref: 优化行号]~~(https://github.com/layui/layui/pull/1352/commits/35417d2ea57bd8e346ada3368907a121a4b3de87)
- ~~修复 codeRender 选项第二个参数 options.elem 的值不正确的问题，[ref: 修复 IE8 下的一些问题](https://github.com/layui/layui/pull/1352/commits/37f756f9ba8671c50f72f9518504bcfdd735c75c)~~

### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选（[ ] 内填写 x ）

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明

