### PR TITLE
fix(table): 修复设置列宽的一些边缘情况

### DIFF
--- a/src/modules/table.js
+++ b/src/modules/table.js
@@ -487,7 +487,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
         var isNone;
         parent = parent || options.elem.parent();
 
-        width = that.getInnerWidth(parent);
+        width = that.getContentWidth(parent);
 
         try {
           isNone = parent.css('display') === 'none';
@@ -1033,7 +1033,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
 
         if (!isInit && isEmptyTable){
           // 将表格宽度设置为跟表头一样的宽度，使之可以出现底部滚动条，以便滚动查看所有字段
-          mainTableElem.width(that.getInnerWidth(headerTableElem));
+          mainTableElem.width(that.getContentWidth(headerTableElem));
         }
         // 二次校验，如果仍然出现横向滚动条（通常是 1px 的误差导致）
         // 不同屏幕分辨率、缩放水平以及浏览器渲染差异，可能会触发这个问题 
@@ -1045,7 +1045,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
 
     if (!isInit && isEmptyTable) {
       // 将表格宽度设置为跟表头一样的宽度，使之可以出现底部滚动条，以便滚动查看所有字段
-      mainTableElem.width(that.getInnerWidth(headerTableElem));
+      mainTableElem.width(that.getContentWidth(headerTableElem));
     } else {
       mainTableElem.width('auto');
     }
@@ -2840,7 +2840,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
    * 获取元素 content 区域宽度值
    * @param {JQuery} elem - 元素的 jQuery 对象
    */
-  Class.prototype.getInnerWidth = function(elem){
+  Class.prototype.getContentWidth = function(elem){
     var that = this;
 
     if(!window.getComputedStyle){

--- a/src/modules/table.js
+++ b/src/modules/table.js
@@ -447,7 +447,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
 
     // 让表格平铺
     that.fullSize();
-    that.setColsWidth();
+    that.setColsWidth({isInit: true});
 
     that.pullData(that.page); // 请求数据
     that.events(); // 事件
@@ -487,17 +487,8 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
         var isNone;
         parent = parent || options.elem.parent();
 
-        if(!window.getComputedStyle){
-          // IE 中的 `currentStyle` 获取未显式设置的宽高时会得到 'auto'，jQuery 中有一些 hack 方法获取准确值
-          width = parent.width();
-        }else{
-          var size = that.getElementSize(parent[0]);
-          // IE BUG
-          // border-box: getComputedStyle 得到的 width/height 是按照 content-box 计算出来的
-          width = size.boxSizing === 'border-box' && !lay.ie
-            ? size.width - size.paddingLeft - size.paddingRight - size.borderLeftWidth - size.borderRightWidth
-            : size.width
-        }
+        width = that.getInnerWidth(parent);
+
         try {
           isNone = parent.css('display') === 'none';
         } catch(e){}
@@ -907,7 +898,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
   };
 
   // 动态分配列宽
-  Class.prototype.setColsWidth = function(){
+  Class.prototype.setColsWidth = function(opt){
     var that = this;
     var options = that.config;
     var colNums = 0; // 列个数
@@ -917,6 +908,10 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
     var cntrWidth = that.setInit('width');
     var borderWidth = parseFloat(layui.getStyle(that.elem[0], 'border-left-width'));
     var lastSpreadCol;
+    var headerTableElem = that.layHeader.first().children('table');
+    var mainTableElem = that.layMain.find('table');
+    var isEmptyTable = that.layMain.find('tbody').is(":empty");
+    var isInit = opt && opt.isInit;
 
     // 统计列个数和最后一个分配宽度的列
     that.eachCols(function(i, item){
@@ -989,15 +984,6 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
     // 记录自动列数
     that.autoColNums = autoColNums = autoColNums > 0 ? autoColNums : 0;
 
-    // 如果表格内容为空（无数据 或 请求异常）
-    if (that.layMain.find('tbody').is(":empty")) {
-      // 将表格宽度设置为跟表头一样的宽度，使之可以出现底部滚动条，以便滚动查看所有字段
-      var headerWidth = that.layHeader.first().children('table').width()
-      that.layMain.find('table').width(headerWidth);
-    } else {
-      that.layMain.find('table').width('auto');
-    }
-
     var pixelsForLastCol = cntrWidth;
     that.eachCols(function(i3, item3){
       var minWidth = item3.minWidth || options.cellMinWidth;
@@ -1045,12 +1031,23 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
         var newWidth = Math.max(Math.min(pixelsForLastCol, maxWidth), minWidth);
         item.style.width = newWidth + 'px';
 
+        if (!isInit && isEmptyTable){
+          // 将表格宽度设置为跟表头一样的宽度，使之可以出现底部滚动条，以便滚动查看所有字段
+          mainTableElem.width(that.getInnerWidth(headerTableElem));
+        }
         // 二次校验，如果仍然出现横向滚动条（通常是 1px 的误差导致）
         // 不同屏幕分辨率、缩放水平以及浏览器渲染差异，可能会触发这个问题 
         if(that.layMain.prop('offsetHeight') > that.layMain.prop('clientHeight')){
           item.style.width = (parseFloat(item.style.width) - borderWidth) + 'px';
         }
       });
+    }
+
+    if (!isInit && isEmptyTable) {
+      // 将表格宽度设置为跟表头一样的宽度，使之可以出现底部滚动条，以便滚动查看所有字段
+      mainTableElem.width(that.getInnerWidth(headerTableElem));
+    } else {
+      mainTableElem.width('auto');
     }
 
     that.setGroupWidth();
@@ -2836,6 +2833,26 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
       marginBottom: parseFloat(style.marginBottom || '0'),
       marginLeft: parseFloat(style.marginLeft || '0'),
       boxSizing: style.boxSizing
+    }
+  }
+
+  /**
+   * 获取元素 content 区域宽度值
+   * @param {JQuery} elem - 元素的 jQuery 对象
+   */
+  Class.prototype.getInnerWidth = function(elem){
+    var that = this;
+
+    if(!window.getComputedStyle){
+      // IE 中的 `currentStyle` 获取未显式设置的宽高时会得到 'auto'，jQuery 中有一些 hack 方法获取准确值
+      return elem.width();
+    }else{
+      var size = that.getElementSize(elem[0]);
+      // IE BUG
+      // border-box: getComputedStyle 得到的 width/height 是按照 content-box 计算出来的
+      return (size.boxSizing === 'border-box' && !lay.ie)
+        ? size.width - size.paddingLeft - size.paddingRight - size.borderLeftWidth - size.borderRightWidth
+        : size.width
     }
   };
 


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [x] 问题修复
- [ ] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- 去除表格初始加载时的横向滚动条

    https://github.com/layui/layui/pull/2187#issuecomment-2372952155 这个问题没有完全修复，现在去掉初始加载时的滚动条，应该能够规避这类问题。

- 修复改变浏览器窗口大小时，空表格偶现滚动条的问题

  也许能修复 #2323 。设置了 min/max width 的表格拖动窗口中偶现滚动条是正常现象，列宽计算结果如此，测试方法见代码注释。
 [演示] https://stackblitz.com/edit/vzzwk2?file=index.html




### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明
