### PR TITLE
refactor: 将部分组件上的 `lay-id` 属性重命名为 `lay-${MOD_NAME}-id`

### DIFF
--- a/src/modules/dropdown.js
+++ b/src/modules/dropdown.js
@@ -16,6 +16,7 @@ layui.define(['jquery', 'laytpl', 'lay', 'util'], function(exports){
   // 模块名
   var MOD_NAME = 'dropdown';
   var MOD_INDEX = 'layui_'+ MOD_NAME +'_index'; // 模块索引名
+  var MOD_ID = 'lay-' + MOD_NAME + '-id';
 
   // 外部接口
   var dropdown = {
@@ -151,7 +152,7 @@ layui.define(['jquery', 'laytpl', 'lay', 'util'], function(exports){
     );
 
     if(!lay.isTopElem(elem[0])){
-      elem.attr('lay-id',  options.id);
+      elem.attr(MOD_ID, options.id);
     }
 
     // 初始化自定义字段名
@@ -276,7 +277,7 @@ layui.define(['jquery', 'laytpl', 'lay', 'util'], function(exports){
     };
     
     // 主模板
-    var TPL_MAIN = ['<div class="layui-dropdown layui-border-box layui-panel layui-anim layui-anim-downbit" lay-id="' + options.id + '">'
+    var TPL_MAIN = ['<div class="layui-dropdown layui-border-box layui-panel layui-anim layui-anim-downbit" ' + MOD_ID + '="' + options.id + '">'
     ,'</div>'].join('');
     
     // 如果是右键事件，则每次触发事件时，将允许重新渲染
@@ -286,7 +287,7 @@ layui.define(['jquery', 'laytpl', 'lay', 'util'], function(exports){
     if(!rerender && options.elem.data(MOD_INDEX +'_opened')) return;
 
     // 记录模板对象
-    that.elemView = $('.' + STR_ELEM + '[lay-id="' + options.id + '"]');
+    that.elemView = $('.' + STR_ELEM + '[' + MOD_ID + '="' + options.id + '"]');
     if (type === 'reloadData' && that.elemView.length) {
       that.elemView.html(options.content || getDefaultView());
     } else {
@@ -388,7 +389,7 @@ layui.define(['jquery', 'laytpl', 'lay', 'util'], function(exports){
     
     // 若存在已打开的面板元素，则移除
     if(prevContentElem){
-      var prevId = prevContentElem.attr('lay-id');
+      var prevId = prevContentElem.attr(MOD_ID);
       var prevTriggerElem = prevContentElem.data('prevElem');
       var prevInstance = thisModule.getThis(prevId);
       var prevOnClose = prevInstance.config.close;

--- a/src/modules/laydate.js
+++ b/src/modules/laydate.js
@@ -24,7 +24,7 @@
 
   // 模块名
   var MOD_NAME = 'laydate';
-  var MOD_ID = 'layui-' + MOD_NAME + '-id'; // 已渲染过的索引标记名
+  var MOD_ID = 'lay-' + MOD_NAME + '-id'; // 已渲染过的索引标记名
 
   // 外部调用
   var laydate = {

--- a/src/modules/table.js
+++ b/src/modules/table.js
@@ -118,6 +118,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
 
   // 字符
   var MOD_NAME = 'table';
+  var MOD_ID = 'lay-' + MOD_NAME + '-id';
   var ELEM = '.layui-table';
   var THIS = 'layui-this';
   var SHOW = 'layui-show';
@@ -392,16 +393,19 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
       ];
       if(options.className) arr.push(options.className);
       return arr.join(' ');
-    }()).attr({
-      'lay-filter': 'LAY-TABLE-FORM-DF-'+ that.index,
-      'lay-id': options.id,
-      'style': function(){
-        var arr = [];
-        if(options.width) arr.push('width:'+ options.width + 'px;');
-        // if(options.height) arr.push('height:'+ options.height + 'px;');
-        return arr.join('')
-      }()
-    }).html(laytpl(TPL_MAIN, {
+    }()).attr(function(){
+      var obj = {
+        'lay-filter': 'LAY-TABLE-FORM-DF-'+ that.index,
+        'style': function(){
+          var arr = [];
+          if(options.width) arr.push('width:'+ options.width + 'px;');
+          // if(options.height) arr.push('height:'+ options.height + 'px;');
+          return arr.join('')
+        }()
+      }
+      obj[MOD_ID] = options.id;
+      return obj;
+    }()).html(laytpl(TPL_MAIN, {
       open: '{{', // 标签符前缀
       close: '}}' // 标签符后缀
     }).render({
@@ -2191,7 +2195,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
 
           if(dict.rule){
             var setWidth = dict.ruleWidth + e.clientX - dict.offset[0];
-            var id = thisTable.eventMoveElem.closest('.' + ELEM_VIEW).attr('lay-id');
+            var id = thisTable.eventMoveElem.closest('.' + ELEM_VIEW).attr(MOD_ID);
             var thatTable = getThisTable(id);
 
             if(!thatTable) return;
@@ -2207,7 +2211,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
       }).on('mouseup', function(e){
         if(thisTable.eventMoveElem){
           var th = thisTable.eventMoveElem; // 当前触发拖拽的 th 元素
-          var id = th.closest('.' + ELEM_VIEW).attr('lay-id');
+          var id = th.closest('.' + ELEM_VIEW).attr(MOD_ID);
           var thatTable = getThisTable(id);
 
           if(!thatTable) return;

--- a/src/modules/treeTable.js
+++ b/src/modules/treeTable.js
@@ -60,6 +60,7 @@ layui.define(['table'], function (exports) {
 
   // 字符
   var MOD_NAME = 'treeTable';
+  var MOD_ID = 'lay-table-id';
   var HIDE = 'layui-hide';
 
   var ELEM_VIEW = '.layui-table-view';
@@ -564,7 +565,7 @@ layui.define(['table'], function (exports) {
     // treeNode // 需要展开的节点
     var trElem = treeNode.trElem;
     var tableViewElem = treeNode.tableViewElem || trElem.closest(ELEM_VIEW);
-    var tableId = treeNode.tableId || tableViewElem.attr('lay-id');
+    var tableId = treeNode.tableId || tableViewElem.attr(MOD_ID);
     var options = treeNode.options || table.getOptions(tableId);
     var dataIndex = treeNode.dataIndex || trElem.attr('lay-data-index'); // 可能出现多层
     var treeTableThat = getThisTable(tableId);
@@ -1102,12 +1103,12 @@ layui.define(['table'], function (exports) {
       });
       // #1463 expandNode 中已经展开过的节点不会重新渲染
       debounceFn('renderTreeTable2-' + tableId, function () {
-        form.render($('.layui-table-tree[lay-id="' + tableId + '"]'));
+        form.render($('.layui-table-tree[' + MOD_ID + '="' + tableId + '"]'));
       }, 0)();
     } else {
       debounceFn('renderTreeTable-' + tableId, function () {
         options.hasNumberCol && formatNumber(that);
-        form.render($('.layui-table-tree[lay-id="' + tableId + '"]'));
+        form.render($('.layui-table-tree[' + MOD_ID + '="' + tableId + '"]'));
       }, 0)();
     }
   }


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [ ] 问题修复
- [ ] 功能优化
- [ ] 分支合并
- [x] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- refactor: 将 dropdown, table, treeTable 组件上的 `lay-id` 属性重命名为 `lay-${MOD_NAME}-id`, laydate 由 `layui-laydate-id` 重命名为 `lay-laydate-id`。

  close #1883


### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明
