### PR TITLE
fix(table): 修复 Chrome DevTools 审查 iframe srcdoc 中的 table 元素导致的页面崩溃

### DIFF
--- a/src/modules/table.js
+++ b/src/modules/table.js
@@ -1750,7 +1750,24 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
 
     lay.getStyleRules(style, function(item){
       if (item.selectorText === ('.laytable-cell-'+ key)) {
-        return callback(item), true;
+        callback(item);
+
+        /* 以下代码为防止 Chrome DevTools 审查 iframe 中的 table 元素时出现的页面崩溃
+         * closes https://gitee.com/layui/layui/issues/I8N08M
+         * 具体原因不明，可能是初始操作 cssRules 触发了 DevTools inspect 的解析报错
+         * 后续若浏览器本身修复了该问题，下述补丁也将会剔除
+         */
+        (function PatcheToCssRulesInDevTools(){
+          if (self === parent) return;
+          var input = lay.elem('input', {
+            style: 'position: absolute; left: 0; top: 0; opacity: 0.01;'
+          });
+          document.body.appendChild(input);
+          input.focus();
+          document.body.removeChild(input);
+        })();
+
+        return true;
       }
     });
   };


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [x] 问题修复
- [ ] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- 新增 cssRules 补丁，为避免 DevTools 审查 iframe 通过 **srcdoc** 加载的 table 元素时导致的页面崩溃

### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明
