### PR TITLE
优化 `lay.clipboard.writeText`，没有剪贴板写入权限时使用 legacy 方法

### DIFF
--- a/src/modules/lay.js
+++ b/src/modules/lay.js
@@ -468,11 +468,16 @@
     writeText: function(options) {
       var text = String(options.text);
 
-      try {
-        navigator.clipboard.writeText(text).then(
-          options.done
-        )['catch'](options.error);
-      } catch(e) {
+      if(navigator && 'clipboard' in navigator){
+        navigator.clipboard.writeText(text)
+          .then(options.done, function(){
+            legacyCopy();
+        });
+      }else{
+        legacyCopy();
+      }
+
+      function legacyCopy(){
         var elem = document.createElement('textarea');
 
         elem.value = text;


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [x] 问题修复
- [ ] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- 优化 `lay.clipboard.writeText`，没有剪贴板写入权限时使用 legacy 方法。修复 [I8D94I](https://gitee.com/layui/layui/issues/I8D94I)

【演示】https://stackblitz.com/edit/web-platform-51v1cs?file=index.html

  例如现在可以在 stackblitz 的 iframe 中复制

![image](https://github.com/layui/layui/assets/26325820/9bd9271b-50c0-453f-815b-e0cb95d75c31)


### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明
