### PR TITLE
优化 layer 移动端定位

### DIFF
--- a/examples/layer.html
+++ b/examples/layer.html
@@ -24,6 +24,7 @@
   <button class="layui-btn" lay-on="test7">Prompt</button>
   <button class="layui-btn" lay-on="test8">Tab</button>
   <button class="layui-btn" lay-on="test9">Photo</button>
+  <button class="layui-btn" lay-on="test10">Drawer</button>
   <button class="layui-btn" lay-on="testTime">自动关闭</button>
   <a href="https://layui.dev/docs/2.8/layer/" target="_blank" class="layui-btn">更多例子</a>
 </div>
@@ -213,6 +214,19 @@ layui.use(['layer', 'util'], function(layer, util){
         ,end: function(){
           clearInterval(this.timer);
         }
+      });
+    }
+    ,test10: function(){
+      layer.open({
+        title:'drawer',
+        type: 1,
+        offset: 'b',
+        anim: 'slideUp', // 从下往上
+        area: ['100%', '160px'],
+        shade: 0.1,
+        shadeClose: true,
+        content: $('#test11111'),
+        maxmin: true,
       });
     }
   });

--- a/src/modules/layer.js
+++ b/src/modules/layer.js
@@ -1727,15 +1727,12 @@ ready.run = function(_$){
   var isMobile = /android|iphone|ipod|ipad|ios/.test(agent)
   var _win = $(window);
   if(isMobile){
-    $.each({Height: "height", Width: "width"}, function(k, v){
-      var nativeProp = 'inner' + k;
-      var jQFunc = v;
-      win[jQFunc] = function(val){
-        return val
-          ? _win[jQFunc](val) 
-          : nativeProp in window 
-          ? window[nativeProp]
-          : _win[jQFunc]()
+    $.each({Height: "height", Width: "width"}, function(propSuffix, funcName){
+      var propName = 'inner' + propSuffix;
+      win[funcName] = function(){
+        return propName in window 
+          ? window[propName]
+          : _win[funcName]()
       }
     })
   }

--- a/src/modules/layer.js
+++ b/src/modules/layer.js
@@ -1719,6 +1719,26 @@ layer.photos = function(options, loop, key){
 ready.run = function(_$){
   $ = _$;
   win = $(window);
+  
+  // 移动端兼容性处理
+  // https://gitee.com/layui/layui/issues/I81WGC
+  // https://github.com/jquery/jquery/issues/1729
+  var agent = navigator.userAgent.toLowerCase();
+  var isMobile = /android|iphone|ipod|ipad|ios/.test(agent)
+  var _win = $(window);
+  if(isMobile){
+    $.each({Height: "height", Width: "width"}, function(k, v){
+      var nativeProp = 'inner' + k;
+      var jQFunc = v;
+      win[jQFunc] = function(val){
+        return val
+          ? _win[jQFunc](val) 
+          : nativeProp in window 
+          ? window[nativeProp]
+          : _win[jQFunc]()
+      }
+    })
+  }
   doms.html = $('html');
   layer.open = function(deliver){
     var o = new Class(deliver);


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [x] 问题修复
- [x] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- 优化 layer 移动端定位，关闭 [I81WGC](https://gitee.com/layui/layui/issues/I81WGC)，也可能解决 [I7W9FN](https://gitee.com/layui/layui/issues/I7W9FN)

已在 Android 9 系统 webview(chrome 73)，Kiwi Browser(chrome 112)中测试通过。这应该是 jQuery 的 BUG，详细信息参考 https://github.com/jquery/jquery/pull/764
jQuery 在 2.2 中解决了这个问题，使用 $(window).outerXXX() 时和 window.innerXXX 行为一致 
https://github.com/jquery/jquery/issues/1729
https://github.com/jquery/jquery/commit/7d44d7f9e7cb73ff2b373f08cea13ea9958bb462

Before
![官网](https://github.com/layui/layui/assets/26325820/76451059-94db-48bd-b89a-61752fa17f54)

After
![官网](https://github.com/layui/layui/assets/26325820/112a9271-34b1-40c5-973f-003834df0840)


【演示】https://stackblitz.com/edit/web-platform-nihidf



### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明
