### PR TITLE
筛选显示列时，增加显示父列名

### DIFF
--- a/src/modules/table.js
+++ b/src/modules/table.js
@@ -1882,10 +1882,44 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
         case 'LAYTABLE_COLS': // 筛选列
           openPanel({
             list: function(){
+              var cols = [];
+              layui.each(that.config.cols, function (i1, row) {
+                layui.each(row, function (i2, col) {
+                  cols.push(col);
+                });
+              });
+
+              var findColParents = function (parentKey) {
+                var list = [];
+                var parentTitle = null;
+
+                if (!parentKey) return [];
+
+                while (true) {
+                  parentTitle = null;
+
+                  layui.each(cols, function (i, item) {
+                    if (item.key === parentKey) {
+                      parentTitle = util.escape($('<div>' + (item.fieldTitle || item.title || item.field) + '</div>').text());
+                      parentKey = item.parentKey || null;
+                      return false;
+                    }
+                  })
+
+                  if (null === parentTitle) break;
+                  list.push(parentTitle);
+                  if (null === parentKey) break;
+                }
+
+                return list.reverse();
+              }
+
               var lis = [];
               that.eachCols(function(i, item){
                 if(item.field && item.type == 'normal'){
-                  lis.push('<li><input type="checkbox" name="'+ item.field +'" data-key="'+ item.key +'" data-parentkey="'+ (item.parentKey||'') +'" lay-skin="primary" '+ (item.hide ? '' : 'checked') +' title="'+ util.escape($('<div>' + (item.fieldTitle || item.title || item.field) + '</div>').text()) +'" lay-filter="LAY_TABLE_TOOL_COLS"></li>');
+                  var colTitle = findColParents(item.parentKey);
+                  colTitle.push(util.escape($('<div>' + (item.fieldTitle || item.title || item.field) + '</div>').text()));
+                  lis.push('<li><input type="checkbox" name="'+ item.field +'" data-key="'+ item.key +'" data-parentkey="'+ (item.parentKey||'') +'" lay-skin="primary" '+ (item.hide ? '' : 'checked') +' title="'+ colTitle.join(' - ') +'" lay-filter="LAY_TABLE_TOOL_COLS"></li>');
                 }
               });
               return lis.join('');


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [ ] 问题修复
- [x] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

筛选表格列时，增加显示父列名。因为多级表头，可能会存在同名的子列名，例如：

* 联系人1：姓名、电话、性别
* 联系人2：姓名、电话、性别
* .....

筛选列时，会有多个姓名、电话或性别，分不清属于那个联系人。

### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [x] 在线演示地址[codepen](https://codepen.io/big-dream-the-solid/pen/ExGWqjX)
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明

![image](https://github.com/layui/layui/assets/9215157/aee7cf97-00f3-428f-a08a-1e4cf887ca8b)

