### PR TITLE
fix(form-select): 开启 `lay-append-to` 时，在 dropdown 中点击 select 面板，会导致 dropdown 面板关闭

### DIFF
--- a/src/modules/form.js
+++ b/src/modules/form.js
@@ -745,6 +745,11 @@ layui.define(['lay', 'layer', 'util'], function(exports){
             hideDown(true);
             return false;
           });
+
+          // 
+          dl.on('mousedown pointerdown touchstart', function(e){
+            return false;
+          })
           
           reElem.find('dl>dt').on('click', function(e){
             return false;

--- a/src/modules/form.js
+++ b/src/modules/form.js
@@ -746,7 +746,7 @@ layui.define(['lay', 'layer', 'util'], function(exports){
             return false;
           });
 
-          // 
+          // 用于开启 lay-append-to 时兼容 dropdown
           dl.on('mousedown pointerdown touchstart', function(e){
             return false;
           })


### PR DESCRIPTION
…ropdown 面板意外关闭

### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [x] 问题修复
- [ ] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- fix(form-select): 开启 `lay-append-to` 时，在 dropdown 中点击 select 面板，会导致 dropdown 面板关闭

  https://stackblitz.com/edit/pszywd-zmy6ff?file=index.html


### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明
