### PR TITLE
修复 table 单元格多行展开风格，关闭展开状态时，表格行悬停状态类未移除的问题

### DIFF
--- a/src/modules/table.js
+++ b/src/modules/table.js
@@ -2537,7 +2537,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
         // 关闭展开状态
         elemCellClose.on('click', function(){
           var $this = $(this);
-          that.setRowActive(index, ELEM_EXPAND, true); // 移除单元格展开样式
+          that.setRowActive(index, [ELEM_EXPAND, ELEM_HOVER].join(' '), true); // 移除单元格展开样式
           that.cssRules(key, function(item){
             item.style.width =  $this.data('cell-width'); // 恢复单元格展开前的宽度
             that.resize(); // 滚动条补丁


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [x] 问题修复
- [ ] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- 修复 table 单元格多行展开风格，关闭展开状态时，表格行悬停状态类未移除的问题
Before
![官网2](https://github.com/layui/layui/assets/26325820/893cf637-6356-4217-9b99-60feaf151c4c)

After
![官网2](https://github.com/layui/layui/assets/26325820/72a2c4a1-289c-4f76-a138-6a8308eb23b4)



### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [ ] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明
