### PR TITLE
feat(form-select): lay-creatable 的基础上增加 lay-auto-creatable，增加在下拉失焦、回车时自动添加选项

### DIFF
--- a/src/modules/form.js
+++ b/src/modules/form.js
@@ -712,7 +712,8 @@ layui.define(['lay', 'layer', 'util'], function(exports){
               initValue = $(select[0].options[selectedIndex]).text(); // 重新获得初始选中值
               
               // 如果是第一项，且文本值等于 placeholder，则清空初始值
-              if(selectedIndex === 0 && initValue === input.attr('placeholder')){
+              if(selectedIndex === 0 && initValue === input.attr('placeholder') 
+                && $(select[0].options[selectedIndex]).hasClass('layui-select-tips')){
                 initValue = '';
               }
               

--- a/src/modules/form.js
+++ b/src/modules/form.js
@@ -478,8 +478,10 @@ layui.define(['lay', 'layer', 'util'], function(exports){
             title.parent().removeClass(CLASS+'ed ' + CLASS+'up');
             input.blur();
             if(isAutoCreatable){
-              input.val() && layui.each(dl.children('dd'), (_, el) => {
-                input.val() == $(el).text() && el.click();
+              layui.each(dl.children('dd'), (_, el) => {
+                if(input.val())
+                  input.val() == $(el).text() && el.click();
+                else $(el).attr('lay-value') || el.click();
               });
             }
             dl.children('.' + CREATE_OPTION).removeClass(CREATE_OPTION).addClass(THIS);
@@ -585,7 +587,8 @@ layui.define(['lay', 'layer', 'util'], function(exports){
 
               var selectedElem = allDisplayedElem.eq(nextIndex);
               selectedElem.addClass(THIS).siblings().removeClass(THIS); // 标注样式
-              selectedElem.hasClass('layui-select-tips') || input.val(selectedElem.text());
+              if(selectedElem.hasClass('layui-select-tips')) input.val('');
+              else input.val(selectedElem.text());
               followScroll(); // 定位滚动条
             };
             


### PR DESCRIPTION
1、lay-creatable 的基础上增加 lay-auto-creatable，增加在下拉失焦、回车时自动添加选项 2、增加了按上下按键选择时显示随之改变的功能

### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [x] 功能新增
- [ ] 问题修复
- [x] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容
- 在此处列出本次 PR 的每一项改动内容
#### 1、lay-creatable 的基础上增加 lay-auto-creatable，点击添加选项外增加在下拉菜单失焦、回车时自动添加选项 
#### 2、增加了按上下按键选择时显示随之改变的功能



### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [ ] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明
