### PR TITLE
修复 treeTable 数据格式为简单类型时 IE9+ 兼容问题

### DIFF
--- a/src/modules/treeTable.js
+++ b/src/modules/treeTable.js
@@ -301,9 +301,13 @@ layui.define(['table'], function (exports) {
       }
     })
     // 返回顶层节点
-    return Object.values(nodes).filter(function (item) {
-      return rootPid ? item[pIdKey] === rootPid : !item[pIdKey];
-    })
+    return Object.keys(nodes)
+      .map(function(k) {
+        return nodes[k];
+      })
+      .filter(function (item) {
+        return rootPid ? item[pIdKey] === rootPid : !item[pIdKey];
+      })
   }
 
   Class.prototype.flatToTree = function (tableData) {


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [x] 问题修复
- [ ] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- 修复 treeTable 数据格式为简单类型时 IE9+ 兼容问题，关闭 [I8C04Y](https://gitee.com/layui/layui/issues/I8C04Y)

  IE8 仍需要添加 [Object.keys 的 polyfill](https://github.com/inexorabletash/polyfill/blob/716a3f36ca10fad032083014faf1a47c638e2502/es5.js#L111-L124)


### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [ ] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明
