### PR TITLE
fix(slider): Firefox 浏览器中拖动滑块时会选中文本的问题

### DIFF
--- a/src/css/layui.css
+++ b/src/css/layui.css
@@ -589,7 +589,7 @@ a cite{font-style: normal; *cursor:pointer;}
 .layui-panel-window{position: relative; padding: 15px; border-radius: 0; border-top: 5px solid #eee; background-color: #fff;}
 
 /* 其它辅助 */
-.layui-auxiliar-moving{position: fixed; left: 0; right: 0; top: 0; bottom: 0; width: 100%; height: 100%; background: none; z-index: 9999999999;}
+.layui-auxiliar-moving{position: fixed; left: 0; right: 0; top: 0; bottom: 0; width: 100%; height: 100%; background: none; z-index: 9999999999; -moz-user-select: none; -webkit-user-select: none; -ms-user-select: none; user-select: none;}
 .layui-scrollbar-hide{overflow: hidden !important;}
 
 


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [x] 问题修复
- [ ] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- fix(slider): Firefox 浏览器中拖动滑块时会选中文本的问题   closes #1714 

  从 layui v2.9.6 开始有此问题，但 slider 代码逻辑并没有变化，原因不明。


### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [ ] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明
