### PR TITLE
feat(dropdown): 支持自定义自动关闭功能

### DIFF
--- a/docs/dropdown/detail/options.md
+++ b/docs/dropdown/detail/options.md
@@ -63,6 +63,20 @@
 </td>
     </tr>
     <tr>
+<td>closeOnClick <sup>2.9.18+</sup></td>
+<td>
+  
+点击触发元素时是否关闭面板。
+
+</td>
+<td>boolean</td>
+<td>
+
+`false`
+
+</td>
+    </tr>
+    <tr>
 <td>show</td>
 <td>
   
@@ -313,6 +327,20 @@ click: function(data, othis){
 ```
 close: function(elem){
   console.log(elem); // 当前组件绑定的目标元素对象
+}   
+```
+
+</td>
+    </tr>
+    <tr>
+<td>onClickOutside <sup>2.9.18+</sup></td>
+<td colspan="3">
+  
+点击 dropdown 外部时的回调函数，返回 `false` 阻止关闭。
+
+```
+onClickOutside: function(event){
+  - event: 当前点击的 `event` 对象
 }   
 ```
 

--- a/docs/dropdown/detail/options.md
+++ b/docs/dropdown/detail/options.md
@@ -336,7 +336,7 @@ close: function(elem){
 <td>onClickOutside <sup>2.9.18+</sup></td>
 <td colspan="3">
   
-点击 dropdown 外部时的回调函数，返回 `false` 阻止关闭。
+点击 dropdown 外部时的回调函数，返回 `false` 可阻止关闭。
 
 ```
 onClickOutside: function(event){

--- a/docs/dropdown/detail/options.md
+++ b/docs/dropdown/detail/options.md
@@ -66,7 +66,7 @@
 <td>closeOnClick <sup>2.9.18+</sup></td>
 <td>
   
-点击触发元素时是否关闭面板。
+下拉面板打开后，再次点击目标元素时是否关闭该面板。
 
 </td>
 <td>boolean</td>

--- a/src/modules/dropdown.js
+++ b/src/modules/dropdown.js
@@ -108,7 +108,7 @@ layui.define(['jquery', 'laytpl', 'lay', 'util'], function(exports){
     delay: [200, 300], // 延时显示或隐藏的毫秒数，若为 number 类型，则表示显示和隐藏的延迟时间相同，trigger 为 hover 时才生效
     shade: 0, // 遮罩
     accordion: false, // 手风琴效果，仅菜单组生效。基础菜单需要在容器上追加 'lay-accordion' 属性。
-    closeOnClick: false // 点击 dropdown 外部时是否关闭，行为取决于所使用的触发事件类型
+    closeOnClick: false // 面板打开后，再次点击目标元素时是否关闭面板。行为取决于所使用的触发事件类型
   };
   
   // 重载实例


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [x] 功能新增
- [x] 问题修复
- [ ] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

1. 新增 closeOnClick 选项 close #2211
2. 新增 onClickOutside 回调
   - 可以实现点击面板外部不关闭面板，最常见的场景就是表单填写一半时防误触
   - 可以简化非当前节点渲染的第三方组件在 dropdown 中的使用
4. 修复自定义 content 的上下文菜单异常关闭问题  close #2275

https://stackblitz.com/edit/mynco9?file=index.html


### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明
