### PR TITLE
fix(treeTable): 修复直接赋值 `data` 时切换分页出现报错的问题

### DIFF
--- a/src/modules/treeTable.js
+++ b/src/modules/treeTable.js
@@ -1048,6 +1048,7 @@ layui.define(['table'], function (exports) {
     var isParentKey = customName.isParent;
     var tableFilterId = tableViewElem.attr('lay-filter');
     var treeTableThat = that;
+    var existsData = options.data.length; // 是否直接赋值 data
     // var tableData = treeTableThat.getTableData();
 
     level = level || 0;
@@ -1056,9 +1057,11 @@ layui.define(['table'], function (exports) {
       // 初始化的表格里面没有level信息，可以作为顶层节点的判断
       tableViewElem.find('.layui-table-body tr:not([data-level])').attr('data-level', level);
       layui.each(table.cache[tableId], function (dataIndex, dataItem) {
-        tableViewElem.find('.layui-table-main tbody tr[data-level="0"]:eq(' + dataIndex + ')').attr('lay-data-index', dataItem[LAY_DATA_INDEX]);
-        tableViewElem.find('.layui-table-fixed-l tbody tr[data-level="0"]:eq(' + dataIndex + ')').attr('lay-data-index', dataItem[LAY_DATA_INDEX]);
-        tableViewElem.find('.layui-table-fixed-r tbody tr[data-level="0"]:eq(' + dataIndex + ')').attr('lay-data-index', dataItem[LAY_DATA_INDEX]);
+        // 若直接赋值 data，则将顶层节点 lay-data-index 赋值为 data-index，以规避 LAY_DATA_INDEX 值异常
+        var layDataIndex = existsData ? dataItem[table.config.indexName] : dataItem[LAY_DATA_INDEX];
+        tableViewElem.find('.layui-table-main tbody tr[data-level="0"]:eq(' + dataIndex + ')').attr('lay-data-index', layDataIndex);
+        tableViewElem.find('.layui-table-fixed-l tbody tr[data-level="0"]:eq(' + dataIndex + ')').attr('lay-data-index', layDataIndex);
+        tableViewElem.find('.layui-table-fixed-r tbody tr[data-level="0"]:eq(' + dataIndex + ')').attr('lay-data-index', layDataIndex);
       })
     }
 

--- a/src/modules/treeTable.js
+++ b/src/modules/treeTable.js
@@ -1057,8 +1057,11 @@ layui.define(['table'], function (exports) {
       // 初始化的表格里面没有level信息，可以作为顶层节点的判断
       tableViewElem.find('.layui-table-body tr:not([data-level])').attr('data-level', level);
       layui.each(table.cache[tableId], function (dataIndex, dataItem) {
-        // 若直接赋值 data，则将顶层节点 lay-data-index 赋值为 data-index，以规避 LAY_DATA_INDEX 值异常
-        var layDataIndex = existsData ? dataItem[table.config.indexName] : dataItem[LAY_DATA_INDEX];
+        // fix: 修正直接赋值 data 时顶层节点 LAY_DATA_INDEX 值的异常问题
+        if (existsData) {
+          dataItem[LAY_DATA_INDEX] = String(dataIndex);
+        }
+        var layDataIndex = dataItem[LAY_DATA_INDEX];
         tableViewElem.find('.layui-table-main tbody tr[data-level="0"]:eq(' + dataIndex + ')').attr('lay-data-index', layDataIndex);
         tableViewElem.find('.layui-table-fixed-l tbody tr[data-level="0"]:eq(' + dataIndex + ')').attr('lay-data-index', layDataIndex);
         tableViewElem.find('.layui-table-fixed-r tbody tr[data-level="0"]:eq(' + dataIndex + ')').attr('lay-data-index', layDataIndex);


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [x] 问题修复
- [ ] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- closes #2056
该问题触发原因：treeTable 的 [initData](https://github.com/layui/layui/blob/main/src/modules/treeTable.js#L549-L568) 方法中，若直接赋值 data ，`LAY_DATA_INDEX` 字段未对 data 进行分页赋值索引，导致顶层节点 `lay-data-index` 属性值不匹配，getNodeDataByIndex 方法无法获取到对应的数据，进而导致报错。
[演示]：https://stackblitz.com/edit/kqvd3s4z?file=index.html


### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明
