### PR TITLE
修复 input-number `lay-precision` 属性初始渲染时无效的问题

### DIFF
--- a/src/css/layui.css
+++ b/src/css/layui.css
@@ -825,7 +825,7 @@ a cite{font-style: normal; *cursor:pointer;}
 .layui-input-wrap .layui-input[type="number"]::-webkit-outer-spin-button,
 .layui-input-wrap .layui-input[type="number"]::-webkit-inner-spin-button{-webkit-appearance: none !important;}
 .layui-input-wrap .layui-input[type="number"]{-moz-appearance: textfield;}
-.layui-input-wrap .layui-input[type="number"].layui-input-out-of-range{color:#ff5722}
+.layui-input-wrap .layui-input[type="number"].layui-input-number-out-of-range{color:#ff5722;}
 
 
 

--- a/src/css/layui.css
+++ b/src/css/layui.css
@@ -825,6 +825,7 @@ a cite{font-style: normal; *cursor:pointer;}
 .layui-input-wrap .layui-input[type="number"]::-webkit-outer-spin-button,
 .layui-input-wrap .layui-input[type="number"]::-webkit-inner-spin-button{-webkit-appearance: none !important;}
 .layui-input-wrap .layui-input[type="number"]{-moz-appearance: textfield;}
+.layui-input-wrap .layui-input[type="number"].layui-input-out-of-range{color:#ff5722}
 
 
 

--- a/src/modules/form.js
+++ b/src/modules/form.js
@@ -184,6 +184,7 @@ layui.define(['lay', 'layer', 'util'], function(exports){
           var max = Number(elem.attr('max'));
           var precision = Number(elem.attr('lay-precision'));
           var noAction = eventType !== 'click' && rawValue === ''; // 初始渲染和失焦时空值不作处理
+          var isInit = eventType === 'init';
 
           if(isNaN(value)) return; // 若非数字，则不作处理
 
@@ -202,7 +203,7 @@ layui.define(['lay', 'layer', 'util'], function(exports){
 
           if(!noAction){
             // 初始渲染时只处理数字精度
-            if(eventType !== 'init'){
+            if(!isInit){
               if(value <= min) value = min;
               if(value >= max) value = max;
             }
@@ -213,6 +214,8 @@ layui.define(['lay', 'layer', 'util'], function(exports){
           // 超出范围的样式
           var outOfRange = value < min || value > max;
           elem[outOfRange && !noAction ? 'addClass' : 'removeClass'](OUT_OF_RANGE);
+
+          if(isInit) return;
 
           // 更新按钮状态
           var controlBtn = {

--- a/src/modules/form.js
+++ b/src/modules/form.js
@@ -17,7 +17,7 @@ layui.define(['lay', 'layer', 'util'], function(exports){
   var SHOW = 'layui-show';
   var HIDE = 'layui-hide';
   var DISABLED = 'layui-disabled';
-  var OUT_OF_RANGE = 'layui-input-out-of-range';
+  var OUT_OF_RANGE = 'layui-input-number-out-of-range';
   
   var Form = function(){
     this.config = {


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [x] 问题修复
- [ ] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- 修复 input-number `lay-precision` 属性初始渲染时无效的问题，关闭 [I85Z5Y](https://gitee.com/layui/layui/issues/I85Z5Y)

  [演示] https://stackblitz.com/edit/ovywgf-psxkna?file=index.html


### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明
