### PR TITLE
feat(layer): 遮罩层添加过渡效果

### DIFF
--- a/src/css/modules/layer.css
+++ b/src/css/modules/layer.css
@@ -6,7 +6,7 @@ html #layuicss-layer{display: none; position: absolute; width: 1989px;}
 
 /* common */
 .layui-layer-shade, .layui-layer{position:fixed; _position:absolute; pointer-events: auto;}
-.layui-layer-shade{top:0; left:0; width:100%; height:100%; _height:expression(document.body.offsetHeight+"px");}
+.layui-layer-shade{opacity: 0; transition: opacity .35s cubic-bezier(0.34, 0.69, 0.1, 1); top:0; left:0; width:100%; height:100%; _height:expression(document.body.offsetHeight+"px");}
 .layui-layer{-webkit-overflow-scrolling: touch;}
 .layui-layer{top:150px; left: 0; margin:0; padding:0; background-color:#fff; -webkit-background-clip: content; border-radius: 2px; box-shadow: 1px 1px 50px rgba(0,0,0,.3);}
 .layui-layer-close{position:absolute;}

--- a/src/modules/layer.js
+++ b/src/modules/layer.js
@@ -405,7 +405,7 @@ Class.pt.creat = function(){
       config.anim = config.shift;
     }
 
-  // 为兼容 jQuery3.0 的 css 动画影响元素尺寸计算
+    // 为兼容 jQuery3.0 的 css 动画影响元素尺寸计算
     if(doms.anim[config.anim]){
       var animClass = 'layer-anim '+ doms.anim[config.anim];
       layero.addClass(animClass).one('webkitAnimationEnd mozAnimationEnd MSAnimationEnd oanimationend animationend', function(){


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [ ] 问题修复
- [x] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- 遮罩层添加过渡效果
- 设置 hideOnClose 时支持动画效果
  
shade 数组类型，第三个值仅限内部使用，不在文档中公开，用于处理 layer.photos 遮罩。
https://stackblitz.com/edit/orsrjb-kf8ps8?file=index.html

  close #1601


### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明
