### PR TITLE
fix(table): 修复排序且重载后 `table.cache` 数据中的 `LAY_INDEX` 丢失的问题

### DIFF
--- a/src/modules/table.js
+++ b/src/modules/table.js
@@ -20,7 +20,8 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
   var table = {
     config: { // 全局配置项
       checkName: 'LAY_CHECKED', // 是否选中状态的特定字段名
-      indexName: 'LAY_INDEX', // 初始下标索引名，用于恢复当前页表格排序
+      indexName: 'LAY_INDEX', // 下标索引
+      initIndexName: 'LAY_INDEX_INIT', // 初始下标索引名，仅用于内部恢复当前页表格排序
       numbersName: 'LAY_NUM', // 序号
       disabledName: 'LAY_DISABLED' // 禁用状态的特定字段名
     },
@@ -1315,8 +1316,9 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
       // 加入序号保留字段
       item1[table.config.numbersName] = numbers;
 
-      // 记录下标索引，用于恢复排序
-      if(!sort) item1[table.config.indexName] = i1;
+      // 记录下标，
+      item1[table.config.indexName] = i1;
+      if(!sort) item1[table.config.initIndexName] = i1; // 记录初始状态下标，仅用于内部恢复当前页表格排序
 
       // 遍历表头
       that.eachCols(function(i3, item3){
@@ -1463,6 +1465,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
           reloadType: opts.type
         });
       }
+
       that.getTrHtml(data, sort, curr, {
         trs: trs,
         trs_fixed: trs_fixed,
@@ -1897,7 +1900,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
       } else if(opts.type === 'desc'){ //降序
         thisData = layui.sort(data, field, true, true);
       } else { // 清除排序
-        thisData = layui.sort(data, table.config.indexName, null, true);
+        thisData = layui.sort(data, table.config.initIndexName, null, true);
         delete that.sortKey;
         delete options.initSort;
       }
@@ -3283,6 +3286,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
     data = $.extend({}, data);
     delete data[table.config.checkName];
     delete data[table.config.indexName];
+    delete data[table.config.initIndexName];
     delete data[table.config.numbersName];
     delete data[table.config.disabledName];
     return data;


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [x] 问题修复
- [x] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- closes #1834 #2309
  - Preview: https://stackblitz.com/edit/gioivx?file=index.html,index.js


### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明
