### PR TITLE
refactor(table): 重构 table.setRowChecked() 方法

### DIFF
--- a/docs/table/index.md
+++ b/docs/table/index.md
@@ -381,8 +381,8 @@ console.log(tableStatus.isAll ) // 表格是否全选
 | opts | 描述 | 类型 | 默认值 |
 | --- | --- | --- | --- |
 | type | 选中方式。可选值: `checkbox,radio`  | string | `checkbox` |
-| index | 选中行的下标。支持以下几种情况：<ul><li>若值为 `number` 类型，则表示行所在的数组下标（`0` 开头）</li><li>若值为 `array` 类型 <sup>2.9.1+</sup>，则表示批量下标。</li><li>若值为 `string` 类型，则可设置 `all` 操作全选。</li></ul> | number<br>array<br>string | - |
-| checked | 选中状态值。 <ul><li>若传递该属性，则赋值固定值。</li><li>若不传递该属性（默认），则 `checkbox` 将在 `true\|false` 中自动切换值，而 `radio` 将赋值 `true` 固定值。<sup>2.8.4+</sup></li></ul> | boolean | - |
+| index | 选中行的下标。支持以下几种情况：<ul><li>若值为 `number` 类型，则表示行所在的数组下标（`0` 开头）</li><li>若值为 `array` 类型 <sup>2.9.1+</sup>，则表示多选下标。</li><li>若值为 `string` 类型，则可设置 `all` 操作全选。</li></ul> | number<br>array<br>string | - |
+| checked | 选中状态值。 <ul><li>若传递该属性，则赋值固定值。</li><li>若不传递该属性（默认），则 `checkbox` 将在 `true\|false` 中自动切换值，而 `radio` 将赋值 `true` 固定值。<sup>2.8.4+</sup><br>**注意**：若 `index` 指定为多选或全选，`checked` 应当显式传递固定值</li></ul> | boolean | - |
 
 该方法用于设置行的选中样式及相关的特定属性值 `LAY_CHECKED`。
 

--- a/examples/table-test.html
+++ b/examples/table-test.html
@@ -84,7 +84,7 @@
 (function(off){
   if(!off) return;
   layui.disuse('table').extend({
-    table: '{/}https://cdn.staticfile.net/layui/2.7.6/layui.js'
+    table: '{/}https://cdn.jsdelivr.net/gh/layui/layui@2.7.6/src/modules/table'
   });
 })();
 

--- a/src/modules/table.js
+++ b/src/modules/table.js
@@ -1724,9 +1724,10 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
     var isCheckMult = layui.type(opts.index) === 'array'; // 是否操作多个
     var isCheckAllOrMult = isCheckAll || isCheckMult; // 是否全选或多选
 
-    // 全选或多选时减少回流
-    if(isCheckAllOrMult){
-      that.layBox.addClass(DISABLED_TRANSITION);
+    // 全选或多选时
+    if (isCheckAllOrMult) {
+      that.layBox.addClass(DISABLED_TRANSITION); // 减少回流
+      if (opts.type === 'radio') return; // radio 不允许全选或多选
     }
 
     if(isCheckMult){
@@ -1761,7 +1762,9 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
       return opts.type === 'radio' ? true : (existChecked ? opts.checked : !value)
     };
 
-    // 设置选中状态
+    var radioCheckedIndex;
+
+    // 给匹配行设置选中状态
     tr.each(function() {
       var el = $(this);
       var i = el.attr('data-index');
@@ -1774,27 +1777,27 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
         return;
       }
 
-      // 匹配条件
-      var matched = isCheckAll || (
-        isCheckMult ? opts.index[i] : Number(opts.index) === Number(i)
-      );
+      // 标记数据选中状态
+      var checked = item[options.checkName] = getChecked(el.hasClass(ELEM_CHECKED));
 
-      // 设置匹配项的选中值
-      if (matched) {
-        // 标记数据选中状态
-        var checked = item[options.checkName] = getChecked(item[options.checkName]);
+      // 标记当前行背景色
+      el.toggleClass(ELEM_CHECKED, !!checked);
 
-        // 标记当前行背景色
-        el.toggleClass(ELEM_CHECKED, !!checked);
-
-        // 若为 radio 类型，则取消其他行选中背景色
-        if (opts.type === 'radio') {
-          el.siblings().removeClass(ELEM_CHECKED);
-        }
-      } else if(opts.type === 'radio') {
-        delete item[options.checkName];
+      // 若为 radio 类型，则取消其他行选中背景色
+      if (opts.type === 'radio') {
+        radioCheckedIndex = i;
+        el.siblings().removeClass(ELEM_CHECKED);
       }
     });
+
+    // 若为 radio 类型，移除其他行数据选中状态
+    if (opts.type === 'radio' && radioCheckedIndex) {
+      layui.each(thisData, function(i, item) {
+        if (Number(radioCheckedIndex) !== Number(i)) {
+          delete item[options.checkName];
+        }
+      });
+    }
 
     // 若存在复选框或单选框，则标注选中状态样式
     var td = tr.children('td').children('.layui-table-cell');

--- a/src/modules/table.js
+++ b/src/modules/table.js
@@ -1791,7 +1791,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
     });
 
     // 若为 radio 类型，移除其他行数据选中状态
-    if (opts.type === 'radio' && radioCheckedIndex) {
+    if (radioCheckedIndex) {
       layui.each(thisData, function(i, item) {
         if (Number(radioCheckedIndex) !== Number(i)) {
           delete item[options.checkName];


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [x] 问题修复
- [x] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- 继承自 #2119
closes #2116
- 修复 table 表格嵌套时，选中当前行，影响到当前行嵌套表格所有行的选中问题
- 重构 table.setRowChecked() 方法，优化循环代码
  *根据测试，性能方面与 2.9.14 没有太大变化，这一项主要是代码简洁层面的优化*

#### DEMO: 
> stackblitz 的静态页面，最近好像存在一些 BUG
1. table 表格嵌套: 
https://codepen.io/layui/pen/ExBmRwL
1. table 性能测试（来自 #2004）: 
https://codepen.io/layui/pen/VwJbdXO


### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明
