### PR TITLE
refactor: 重构 dropdown 打开与关闭逻辑

### DIFF
--- a/docs/dropdown/examples/base.md
+++ b/docs/dropdown/examples/base.md
@@ -46,6 +46,7 @@ layui.use(function(){
   // 绑定输入框
   dropdown.render({
     elem: '#ID-dropdown-demo-base-input',
+    closeOnClick: false, // 不开启“打开与关闭的自动切换”，即点击输入框时始终为打开状态
     data: [{
       title: 'menu item 1',
       id: 101

--- a/docs/dropdown/examples/contextmenu.md
+++ b/docs/dropdown/examples/contextmenu.md
@@ -65,20 +65,22 @@ layui.use(function(){
 
   // 其他操作
   util.event('lay-on', {
-    // 全局右键菜单
+    // 改变触发右键菜单的目标元素
     contextmenu: function(othis){
       var ID = 'ID-dropdown-demo-contextmenu';
-      if(!othis.data('open')){
+      if (!othis.data('open')) {
         dropdown.reload(ID, {
-          elem: document // 将事件直接绑定到 document
+          elem: document // 设置全局元素右键
         });
+
         layer.msg('已开启全局右键菜单，请尝试在页面任意处单击右键。')
         othis.html('取消全局右键菜单');
         othis.data('open', true);
       } else {
         dropdown.reload(ID, {
-          elem: '#'+ ID // 重新绑定到指定元素上
+          elem: '#'+ ID // 设置局部元素右键
         });
+
         layer.msg('已取消全局右键菜单，恢复默认右键菜单')
         othis.html('开启全局右键菜单');
         othis.data('open', false);

--- a/docs/table/examples/demo.md
+++ b/docs/table/examples/demo.md
@@ -316,11 +316,19 @@ layui.use(['table', 'dropdown'], function(){
             });
           } 
         },
+        id: 'dropdown-table-tool',
         align: 'right', // 右对齐弹出
         style: 'box-shadow: 1px 1px 10px rgb(0 0 0 / 12%);' // 设置额外样式
-      })
+      });
     }
   });
+
+  // table 滚动时移除内部弹出的元素
+  var tableInst = table.getOptions('test');
+  tableInst.elem.next().find('.layui-table-main').on('scroll', function() {
+    dropdown.close('dropdown-table-tool');
+  });
+
  
   // 触发表格复选框选择
   table.on('checkbox(test)', function(obj){

--- a/examples/dropdown.html
+++ b/examples/dropdown.html
@@ -35,9 +35,13 @@
     <button class="layui-btn" lay-on="close">close</button>
   </div>
 
-  <div class="layui-bg-gray" style="margin-top: 30px; width: 100%; height: 300px; text-align: center;" id="demo20">
+  <div class="layui-bg-gray" style="margin-top: 30px; width: 100%; height: 300px; text-align: center;" id="ID-dropdown-demo-contextmenu">
     <span class="layui-font-gray" style="position: relative; top:50%;">鼠标右键菜单</span>
   </div>
+  <button class="layui-btn" style="margin-top: 15px;" lay-on="contextmenu">
+    开启全局右键菜单
+  </button>
+
 </div>
 
 
@@ -258,9 +262,9 @@ layui.use('dropdown', function () {
     }
   });
 
-  //右键
+  // 右键
   dropdown.render({
-    elem: document, //'#demo20' //也可绑定到 document，从而重置整个右键
+    elem: '#ID-dropdown-demo-contextmenu', // 也可绑定到 document，从而重置整个右键
     trigger: 'contextmenu', //contextmenu
     isAllowSpread: false,
     //,style: 'width: 200px'
@@ -316,6 +320,28 @@ layui.use('dropdown', function () {
     }
   });
 
+  util.on({
+    // 改变触发右键菜单的目标元素
+    contextmenu: function(othis){
+      var ID = 'ID-dropdown-demo-contextmenu';
+      if (!othis.data('open')) {
+        dropdown.reload(ID, {
+          elem: document // 设置全局元素右键
+        });
+
+        othis.html('取消全局右键菜单');
+        othis.data('open', true);
+      } else {
+        dropdown.reload(ID, {
+          elem: '#'+ ID // 设置局部元素右键
+        });
+
+        othis.html('开启全局右键菜单');
+        othis.data('open', false);
+      }
+    }
+  });
+
   dropdown.render({
     elem: '#testopen',
     id: 'testopen',
@@ -330,8 +356,7 @@ layui.use('dropdown', function () {
     close: function(){
       dropdown.close('testopen')
     }
-  },
-  {trigger: 'mouseenter'});
+  });
 
   return;
 

--- a/src/modules/dropdown.js
+++ b/src/modules/dropdown.js
@@ -84,6 +84,8 @@ layui.define(['jquery', 'laytpl', 'lay', 'util'], function(exports){
   
   var STR_GROUP_TITLE = '.'+ STR_ITEM_GROUP + '>.'+ STR_MENU_TITLE;
 
+  var bodyElem = $('body');
+
   // 构造器
   var Class = function(options){
     var that = this;
@@ -160,7 +162,7 @@ layui.define(['jquery', 'laytpl', 'lay', 'util'], function(exports){
     }
 
     // 初始即显示或者面板弹出之后执行了刷新数据
-    if(options.show || (type === 'reloadData' && that.mainElem && $('body').find(that.mainElem.get(0)).length)) that.render(type);
+    if(options.show || (type === 'reloadData' && that.mainElem && bodyElem.find(that.mainElem.get(0)).length)) that.render(type);
 
     // 事件
     that.events();
@@ -171,7 +173,6 @@ layui.define(['jquery', 'laytpl', 'lay', 'util'], function(exports){
     var that = this;
     var options = that.config;
     var customName = options.customName;
-    var elemBody = $('body');
     
     // 默认菜单内容
     var getDefaultView = function(){
@@ -302,7 +303,7 @@ layui.define(['jquery', 'laytpl', 'lay', 'util'], function(exports){
 
       // 辞旧迎新
       that.remove(dropdown.thisId);
-      elemBody.append(mainElem);
+      bodyElem.append(mainElem);
 
       // 遮罩
       var shade = options.shade ? ('<div class="'+ STR_ELEM_SHADE +'" style="'+ ('z-index:'+ (mainElem.css('z-index')-1) +'; background-color: ' + (options.shade[1] || '#000') + '; opacity: ' + (options.shade[0] || options.shade)) +'"></div>') : '';

--- a/src/modules/dropdown.js
+++ b/src/modules/dropdown.js
@@ -15,6 +15,8 @@ layui.define(['jquery', 'laytpl', 'lay', 'util'], function(exports){
   
   // 模块名
   var MOD_NAME = 'dropdown';
+  var MOD_INDEX = 'layui_'+ MOD_NAME +'_index'; // 模块索引名
+  var MOD_INDEX_OPENED = MOD_INDEX + '_opened';
   var MOD_ID = 'lay-' + MOD_NAME + '-id';
 
   // 外部接口
@@ -304,6 +306,7 @@ layui.define(['jquery', 'laytpl', 'lay', 'util'], function(exports){
       // 辞旧迎新
       that.remove(dropdown.thisId);
       bodyElem.append(mainElem);
+      options.elem.data(MOD_INDEX_OPENED, true); // 面板已打开的标记
 
       // 遮罩
       var shade = options.shade ? ('<div class="'+ STR_ELEM_SHADE +'" style="'+ ('z-index:'+ (mainElem.css('z-index')-1) +'; background-color: ' + (options.shade[1] || '#000') + '; opacity: ' + (options.shade[0] || options.shade)) +'"></div>') : '';
@@ -385,6 +388,7 @@ layui.define(['jquery', 'laytpl', 'lay', 'util'], function(exports){
     if (mainElem[0]) {
       mainElem.prev('.' + STR_ELEM_SHADE).remove(); // 先移除遮罩
       mainElem.remove();
+      options.elem.removeData(MOD_INDEX_OPENED);
       delete dropdown.thisId;
       typeof options.close === 'function' && options.close(options.elem);
     }
@@ -427,14 +431,11 @@ layui.define(['jquery', 'laytpl', 'lay', 'util'], function(exports){
 
     // 触发元素事件
     options.elem.off(trigger).on(trigger, function(e) {
-      if (options.show) return; // 若是直接显示，则不必事件再执行渲染
-
       clearTimeout(thisModule.timer);
       that.e = e;
 
-      // 已存在于页面的主面板
-      var mainElemExisted = $('.' + STR_ELEM + '[' + MOD_ID + '="' + options.id + '"]');
-      var opened = mainElemExisted.attr(MOD_ID) == options.id; // 主面板是否已打开
+      // 主面板是否已打开
+      var opened = options.elem.data(MOD_INDEX_OPENED);
 
       // 若为鼠标移入事件，则延迟触发
       if (isMouseEnter) {
@@ -548,7 +549,7 @@ layui.define(['jquery', 'laytpl', 'lay', 'util'], function(exports){
       var isPanelTarget = that.mainElem && (e.target === that.mainElem[0] || that.mainElem.find(e.target)[0]);
       if(isTriggerTarget || isPanelTarget) return;
       // 处理移动端点击穿透问题
-      if(e.type === 'touchstart'){
+      if(e.type === 'touchstart' && options.elem.data(MOD_INDEX_OPENED)){
         $(e.target).hasClass(STR_ELEM_SHADE) && e.preventDefault();
       }
 

--- a/src/modules/dropdown.js
+++ b/src/modules/dropdown.js
@@ -291,8 +291,8 @@ layui.define(['jquery', 'laytpl', 'lay', 'util'], function(exports){
 
     // 重载或插入面板内容
     var content = options.content || getDefaultView();
-    var mainElemExisted = $('.' + STR_ELEM + '[' + MOD_ID + '="' + options.id + '"]');
-    if (type === 'reloadData' && mainElemExisted.length) { // // 是否仅重载数据
+    var mainElemExisted = thisModule.findMainElem(options.id);
+    if (type === 'reloadData' && mainElemExisted.length) { // 是否仅重载数据
       var mainElem = that.mainElem = mainElemExisted;
       mainElemExisted.html(content);
     } else { // 常规渲染
@@ -380,11 +380,14 @@ layui.define(['jquery', 'laytpl', 'lay', 'util'], function(exports){
   
   // 移除面板
   Class.prototype.remove = function(id) {
-    var that = this;
-    var options = that.config;
-    var mainElem = $('.' + STR_ELEM + '[' + MOD_ID + '="' + (id || options.id) + '"]');
+    id = id || this.config.id;
+    var that = thisModule.getThis(id); // 根据 id 查找对应的实例
+    if (!that) return;
 
-    // 移除面板
+    var options = that.config;
+    var mainElem = thisModule.findMainElem(id);
+
+    // 若存在已打开的面板元素，则移除
     if (mainElem[0]) {
       mainElem.prev('.' + STR_ELEM_SHADE).remove(); // 先移除遮罩
       mainElem.remove();
@@ -474,6 +477,11 @@ layui.define(['jquery', 'laytpl', 'lay', 'util'], function(exports){
       throw new Error('ID argument required');
     }
     return thisModule.that[id];
+  };
+
+  // 根据 id 从页面查找组件主面板元素
+  thisModule.findMainElem = function(id) {
+    return $('.' + STR_ELEM + '[' + MOD_ID + '="' + id + '"]');
   };
   
   // 设置菜单组展开和收缩状态


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [x] 问题修复
- [x] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- 重构 面板打开与关闭的逻辑
- 调整 `closeOnClick` 选项默认值为 `true`，即点击目标元素时自动切换打开与关闭
- 修复 在元素自定义事件中创建实例并立刻显示的报错问题
  - closes #2347
  - Preview: https://stackblitz.com/edit/fjx38j?file=index.html,index.js


### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明
