### PR TITLE
table支持二级json解释

### DIFF
--- a/src/modules/table.js
+++ b/src/modules/table.js
@@ -1137,7 +1137,13 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
       that.eachCols(function(i3, item3){
         var field = item3.field || i3;
         var key = item3.key;
-        var content = item1[field];
+        var content = '';
+
+        try {
+          content = eval('item1.'+field);
+        } catch (error) {
+          
+        }
 
         if(content === undefined || content === null) content = '';
         if(item3.colGroup) return;


### PR DESCRIPTION
table支持二级json解释。

### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [ ] 问题修复
- [x] 功能优化
- [ ] 分支合并

### 🌱 本次 PR 的变化内容

-  table 支持二级json解释。用法：
- table.render({
  elem: '#table',
  url: '获取数据的URL',
  cols: [[
  {field: 'id', title: 'ID'},
  {field: 'name', title: '姓名'},
  {field: 'info.name', title: '二级json的姓名'},
  {field: 'info.age', title: '二级json的年龄'}
]]
});

### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [x] 无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明
