### PR TITLE
修改上传组件在auto选项打开的时候同一个文件第二次选择（第一次在before中返回了false）不自动上传的问题

### DIFF
--- a/src/modules/upload.js
+++ b/src/modules/upload.js
@@ -476,6 +476,11 @@ layui.define(['lay', 'layer'], function(exports){
             if(result !== false){
               ready();
             }
+            else{
+              if(options.auto){
+                    elemFile.value = '';
+              }
+            }
           }, function(error){
             error !== undefined && layui.hint().error(error);
           })


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [x] 问题修复
- [ ] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- 修改上传组件在auto选项打开的时候同一个文件第二次选择（第一次在before中返回了false）不自动上传的问题


### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [ ] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [ √] 已对每一项的改动均测试通过
- [ √] 已提供具体的变化内容说明
