### PR TITLE
feat: table 支持分别设置表头和表体样式

### DIFF
--- a/docs/table/detail/options.cols.md
+++ b/docs/table/detail/options.cols.md
@@ -431,7 +431,17 @@ edit: function(d){
 <td>style</td>
 <td>
 
-自定义单元格样式。可传入任意的 CSS 内容，如：`style: 'font-size: 13px; color: red;'`
+自定义单元格样式，该样式作用于表体中的单元格。可传入任意的 CSS 内容，如：`style: 'font-size: 13px; color: red;'`
+
+</td>
+<td>string</td>
+<td>-</td>
+    </tr>
+    <tr>
+<td>tdStyle</td>
+<td>
+
+自定义表头标题单元格样式。可传入任意的 CSS 内容，如：`style: 'font-size: 13px; color: red;'`
 
 </td>
 <td>string</td>

--- a/docs/table/detail/options.cols.md
+++ b/docs/table/detail/options.cols.md
@@ -438,7 +438,7 @@ edit: function(d){
 <td>-</td>
     </tr>
     <tr>
-<td>tdStyle</td>
+<td>tdStyle <sup>2.9.16+</sup></td>
 <td>
 
 自定义表头标题单元格样式。可传入任意的 CSS 内容，如：`style: 'font-size: 13px; color: red;'`

--- a/examples/table-td-style-test.html
+++ b/examples/table-td-style-test.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Demo</title>
+  <!-- 请勿在项目正式环境中引用该 layui.css 地址 -->
+  <link rel="stylesheet" href="../src/css/layui.css">
+</head>
+<body class="layui-padding-3">
+
+<fieldset class="layui-elem-field">
+  <legend>测试表格</legend>
+  <div class="layui-field-box">
+    <table class="layui-hide" id="ID-table-demo-data"></table>
+  </div>
+</fieldset>
+
+<!-- 请勿在项目正式环境中引用该 layui.js 地址 -->
+<script src="../src/layui.js"></script>
+<script>
+layui.use('table', function(){
+  var table = layui.table;
+  var data = [{ // 赋值已知数据
+      "id": "10001",
+      "username": "张三1",
+      "sex": "男",
+      "city": "浙江杭州",
+      "sign": "人生恰似一场修行",
+      "experience": "116"
+    }, {
+      "id": "10002",
+      "username": "张三2",
+      "sex": "男",
+      "city": "浙江杭州",
+      "sign": "人生恰似一场修行",
+      "experience": "12",
+      "LAY_CHECKED": true
+    }, {
+      "id": "10003",
+      "username": "张三3",
+      "sex": "男",
+      "city": "浙江杭州",
+      "sign": "人生恰似一场修行",
+      "experience": "65"
+    }, {
+      "id": "10004",
+      "username": "张三4",
+      "sex": "男",
+      "city": "浙江杭州",
+      "sign": "人生恰似一场修行",
+      "experience": "777"
+    }, {
+      "id": "10005",
+      "username": "张三5",
+      "sex": "男",
+      "city": "浙江杭州",
+      "sign": "人生恰似一场修行",
+      "experience": "86"
+    }, {
+      "id": "10006",
+      "username": "张三6",
+      "sex": "男",
+      "city": "浙江杭州",
+      "sign": "人生恰似一场修行",
+      "experience": "12"
+    }, {
+      "id": "10007",
+      "username": "张三7",
+      "sex": "男",
+      "city": "浙江杭州",
+      "sign": "人生恰似一场修行",
+      "experience": "16"
+    }, {
+      "id": "10008",
+      "username": "张三8",
+      "sex": "男",
+      "city": "浙江杭州",
+      "sign": "人生恰似一场修行",
+      "experience": "106"
+    }];
+  // 已知数据渲染
+  var inst = table.render({
+    elem: '#ID-table-demo-data',
+    toolbar: '#TPL-treeTable-demo',
+    cols: [[ //标题栏
+      {field: 'id', title: 'ID', width: 80, sort: true},
+      {field: 'username', title: '用户', width: 120, style: 'color: blue; text-decoration: none; cursor: pointer;'},
+      {field: 'sign', title: '签名', minWidth: 160, thStyle: 'color: red;'},
+      {field: 'sex', title: '性别', width: 80},
+      {field: 'city', title: '城市', width: 100},
+      {field: 'experience', title: '积分', width: 80, sort: true}
+    ]],
+    data: data,
+    //skin: 'line', // 表格风格
+    //even: true,
+    page: true, // 是否显示分页
+    limits: [5, 10, 15],
+    limit: 5 // 每页默认显示的数量
+  });
+
+});
+</script>
+
+
+</body>
+</html>

--- a/src/modules/table.js
+++ b/src/modules/table.js
@@ -175,7 +175,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
             return '';
           }()
           ,'{{# var isSort = !(item2.colGroup) && item2.sort; }}'
-          ,'<th data-field="{{= item2.field||i2 }}" data-key="{{=d.index}}-{{=i1}}-{{=i2}}" {{# if( item2.parentKey){ }}data-parentkey="{{= item2.parentKey }}"{{# } }} {{# if(item2.minWidth){ }}data-minwidth="{{=item2.minWidth}}"{{# } }} {{# if(item2.maxWidth){ }}data-maxwidth="{{=item2.maxWidth}}"{{# } }} {{# if(item2.style){ }}style="{{=item2.style}}"{{# } }} '+ rowCols +' {{# if(item2.unresize || item2.colGroup){ }}data-unresize="true"{{# } }} class="{{# if(item2.hide){ }}layui-hide{{# } }}{{# if(isSort){ }} layui-unselect{{# } }}{{# if(!item2.field){ }} layui-table-col-special{{# } }}"{{# if(item2.title){ }} title="{{ layui.$(\'<div>\' + item2.title + \'</div>\').text() }}"{{# } }}>'
+          ,'<th data-field="{{= item2.field||i2 }}" data-key="{{=d.index}}-{{=i1}}-{{=i2}}" {{# if( item2.parentKey){ }}data-parentkey="{{= item2.parentKey }}"{{# } }} {{# if(item2.minWidth){ }}data-minwidth="{{=item2.minWidth}}"{{# } }} {{# if(item2.maxWidth){ }}data-maxwidth="{{=item2.maxWidth}}"{{# } }} {{# if(item2.thStyle){ }}style="{{=item2.thStyle}}"{{# } }} '+ rowCols +' {{# if(item2.unresize || item2.colGroup){ }}data-unresize="true"{{# } }} class="{{# if(item2.hide){ }}layui-hide{{# } }}{{# if(isSort){ }} layui-unselect{{# } }}{{# if(!item2.field){ }} layui-table-col-special{{# } }}"{{# if(item2.title){ }} title="{{ layui.$(\'<div>\' + item2.title + \'</div>\').text() }}"{{# } }}>'
             ,'<div class="layui-table-cell laytable-cell-'
               ,'{{# if(item2.colGroup){ }}'
                 ,'group'


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [x] 问题修复
- [x] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- 表头属性新增thStyle选项，原style属性修改为只作用域tbody中的单元格，实现数据表格支持分别设置表头和表体样式。

在线演示地址：https://stackblitz.com/edit/2hpqvf-i4wfhd?file=index.html

### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [x] 已提供在线演示地址
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明
