### PR TITLE
docs(laydate): 优化农历预览显示的事件响应

### DIFF
--- a/docs/laydate/examples/cell.md
+++ b/docs/laydate/examples/cell.md
@@ -93,12 +93,19 @@
       btns: ['now'],
       theme: 'lunar',
       autoConfirm: false,
-      ready: function () {
+      ready: function (date) {
         if (!this._previewEl) {
           var key = this.elem.attr('lay-key');
           var panelEl = $('#layui-laydate' + key);
           this._previewEl = panelEl.find('.layui-laydate-preview');
+          this.cellRender(date);
         }
+      },
+      change: function(value, date) {
+        this.cellRender(date);
+      },
+      onNow: function(value, date) {
+        this.cellRender(date);
       },
       cellRender: function (ymd, render, info) {
         var that = this;
@@ -112,6 +119,30 @@
         var displayHoliday = holiday && holiday.getTarget() === holiday.getDay() ? holiday.getName() : undefined;
         var displayHolidayBadge = holiday && holiday.getTarget() ? (holiday.isWork() ? '班' : '休') : undefined;
         var isHoliday = holiday && holiday.getTarget() && !holiday.isWork();
+        // 在预览区显示自定义农历相关信息
+        if (that._previewEl && (!info || (info && info.type === "date"))) {
+          var holidayBadgeStyle = [
+            'color:#fff',
+            'background-color:' + (isHoliday ? '#eb3333' : '#333'),
+            'display:' + (displayHolidayBadge ? 'inline-block' : 'none')
+          ].join(';')
+          var festivalBadgeStyle = [
+            'color:#fff',
+            'background-color:#1e9fff',
+            'display:' + (displayHoliday || jieQi ? 'inline-block' : 'none')
+          ].join(';')
+          var tipsText = [
+            '<div class="preview-inner">',
+              '<div style="color:#333;">农历' + lunarDate.getMonthInChinese() + '月' + lunarDate.getDayInChinese() + '</div>',
+              '<div style="font-size:10px">' + lunarDate.getYearInGanZhi() + lunarDate.getYearShengXiao() + '年</div>',
+              '<div style="font-size:10px">' + lunarDate.getMonthInGanZhi() + '月 ' + lunarDate.getDayInGanZhi() + '日</div>',
+              '<div class="badge" style="' + holidayBadgeStyle  +'">' + displayHolidayBadge + '</div>',
+              '<div class="badge" style="'+ festivalBadgeStyle +'">' + (displayHoliday || jieQi) + '</div>',
+            '</div>'
+          ].join('');
+          that._previewEl.html(tipsText);
+        };
+        if (!render) return;
         // 面板类型
         if (info.type === 'date') {
           var clazz = [
@@ -135,28 +166,6 @@
               tips: [1, '#16baaa'],
               zIndex: 999999999,
             });
-          });
-          contentEl.on('click', function () {
-            var holidayBadgeStyle = [
-              'color:#fff',
-              'background-color:' + (isHoliday ? '#eb3333' : '#333'),
-              'display:' + (displayHolidayBadge ? 'inline-block' : 'none')
-            ].join(';')
-            var festivalBadgeStyle = [
-              'color:#fff',
-              'background-color:#1e9fff',
-              'display:' + (displayHoliday || jieQi ? 'inline-block' : 'none')
-            ].join(';')
-            var tipsText = [
-              '<div class="preview-inner">',
-                '<div style="color:#333;">农历' + lunarDate.getMonthInChinese() + '月' + lunarDate.getDayInChinese() + '</div>',
-                '<div style="font-size:10px">' + lunarDate.getYearInGanZhi() + lunarDate.getYearShengXiao() + '年</div>',
-                '<div style="font-size:10px">' + lunarDate.getMonthInGanZhi() + '月 ' + lunarDate.getDayInGanZhi() + '日</div>',
-                '<div class="badge" style="' + holidayBadgeStyle  +'">' + displayHolidayBadge + '</div>',
-                '<div class="badge" style="'+ festivalBadgeStyle +'">' + (displayHoliday || jieQi) + '</div>',
-              '</div>'
-            ].join('');
-            that._previewEl.html(tipsText);
           });
           render(contentEl);
         } else if (info.type === 'year') {


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [ ] 问题修复
- [ ] 功能优化
- [ ] 分支合并
- [x] 其他改动：文档示例优化

### 🌱 本次 PR 的变化内容

- 左下角自主拼接的农历信息效果很棒，但在之前的示例中(#1843)，仅在点击单元格时有效，为达到更好的效果，特对此新增事件响应：面板初始打开时、日期改变时、点击底部栏“现在”按钮时。理论上可完全替代原 `isPreview` 选项开启时的效果。
  https://stackblitz.com/edit/web-platform-haqwye?file=index.html

### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明
