### PR TITLE
fix(treetable): 修复 `treeTable.updateNode()` 更新已打开的节点时，未重新渲染表单元素的问题

### DIFF
--- a/src/modules/treeTable.js
+++ b/src/modules/treeTable.js
@@ -1037,6 +1037,10 @@ layui.define(['table'], function (exports) {
         trDefaultExpand.find('.layui-table-tree-flexIcon').html(treeOptionsView.flexIconOpen);
         expandNode({trElem: trDefaultExpand.first()}, true);
       });
+      // #1463 expandNode 中已经展开过的节点不会重新渲染
+      debounceFn('renderTreeTable2-' + tableId, function () {
+        form.render($('.layui-table-tree[lay-id="' + tableId + '"]'));
+      }, 0)();
     } else {
       debounceFn('renderTreeTable-' + tableId, function () {
         options.hasNumberCol && formatNumber(that);


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [x] 问题修复
- [ ] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- 修复 teetable 组件 `treeTable.updateNode` 更新已打开的节点时，未重新渲染表单元素的问题

  [演示]https://stackblitz.com/edit/wyjrwb-98swhb?file=demo-1.json


### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明
