### PR TITLE
chore: 添加 eslint 格式化规则

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,38 @@
+module.exports = {
+  env: {
+    browser: true,
+  },
+  globals: {
+    layui: "readonly",
+    layer: "readonly",
+    lay: "readonly",
+  },
+  parserOptions: {
+    ecmaVersion: 5,
+    sourceType: "script",
+    allowReserved: false,
+    ecmaFeatures: {
+      impliedStrict: true,
+    },
+  },
+  ignorePatterns: ["!src/**/*.js", "src/modules/jquery.js"],
+  plugins: ["@stylistic"],
+  rules: {
+    "@stylistic/indent": ["error", 2], // 缩进
+    "@stylistic/semi": ["error", "always"], // 分号
+    "@stylistic/semi-style": ["error", "last"], // 分号在语句的末尾
+    "@stylistic/quotes": ["error", "single"], // 单引号
+    "@stylistic/comma-style": [ // 逗号风格
+      "error",
+      "last",
+      { exceptions: { VariableDeclaration: false } },
+    ], 
+    "@stylistic/comma-dangle": ["error", "never"], // 不允许尾随逗号
+    "@stylistic/spaced-comment": ["error", "always"], // 注释间距
+    "@stylistic/no-trailing-spaces": ["error", {"ignoreComments": true}], // 禁止行尾尾随空格
+    "@stylistic/eol-last": ["error", "always"], // 文件末尾换行
+    "@stylistic/linebreak-style": ["error", "unix"], // 换行样式
+    "no-console": ["error", { allow: ["warn", "error"] }],
+    "one-var": ["error", "never"],
+  },
+};

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ node_modules/
 _site/
 .git/
 package-lock.json
+.eslintcache
 
 # Published folders
 release/

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
   "scripts": {
     "build": "gulp",
     "release": "npm run build && npm rum release-zip",
-    "release-zip": "gulp release"
+    "release-zip": "gulp release",
+    "lint": "npx eslint src --cache",
+    "lint:fix": "npx eslint src --fix"
   },
   "devDependencies": {
     "gulp": "^4.0.2",
@@ -39,7 +41,9 @@
     "gulp-sourcemaps": "^3.0.0",
     "gulp-zip": "^5.1.0",
     "del": "^6.1.1",
-    "minimist": "^1.2.8"
+    "minimist": "^1.2.8",
+    "eslint": "^8.56.0",
+    "@stylistic/eslint-plugin": "^1.5.1"
   },
   "dependencies": {}
 }

--- a/src/layui.js
+++ b/src/layui.js
@@ -43,6 +43,7 @@
   // 异常提示
   var error = function(msg, type){
     type = type || 'log';
+    /* eslint-disable-next-line no-console */
     win.console && console[type] && console[type]('layui error hint: ' + msg);
   };
 


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [ ] 问题修复
- [ ] 功能优化
- [ ] 分支合并
- [x] 其他改动：lint

### 🌱 本次 PR 的变化内容

  此 PR 根据以往的「优化代码风格」相关提交，配置了一些 eslint 规则，用于自动格式化代码。相比 Prettier 和 dprint 这些流行的格式化工具，eslint 可以保留项目原始代码风格，也可以避免 https://github.com/layui/layui/pull/1453 中这样的低级错误。

  #### 已知问题
  `one-var` 和 `@stylistic/semi-style` 规则在语句末尾有注释时无法自动修复，需要手动调整分号位置。

  参考 
  https://eslint.style
  https://eslint.org

### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [ ] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明
