### PR TITLE
fix(table): 隐藏元素内渲染 table 时获取宽度的行为回退到 2.9.9 之前

### DIFF
--- a/src/modules/table.js
+++ b/src/modules/table.js
@@ -2851,19 +2851,34 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
 
   /**
    * 获取元素 content 区域宽度值
+   * 
+   * layui 内置 jQuery v1.12.4 中的 jQUery.fn.width 始终对值四舍五入(3.x 已修复),
+   * 在支持 subpixel Rendering 的浏览器中渲染表格，由于列宽分配时计算值精度不足，
+   * 可能会导致一些小问题(#1726)
+   * 
+   * 这个方法使用 getComputedStyle 获取精确的宽度值进行计算，为了尽可能和以前的行为
+   * 保持一致(主要是隐藏元素内渲染 table 递归获取父元素宽度 https://github.com/layui/layui/discussions/2398)，
+   * 任何非预期的值，都回退到 jQUery.fn.width。未来的版本使用 ResizeObserver 时，可以直接获取表格视图元素的宽度，
+   * 并移除兼容性代码
+   * 
    * @param {JQuery} elem - 元素的 jQuery 对象
    */
   Class.prototype.getContentWidth = function(elem){
     var that = this;
 
-    if(!window.getComputedStyle){
-      // IE 中的 `currentStyle` 获取未显式设置的宽高时会得到 'auto'，jQuery 中有一些 hack 方法获取准确值
+    // IE 中 border-box 盒模型，getComputedStyle 得到的 width/height 是按照 content-box 计算出来的
+    var isBorderBox = elem.css('box-sizing') === 'border-box';
+    if((isBorderBox && lay.ie) || elem.css('display') === 'none'){
+      return elem.width();
+    }
+
+    var size = that.getElementSize(elem[0]);
+
+    // display: none|inline 元素，getComputedStyle 无法得到准确的 width/height
+    if(typeof size === 'undefined' || !size.width){
       return elem.width();
     }else{
-      var size = that.getElementSize(elem[0]);
-      // IE BUG
-      // border-box: getComputedStyle 得到的 width/height 是按照 content-box 计算出来的
-      return (size.boxSizing === 'border-box' && !lay.ie)
+      return isBorderBox
         ? size.width - size.paddingLeft - size.paddingRight - size.borderLeftWidth - size.borderRightWidth
         : size.width
     }

--- a/src/modules/table.js
+++ b/src/modules/table.js
@@ -494,7 +494,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
           isNone = parent.css('display') === 'none';
         } catch(e){}
         var parentElem = parent.parent();
-        if(parent[0] && parentElem && parentElem[0] && (!width || isNone)) return getWidth(parent.parent());
+        if(parent[0] && parentElem && parentElem[0] && (!width || isNone)) return getWidth(parentElem);
         return width;
       };
       return getWidth();
@@ -2852,7 +2852,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
   /**
    * 获取元素 content 区域宽度值
    * 
-   * layui 内置 jQuery v1.12.4 中的 jQUery.fn.width 始终对值四舍五入(3.x 已修复),
+   * layui 内置 jQuery v1.12.4 中的 jQuery.fn.width 始终对值四舍五入(3.x 已修复),
    * 在支持 subpixel Rendering 的浏览器中渲染表格，由于列宽分配时计算值精度不足，
    * 可能会导致一些小问题(#1726)
    * 

--- a/src/modules/table.js
+++ b/src/modules/table.js
@@ -2862,6 +2862,8 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
    * 并移除兼容性代码
    * 
    * @param {JQuery} elem - 元素的 jQuery 对象
+   * 
+   * @see {@link https://learn.microsoft.com/zh-cn/archive/blogs/ie_cn/css-3}
    */
   Class.prototype.getContentWidth = function(elem){
     var that = this;

--- a/src/modules/table.js
+++ b/src/modules/table.js
@@ -2858,7 +2858,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
    * 
    * 这个方法使用 getComputedStyle 获取精确的宽度值进行计算，为了尽可能和以前的行为
    * 保持一致(主要是隐藏元素内渲染 table 递归获取父元素宽度 https://github.com/layui/layui/discussions/2398)，
-   * 任何非预期的值，都回退到 jQUery.fn.width。未来的版本使用 ResizeObserver 时，可以直接获取表格视图元素的宽度，
+   * 任何非预期的值，都回退到 jQuery.fn.width。未来的版本使用 ResizeObserver 时，可以直接获取表格视图元素的宽度，
    * 并移除兼容性代码
    * 
    * @param {JQuery} elem - 元素的 jQuery 对象

--- a/src/modules/table.js
+++ b/src/modules/table.js
@@ -2870,7 +2870,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
       // document
       elem[0].nodeType === 9 ||
       // IE 中 border-box 盒模型，getComputedStyle 得到的 width/height 是按照 content-box 计算出来的
-      (elem.css('box-sizing') === 'border-box' && lay.ie) ||
+      (lay.ie && elem.css('box-sizing') === 'border-box') ||
       elem.css('display') === 'none'
     ){
       return elem.width();

--- a/src/modules/table.js
+++ b/src/modules/table.js
@@ -494,7 +494,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
           isNone = parent.css('display') === 'none';
         } catch(e){}
         var parentElem = parent.parent();
-        if(parent[0] && parentElem[0] && parentElem[0].nodeType === 1 && (!width || isNone)) return getWidth(parentElem);
+        if(parent[0] && parentElem && parentElem[0] && (!width || isNone)) return getWidth(parent.parent());
         return width;
       };
       return getWidth();
@@ -2866,9 +2866,13 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
   Class.prototype.getContentWidth = function(elem){
     var that = this;
 
-    // IE 中 border-box 盒模型，getComputedStyle 得到的 width/height 是按照 content-box 计算出来的
-    var isBorderBox = elem.css('box-sizing') === 'border-box';
-    if((isBorderBox && lay.ie) || elem.css('display') === 'none'){
+    if(
+      // document
+      elem[0].nodeType === 9 ||
+      // IE 中 border-box 盒模型，getComputedStyle 得到的 width/height 是按照 content-box 计算出来的
+      (elem.css('box-sizing') === 'border-box' && lay.ie) ||
+      elem.css('display') === 'none'
+    ){
       return elem.width();
     }
 
@@ -2878,7 +2882,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
     if(typeof size === 'undefined' || !size.width){
       return elem.width();
     }else{
-      return isBorderBox
+      return size.boxSizing === 'border-box'
         ? size.width - size.paddingLeft - size.paddingRight - size.borderLeftWidth - size.borderRightWidth
         : size.width
     }


### PR DESCRIPTION
#2187

### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [x] 问题修复
- [ ] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- fix(table): 隐藏元素内渲染 table 时获取宽度的行为回退到 2.9.17 之前

  解决 https://github.com/layui/layui/discussions/2398

  https://stackblitz.com/edit/tbfo5w49?file=index.js


### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明
