### PR TITLE
fix(table): 关闭展开状态时，未重置单元格滚动条位置

### DIFF
--- a/src/modules/table.js
+++ b/src/modules/table.js
@@ -2584,6 +2584,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
               that.resize(); // 滚动条补丁
             });
           });
+          elemCell.scrollLeft(0); // 重置单元格滚动条水平位置
           $this.remove();
         });
       }

--- a/src/modules/table.js
+++ b/src/modules/table.js
@@ -2584,8 +2584,10 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
               that.resize(); // 滚动条补丁
             });
           });
-          elemCell.scrollLeft(0); // 重置单元格滚动条水平位置
           $this.remove();
+          // 重置单元格滚动条位置
+          elemCell.scrollTop(0);
+          elemCell.scrollLeft(0); 
         });
       }
 


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [x] 问题修复
- [ ] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- fix(table): 关闭展开状态时，未重置单元格滚动条水平位置。close [#1535](https://github.com/layui/layui/issues/1535)


### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [ ] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明
