### PR TITLE
refactor(table): 优化行单双击事件机制，避免与单元格编辑等事件冲突

### DIFF
--- a/docs/table/index.md
+++ b/docs/table/index.md
@@ -768,17 +768,30 @@ table.render({
 });
  
 // 行单击事件
-table.on('row(test)', function(obj){
+table.on('row(test)', function(obj) {
   var data = obj.data; // 得到当前行数据
   var dataCache = obj.dataCache; // 得到当前行缓存数据，包含特定字段 --- 2.8.8+
   var index = obj.index; // 得到当前行索引
   var tr = obj.tr; // 得到当前行 <tr> 元素的 jQuery 对象
   var options = obj.config; // 获取当前表格基础属性配置项
-  console.log(obj); // 查看对象所有成员
+
+  // 根据自定条件，阻止某个单元格的行事件
+  var event = obj.event; // 2.9.14+
+  var td = $(event.target).closest('td');
+  if (td.data('edit')) { // 此处以阻止可编辑列的行事件为例
+    return layui.stope(event);
+  }
+
+  console.log('onrow', obj); // 查看返回对象的所有成员
   
   // obj.del() // 删除当前行
   // obj.update(fields, related);  // 修改行数据
   // obj.setRowChecked(opts); // 设置行选中状态
+});
+
+// 行双击事件
+table.on('rowDouble(test)', function(obj) {
+  console.log('onrowDouble', obj); // 查看返回对象的所有成员 - 同 row 事件
 });
 ```
 

--- a/docs/table/index.md
+++ b/docs/table/index.md
@@ -774,13 +774,7 @@ table.on('row(test)', function(obj) {
   var index = obj.index; // 得到当前行索引
   var tr = obj.tr; // 得到当前行 <tr> 元素的 jQuery 对象
   var options = obj.config; // 获取当前表格基础属性配置项
-
-  // 根据自定条件，阻止某个单元格的行事件
-  var event = obj.event; // 2.9.14+
-  var td = $(event.target).closest('td');
-  if (td.data('edit')) { // 此处以阻止可编辑列的行事件为例
-    return layui.stope(event);
-  }
+  var e = obj.e; // 当前的 jQuery 事件对象 --- 2.9.14+
 
   console.log('onrow', obj); // 查看返回对象的所有成员
   

--- a/examples/table-test.html
+++ b/examples/table-test.html
@@ -555,18 +555,32 @@ layui.use(['table', 'dropdown'], function(){
   });
 
   // 行单击事件
-  table.on('row(test)', function(obj){
-    console.log(obj);
-    // layer.closeAll('tips');
+  table.on('row(test)', function(obj) {
+    // 根据自定条件，阻止某个单元格的行事件
+    var event = obj.event; // 2.9.14+
+    var td = $(event.target).closest('td');
+    if (td.data('edit')) { // 此处以阻止可编辑列的行事件为例
+      return layui.stope(event);
+    }
+
+    console.log('onrow', obj);
+
+    // 单击行设置选中
     obj.setRowChecked({
       // type: 'radio'
     });
-    // layer.msg('row 事件')
   });
 
   // 行双击事件
-  table.on('rowDouble(test)', function(obj){
-    console.log(obj);
+  table.on('rowDouble(test)', function(obj) {
+    // 根据自定条件，阻止某个单元格的行事件
+    var event = obj.event; // 2.9.14+
+    var td = $(event.target).closest('td');
+    if (td.data('edit')) { // 此处以阻止可编辑列的行事件为例
+      return layui.stope(event);
+    }
+
+    console.log('onrowDouble', obj);
   });
 
   // 单元格编辑事件

--- a/examples/table-test.html
+++ b/examples/table-test.html
@@ -195,7 +195,7 @@ layui.use(['table', 'dropdown'], function(){
       }
     ],
     // escape: false,
-    editTrigger: 'dblclick',
+    // editTrigger: 'dblclick',
     // cellMaxWidth: 320
     // cellExpandedWidth: 160, // 单元格默认展开后的宽度
     // cellExpandedStyle: 'tips', // 单元格默认展开风格
@@ -556,14 +556,7 @@ layui.use(['table', 'dropdown'], function(){
 
   // 行单击事件
   table.on('row(test)', function(obj) {
-    // 根据自定条件，阻止某个单元格的行事件
-    var event = obj.event; // 2.9.14+
-    var td = $(event.target).closest('td');
-    if (td.data('edit')) { // 此处以阻止可编辑列的行事件为例
-      return layui.stope(event);
-    }
-
-    console.log('onrow', obj);
+    console.log('onrow', obj); // 查看返回的对象成员
 
     // 单击行设置选中
     obj.setRowChecked({
@@ -573,14 +566,7 @@ layui.use(['table', 'dropdown'], function(){
 
   // 行双击事件
   table.on('rowDouble(test)', function(obj) {
-    // 根据自定条件，阻止某个单元格的行事件
-    var event = obj.event; // 2.9.14+
-    var td = $(event.target).closest('td');
-    if (td.data('edit')) { // 此处以阻止可编辑列的行事件为例
-      return layui.stope(event);
-    }
-
-    console.log('onrowDouble', obj);
+    console.log('onrowDouble', obj); // 查看返回的对象成员
   });
 
   // 单元格编辑事件

--- a/src/modules/table.js
+++ b/src/modules/table.js
@@ -2494,16 +2494,6 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
       if(othis.data('off')) return; // 不触发事件
       that.layBody.find('tr:eq('+ index +')').removeClass(ELEM_HOVER)
     }).on('click', 'tr', function(e){ // 单击行
-      // 不支持行单击事件的元素
-      var UNROW = [
-        '.layui-form-checkbox',
-        '.layui-form-switch',
-        '.layui-form-radio',
-        '[lay-unrow]'
-      ].join(',');
-      if( $(e.target).is(UNROW) || $(e.target).closest(UNROW)[0]){
-        return;
-      }
       setRowEvent.call(this, 'row', e);
     }).on('dblclick', 'tr', function(e){ // 双击行
       setRowEvent.call(this, 'rowDouble', e);
@@ -2513,14 +2503,29 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
     });
 
     // 创建行单击、双击、菜单事件
-    var setRowEvent = function(eventType, eventObject){
+    var setRowEvent = function(eventType, e){
       var othis = $(this);
-      if(othis.data('off')) return; //不触发事件
+      if(othis.data('off')) return; // 不触发事件
+
+      // 不触发「行单/双击事件」的子元素
+      if (eventType !== 'rowContextmenu') {
+        var UNROW = [
+          '.layui-form-checkbox',
+          '.layui-form-switch',
+          '.layui-form-radio',
+          '[lay-unrow]'
+        ].join(',');
+
+        if($(e.target).is(UNROW) || $(e.target).closest(UNROW)[0]){
+          return;
+        }
+      }
+
       layui.event.call(
         this,
         MOD_NAME, eventType + '('+ filter +')',
         commonMember.call(othis.children('td')[0], {
-          event: eventObject
+          e: e
         })
       );
     };
@@ -2606,7 +2611,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
 
     // 表格主体单元格触发编辑的事件
     that.layBody.on(options.editTrigger, 'td', function(e){
-      renderGridEdit(this, e)
+      renderGridEdit(this, e);
     }).on('mouseenter', 'td', function(){
       showGridExpandIcon.call(this)
     }).on('mouseleave', 'td', function(){

--- a/src/modules/table.js
+++ b/src/modules/table.js
@@ -2504,21 +2504,24 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
       if( $(e.target).is(UNROW) || $(e.target).closest(UNROW)[0]){
         return;
       }
-      setRowEvent.call(this, 'row');
-    }).on('dblclick', 'tr', function(){ // 双击行
-      setRowEvent.call(this, 'rowDouble');
+      setRowEvent.call(this, 'row', e);
+    }).on('dblclick', 'tr', function(e){ // 双击行
+      setRowEvent.call(this, 'rowDouble', e);
     }).on('contextmenu', 'tr', function(e){ // 菜单
       if (!options.defaultContextmenu) e.preventDefault();
-      setRowEvent.call(this, 'rowContextmenu');
+      setRowEvent.call(this, 'rowContextmenu', e);
     });
 
     // 创建行单击、双击、菜单事件
-    var setRowEvent = function(eventType){
+    var setRowEvent = function(eventType, eventObject){
       var othis = $(this);
       if(othis.data('off')) return; //不触发事件
-      layui.event.call(this,
+      layui.event.call(
+        this,
         MOD_NAME, eventType + '('+ filter +')',
-        commonMember.call(othis.children('td')[0])
+        commonMember.call(othis.children('td')[0], {
+          event: eventObject
+        })
       );
     };
 


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [x] 功能新增
- [ ] 问题修复
- [x] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- 单元格编辑不触发 `row, rowDouble` 
  closes #2063
- 对行相关事件新增返回 jQuery event 对象

https://stackblitz.com/edit/4oq31v?file=index.html

### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明
