### PR TITLE
fix(upload): 修复多个文件上传时能选择同样文件问题

### DIFF
--- a/src/modules/upload.js
+++ b/src/modules/upload.js
@@ -600,6 +600,38 @@ layui.define(['lay', 'layer'], function(exports){
       elemFile.after('<span class="layui-inline '+ ELEM_CHOOSE +'">'+ value +'</span>');
     };
 
+    /**
+     * 判断文件是否加入排队
+     * @param file
+     * @return {boolean}
+     */
+    var checkFile = function (file) {
+      var result = true;
+      layui.each(that.files, function (index, item) {
+        if (item.name == file.name) {
+          result = false;
+        }
+      });
+      return result;
+    }
+
+    /**
+     *检查获取文件
+     * @param files
+     * @return {*[]}
+     */
+    var getFiles = function (files) {
+      files = files || [];
+      if (!that.files) return files;
+      var result = [];
+      layui.each(files, function (index, item) {
+        if (checkFile(item)) {
+          result.push(item);
+        }
+      });
+      return result;
+    }
+
     // 点击上传容器
     options.elem.off('upload.start').on('upload.start', function(){
       var othis = $(this);
@@ -620,7 +652,7 @@ layui.define(['lay', 'layer'], function(exports){
       })
       .off('upload.drop').on('upload.drop', function(e, param){
         var othis = $(this);
-        var files = param.originalEvent.dataTransfer.files || [];
+        var files = getFiles(param.originalEvent.dataTransfer.files);
         
         othis.removeAttr('lay-over');
         setChooseFile(files);
@@ -631,7 +663,7 @@ layui.define(['lay', 'layer'], function(exports){
     
     // 文件选择
     that.elemFile.on('change', function(){
-      var files = this.files || [];
+      var files = getFiles(this.files);
 
       if(files.length === 0) return;
 

--- a/src/modules/upload.js
+++ b/src/modules/upload.js
@@ -744,7 +744,7 @@ layui.define(['lay', 'layer'], function(exports){
   upload.util = {
     /**
      * 文件大小处理
-     * @param {number|float} size -文件大小
+     * @param {number | string} size -文件大小
      * @param precision
      * @return {string}
      */

--- a/src/modules/upload.js
+++ b/src/modules/upload.js
@@ -602,13 +602,13 @@ layui.define(['lay', 'layer'], function(exports){
 
     /**
      * 判断文件是否加入排队
-     * @param file
+     * @param {File} file
      * @return {boolean}
      */
     var checkFile = function (file) {
       var result = true;
       layui.each(that.files, function (index, item) {
-        result = !(item.name == file.name);
+        result = !(item.name === file.name);
         if(!result) return true;
       });
       return result;
@@ -616,8 +616,9 @@ layui.define(['lay', 'layer'], function(exports){
 
     /**
      * 扩展文件信息
-     * @param obj
-     * @return {*}
+     * @template {File | FileList} T
+     * @param {T} obj
+     * @return {T}
      */
     var extendInfo = function (obj) {
 
@@ -643,8 +644,8 @@ layui.define(['lay', 'layer'], function(exports){
     
     /**
      * 检查获取文件
-     * @param files
-     * @return {*[]|*}
+     * @param {FileList} files
+     * @return {Array<File>|FileList}
      */
     var getFiles = function (files) {
       files = files || [];
@@ -737,25 +738,24 @@ layui.define(['lay', 'layer'], function(exports){
     options.elem.data(MOD_INDEX, options.id);
   };
 
-    /**
+  /**
    * 上传组件辅助方法
-   * @type {{parseSize: ((function((number|float), *=): string)|*)}}
    */
   upload.util = {
     /**
      * 文件大小处理
      * @param {number | string} size -文件大小
-     * @param precision
+     * @param {number} [precision] - 数值精度
      * @return {string}
      */
-    parseSize: function (/*文件大小*/size, precision) {
+    parseSize: function (size, precision) {
       precision = precision || 2;
       if (null == size || !size) {
         return '0';
       }
       var unitArr = ["Bytes", "Kb", "Mb", "Gb", "Tb", "Pb", "Eb", "Zb", "Yb"];
       var index;
-      var formatSize = typeof size === 'string' ? parseFloat(size + '') : size;
+      var formatSize = typeof size === 'string' ? parseFloat(size) : size;
       index = Math.floor(Math.log(formatSize) / Math.log(1024));
       size = formatSize / Math.pow(1024, index);
       size = size % 1 === 0 ? size : parseFloat(size.toFixed(precision));//保留的小数位数

--- a/src/modules/upload.js
+++ b/src/modules/upload.js
@@ -608,9 +608,8 @@ layui.define(['lay', 'layer'], function(exports){
     var checkFile = function (file) {
       var result = true;
       layui.each(that.files, function (index, item) {
-        if (item.name == file.name) {
-          result = false;
-        }
+        result = !(item.name == file.name);
+        if(!result) return true;
       });
       return result;
     }

--- a/src/modules/upload.js
+++ b/src/modules/upload.js
@@ -755,7 +755,7 @@ layui.define(['lay', 'layer'], function(exports){
       }
       var unitArr = ["Bytes", "Kb", "Mb", "Gb", "Tb", "Pb", "Eb", "Zb", "Yb"];
       var index;
-      var formatSize = typeof value === 'string' ? parseFloat(size + '') : size;
+      var formatSize = typeof size === 'string' ? parseFloat(size + '') : size;
       index = Math.floor(Math.log(formatSize) / Math.log(1024));
       size = formatSize / Math.pow(1024, index);
       size = size % 1 === 0 ? size : parseFloat(size.toFixed(precision));//保留的小数位数

--- a/src/modules/upload.js
+++ b/src/modules/upload.js
@@ -615,17 +615,45 @@ layui.define(['lay', 'layer'], function(exports){
     }
 
     /**
-     *检查获取文件
+     * 扩展文件信息
+     * @param obj
+     * @return {*}
+     */
+    var extendInfo = function (obj) {
+
+      var extInfo = function (file) {
+        //文件扩展名
+        file.ext = file.name.substr(file.name.lastIndexOf('.') + 1).toLowerCase();
+        // 文件大小
+        file.sizes = upload.util.parseSize(file.size);
+        // 可以继续扩展
+      }
+
+      //FileList对象
+      if (obj instanceof FileList) {
+        layui.each(obj, function (index, item) {
+          extInfo(item);
+        });
+      } else {
+        extInfo(obj);
+      }
+
+      return obj;
+    }
+    
+    /**
+     * 检查获取文件
      * @param files
-     * @return {*[]}
+     * @return {*[]|*}
      */
     var getFiles = function (files) {
       files = files || [];
-      if (!that.files) return files;
+      if (!files.length) return [];
+      if (!that.files) return extendInfo(files);
       var result = [];
       layui.each(files, function (index, item) {
         if (checkFile(item)) {
-          result.push(item);
+          result.push(extendInfo(item));
         }
       });
       return result;
@@ -708,6 +736,32 @@ layui.define(['lay', 'layer'], function(exports){
     // 绑定元素索引
     options.elem.data(MOD_INDEX, options.id);
   };
+
+    /**
+   * 上传组件辅助方法
+   * @type {{parseSize: ((function((number|float), *=): string)|*)}}
+   */
+  upload.util = {
+    /**
+     * 文件大小处理
+     * @param {number|float} size -文件大小
+     * @param precision
+     * @return {string}
+     */
+    parseSize: function (/*文件大小*/size, precision) {
+      precision = precision || 2;
+      if (null == size || !size) {
+        return '0';
+      }
+      var unitArr = ["Bytes", "Kb", "Mb", "Gb", "Tb", "Pb", "Eb", "Zb", "Yb"];
+      var index;
+      var formatSize = typeof value === 'string' ? parseFloat(size + '') : size;
+      index = Math.floor(Math.log(formatSize) / Math.log(1024));
+      size = formatSize / Math.pow(1024, index);
+      size = size % 1 === 0 ? size : parseFloat(size.toFixed(precision));//保留的小数位数
+      return size + unitArr[index];
+    }
+  }
 
   // 记录所有实例
   thisModule.that = {}; // 记录所有实例对象


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [x] 问题修复
- [ ] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

修复多文件上传时选择一个文件后再次点击选择按钮直接取消，再次选择同一个文件时允许加入上传排队问题
演示：
![微信截图_20240414192821](https://github.com/layui/layui/assets/136627746/7f1975b8-a52a-4dac-b8c9-23bdcc25f349)
![微信图片_20240414191951](https://github.com/layui/layui/assets/136627746/63bc1f70-09b5-459b-bf2c-ee8b489ec385)


### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [ ] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [ ] 已对每一项的改动均测试通过
- [ ] 已提供具体的变化内容说明
