### PR TITLE
feat(table): parseData 支持异步

### DIFF
--- a/docs/table/detail/options.ajax.md
+++ b/docs/table/detail/options.ajax.md
@@ -137,6 +137,7 @@ table.render({
 }); 
 
 // 返回 Promise 或 JqueryDeferred 对象(2.10+)
+// 返回 false 或 Promise.reject 时，将取消解析
 table.render({
   elem: '',
   url: '',

--- a/docs/table/detail/options.ajax.md
+++ b/docs/table/detail/options.ajax.md
@@ -135,6 +135,20 @@ table.render({
   },
   // … //其他参数
 }); 
+
+// 返回 Promise 或 JqueryDeferred 对象(2.10+)
+table.render({
+  elem: '',
+  url: '',
+  parseData: function(res){ // res 即为原始返回的数据
+    return new Promise(function(resolve, reject){
+      setTimeout(() => {
+        resolve(res)
+      },3000)
+    })
+  },
+  // … //其他参数
+}); 
 ```
 
 该函数非常实用

--- a/docs/table/detail/options.md
+++ b/docs/table/detail/options.md
@@ -526,12 +526,9 @@ initSort: {
 
 ```
 table.render({
-  before: function(options, data){
+  before: function(options){
     console.log(options); // 当前实例属性配置项
     options.where.abc = 123; // 修改或额外追加 where 属性
-    console.log(data); // 请求参数，包含了自动传递的参数，如：page、limit 等。(2.10+)
-
-    //return false; // 返回 false 则停止渲染数据表格(2.10+)
   },
   // …  // 其它属性
 });
@@ -569,21 +566,11 @@ table.render({
 <td>error <sup>2.6+</sup></td>
 <td colspan="3">
 
-数据请求失败的回调函数。返回参数如下：
-
-- e: 错误对象
-- msg: 内容
-- type: 错误类型，可选值(2.10+)：
-  - `NO_DATA_EXCEPTION` 数据为空异常
-  - `PARSE_DATA_EXCEPTION` parseData 解析数据异常
-  - `AJAX_ERROR` ajax 请求错误
-  - `STATUS_CODE_ERROR` 状态码错误
-
-返回 `false` 可阻止默认的异常提示。(2.10+)
+数据请求失败的回调函数。返回两个参数：错误对象、内容。
 
 ```
-error: function(e, msg, type) {
-  console.log(e, msg) // 非 AJAX_ERROR 类型时，这两个参数值为 undefined
+error: function(e, msg) {
+  console.log(e, msg)
 }
 ```
 

--- a/docs/table/detail/options.md
+++ b/docs/table/detail/options.md
@@ -526,9 +526,12 @@ initSort: {
 
 ```
 table.render({
-  before: function(options){
+  before: function(options, data){
     console.log(options); // 当前实例属性配置项
     options.where.abc = 123; // 修改或额外追加 where 属性
+    console.log(data); // 请求参数，包含了自动传递的参数，如：page、limit 等。(2.10+)
+
+    //return false; // 返回 false 则停止渲染数据表格(2.10+)
   },
   // …  // 其它属性
 });
@@ -566,11 +569,21 @@ table.render({
 <td>error <sup>2.6+</sup></td>
 <td colspan="3">
 
-数据请求失败的回调函数。返回两个参数：错误对象、内容。
+数据请求失败的回调函数。返回参数如下：
+
+- e: 错误对象
+- msg: 内容
+- type: 错误类型，可选值(2.10+)：
+  - `NO_DATA_EXCEPTION` 数据为空异常
+  - `PARSE_DATA_EXCEPTION` parseData 解析数据异常
+  - `AJAX_ERROR` ajax 请求错误
+  - `STATUS_CODE_ERROR` 状态码错误
+
+返回 `false` 可阻止默认的异常提示。(2.10+)
 
 ```
-error: function(e, msg) {
-  console.log(e, msg)
+error: function(e, msg, type) {
+  console.log(e, msg) // 非 AJAX_ERROR 类型时，这两个参数值为 undefined
 }
 ```
 

--- a/src/modules/table.js
+++ b/src/modules/table.js
@@ -152,12 +152,6 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
   var DISABLED_TRANSITION = 'layui-table-disabled-transition';
 
   var DATA_MOVE_NAME = 'LAY_TABLE_MOVE_DICT';
-  var ERROR_TYPE = {
-    NO_DATA_EXCEPTION: 'NO_DATA_EXCEPTION',
-    PARSE_DATA_EXCEPTION: 'PARSE_DATA_EXCEPTION',
-    AJAX_ERROR: 'AJAX_ERROR',
-    STATUS_CODE_ERROR: 'STATUS_CODE_ERROR'
-  }
 
   // thead 区域模板
   var TPL_HEADER = function(options){
@@ -456,7 +450,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
     that.fullSize();
     that.setColsWidth({isInit: true});
 
-    that.pullData(that.page);  // 请求数据
+    that.pullData(that.page); // 请求数据
     that.events(); // 事件
   };
 
@@ -1103,18 +1097,10 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
   };
 
   // 异常提示
-  Class.prototype.errorView = function(html, contextInfo){
-    var that = this;
-    var options = that.config;
-    if(typeof options.error === 'function'){
-      if(options.error(contextInfo.xhr, contextInfo.msg, contextInfo.type) === false){
-        that.loading(false);
-        return;
-      }
-    };
-    if(!html)return;
-    var elemNone = that.layMain.find('.'+ NONE)
-    var layNone = $('<div class="'+ NONE +'">'+ (html || 'Error') +'</div>');
+  Class.prototype.errorView = function(html){
+    var that = this
+    ,elemNone = that.layMain.find('.'+ NONE)
+    ,layNone = $('<div class="'+ NONE +'">'+ (html || 'Error') +'</div>');
 
     if(elemNone[0]){
       that.layNone.remove();
@@ -1171,13 +1157,9 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
     opts = opts || {};
 
     // 数据拉取前的回调
-    if(typeof options.before === 'function' && !options.url){
-      var shouldCancel = options.before(options);
-      if(shouldCancel === false){
-        that.loading(false);
-        return;
-      }
-    } 
+    typeof options.before === 'function' && options.before(
+      options
+    );
     that.startTime = new Date().getTime(); // 渲染开始时间
 
     if (opts.renderData) { // 将 cache 信息重新渲染
@@ -1207,15 +1189,6 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
 
       // 参数
       var data = $.extend(params, options.where);
-
-      if(typeof options.before === 'function'){
-        var shouldCancel = options.before(options, data);
-        if(shouldCancel === false){
-          that.loading(false);
-          return;
-        }
-      } 
-
       if(options.contentType && options.contentType.indexOf("application/json") == 0){ // 提交 json 格式
         data = JSON.stringify(data);
       }
@@ -1246,8 +1219,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
             if (res[response.statusName] != response.statusCode) {
               that.errorView(
                 res[response.msgName] ||
-                ('返回的数据不符合规范，正确的成功状态码应为："' + response.statusName + '": ' + response.statusCode),
-                {type: ERROR_TYPE.STATUS_CODE_ERROR}
+                ('返回的数据不符合规范，正确的成功状态码应为："' + response.statusName + '": ' + response.statusCode)
               );
             } else {
               // 当前页不能超过总页数
@@ -1271,11 +1243,11 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
           }, function (reason) {
             that.loading(false);
             reason !== undefined && hint.error(reason);
-            that.errorView(null, {type: ERROR_TYPE.PARSE_DATA_EXCEPTION});
           });
         },
-        error: function(xhr, msg){
-          that.errorView('请求异常，错误提示：'+ msg, {xhr: xhr, msg: msg, type: ERROR_TYPE.AJAX_ERROR});
+        error: function(e, msg){
+          that.errorView('请求异常，错误提示：'+ msg);
+          typeof options.error === 'function' && options.error(e, msg);
         }
       });
     } else if(layui.type(options.data) === 'array'){ //已知数据
@@ -1551,7 +1523,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
 
     //如果无数据
     if(data.length === 0){
-      return that.errorView(options.text.none, {type: 'NO_DATA_EXCEPTION'});
+      return that.errorView(options.text.none);
     } else {
       that.layFixLeft.removeClass(HIDE);
     }

--- a/src/modules/table.js
+++ b/src/modules/table.js
@@ -1241,6 +1241,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
             }
             done(res, opts.type);
           }, function (reason) {
+            that.loading(false);
             reason !== undefined && layui.hint().error(reason);
           });
         },

--- a/src/modules/table.js
+++ b/src/modules/table.js
@@ -1194,7 +1194,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
       }
 
       that.loading(true);
-
+      var currentRequestId = that.requestId = that.startTime;
       $.ajax({
         type: options.method || 'get',
         url: options.url,
@@ -1210,6 +1210,11 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
             ? options.parseData(res) || res
             : res;
           util.promiseLikeResolve(maybePromise).then(function(res){
+          // 忽略过期的请求结果
+            if(currentRequestId !== that.requestId){
+              hint.error('AJAX_CANCELED: ' + currentRequestId, 'warn');
+              return;
+            };
             // 检查数据格式是否符合规范
             if (res[response.statusName] != response.statusCode) {
               that.errorView(

--- a/src/modules/table.js
+++ b/src/modules/table.js
@@ -1206,10 +1206,10 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
         complete: typeof options.complete === 'function' ? options.complete : undefined,
         success: function(res){
           // 若有数据解析的回调，则获得其返回的数据
-          var param = typeof options.parseData === 'function'
+          var maybePromise = typeof options.parseData === 'function'
             ? options.parseData(res) || res
             : res;
-          util.promiseLikeResolve(param).then(function(res){
+          util.promiseLikeResolve(maybePromise).then(function(res){
             // 检查数据格式是否符合规范
             if (res[response.statusName] != response.statusCode) {
               that.errorView(

--- a/src/modules/table.js
+++ b/src/modules/table.js
@@ -456,7 +456,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
     that.fullSize();
     that.setColsWidth({isInit: true});
 
-    that.pullData(that.page)  // 请求数据
+    that.pullData(that.page);  // 请求数据
     that.events(); // 事件
   };
 
@@ -1237,7 +1237,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
             ? options.parseData(res) || res
             : res;
           util.promiseLikeResolve(maybePromise).then(function(res){
-          // 忽略过期的请求结果
+            // 忽略过期的请求结果
             if(currentRequestId !== that.requestId){
               hint.error('DATA_EXPIRED: ' + currentRequestId + ' | ' + that.requestId, 'warn');
               return;

--- a/src/modules/table.js
+++ b/src/modules/table.js
@@ -456,7 +456,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
     that.fullSize();
     that.setColsWidth({isInit: true});
 
-    that.pullData(that.page)     // 请求数据
+    that.pullData(that.page)  // 请求数据
     that.events(); // 事件
   };
 
@@ -1239,7 +1239,7 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
           util.promiseLikeResolve(maybePromise).then(function(res){
           // 忽略过期的请求结果
             if(currentRequestId !== that.requestId){
-              hint.error('AJAX_CANCELED: ' + currentRequestId, 'warn');
+              hint.error('DATA_EXPIRED: ' + currentRequestId + ' | ' + that.requestId, 'warn');
               return;
             };
             // 检查数据格式是否符合规范
@@ -1276,7 +1276,6 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
         },
         error: function(xhr, msg){
           that.errorView('请求异常，错误提示：'+ msg, {xhr: xhr, msg: msg, type: ERROR_TYPE.AJAX_ERROR});
-          //typeof options.error === 'function' && options.error(e, msg);
         }
       });
     } else if(layui.type(options.data) === 'array'){ //已知数据

--- a/src/modules/table.js
+++ b/src/modules/table.js
@@ -1204,12 +1204,14 @@ layui.define(['lay', 'laytpl', 'laypage', 'form', 'util'], function(exports){
         jsonpCallback: options.jsonpCallback,
         headers: options.headers || {},
         complete: typeof options.complete === 'function' ? options.complete : undefined,
-        success: function(res){
+        success: function(response){
           // 若有数据解析的回调，则获得其返回的数据
           var maybePromise = typeof options.parseData === 'function'
-            ? options.parseData(res) || res
-            : res;
+            ? options.parseData(response)
+            : response;
           util.promiseLikeResolve(maybePromise).then(function(res){
+            if(res === false) return;
+            res = res || response;
             // 忽略过期的请求结果
             if(currentRequestId !== that.requestId){
               hint.error('DATA_EXPIRED: ' + currentRequestId + ' | ' + that.requestId, 'warn');

--- a/src/modules/treeTable.js
+++ b/src/modules/treeTable.js
@@ -682,7 +682,7 @@ layui.define(['table', 'util'], function (exports) {
       } else {
         var asyncSetting = treeOptions.async || {};
         var asyncUrl = asyncSetting.url || options.url;
-        if (asyncSetting.enable && trData[isParentKey] && !trData[LAY_ASYNC_STATUS]) {
+        if (asyncSetting.enable && trData[isParentKey] && (!trData[LAY_ASYNC_STATUS] || trData[LAY_ASYNC_STATUS] === 'error')) {
           trData[LAY_ASYNC_STATUS] = 'loading';
           flexIconElem.html('<i class="layui-icon layui-icon-loading layui-anim layui-anim-loop layui-anim-rotate"></i>');
 
@@ -731,9 +731,6 @@ layui.define(['table', 'util'], function (exports) {
             headers: asyncHeaders || {},
             success: function (res) {
               // 若有数据解析的回调，则获得其返回的数据
-              if (typeof asyncParseData === 'function') {
-                res = asyncParseData.call(options, res) || res;
-              }
               var maybePromise = typeof asyncParseData === 'function'
                 ? asyncParseData.call(options, res) || res
                 : res;
@@ -742,6 +739,7 @@ layui.define(['table', 'util'], function (exports) {
                   // 检查数据格式是否符合规范
                   if (res[asyncResponse.statusName] != asyncResponse.statusCode) {
                     trData[LAY_ASYNC_STATUS] = 'error';
+                    trData[LAY_EXPAND] = false;
                     // 异常处理 todo
                     flexIconElem.html('<i class="layui-icon layui-icon-refresh"></i>');
                     // 事件
@@ -750,6 +748,7 @@ layui.define(['table', 'util'], function (exports) {
                     asyncSuccessFn(res[asyncResponse.dataName]);
                   }
                 }, function (reason) {
+                  trData[LAY_EXPAND] = false;
                   trData[LAY_ASYNC_STATUS] = 'error';
                   // 异常处理 todo
                   flexIconElem.html('<i class="layui-icon layui-icon-refresh"></i>');

--- a/src/modules/treeTable.js
+++ b/src/modules/treeTable.js
@@ -153,10 +153,7 @@ layui.define(['table', 'util'], function (exports) {
           var defer = $.Deferred();
           var parseDataThat = this;
           var args = arguments;
-          var retData = args[0];
-          if (layui.type(parseData) === 'function') {
-            retData = parseData.apply(parseDataThat, args) || args[0];
-          }
+
           var maybePromise = layui.type(parseData) === 'function'
             ? parseData.apply(parseDataThat, args) || args[0]
             : args[0];

--- a/src/modules/treeTable.js
+++ b/src/modules/treeTable.js
@@ -157,10 +157,10 @@ layui.define(['table', 'util'], function (exports) {
           if (layui.type(parseData) === 'function') {
             retData = parseData.apply(parseDataThat, args) || args[0];
           }
-          var p = layui.type(parseData) === 'function'
+          var maybePromise = layui.type(parseData) === 'function'
             ? parseData.apply(parseDataThat, args) || args[0]
             : args[0];
-          util.promiseLikeResolve(p).then(function (res) {
+          util.promiseLikeResolve(maybePromise).then(function (res) {
             return res;
           },function(reason){
             reason !== undefined && layui.hint().error(reason);
@@ -735,10 +735,10 @@ layui.define(['table', 'util'], function (exports) {
               if (typeof asyncParseData === 'function') {
                 res = asyncParseData.call(options, res) || res;
               }
-              var param = typeof asyncParseData === 'function'
+              var maybePromise = typeof asyncParseData === 'function'
                 ? asyncParseData.call(options, res) || res
                 : res;
-              util.promiseLikeResolve(param)
+              util.promiseLikeResolve(maybePromise)
                 .then(function (res) {
                   // 检查数据格式是否符合规范
                   if (res[asyncResponse.statusName] != asyncResponse.statusCode) {

--- a/src/modules/treeTable.js
+++ b/src/modules/treeTable.js
@@ -160,12 +160,7 @@ layui.define(['table', 'util'], function (exports) {
           var maybePromise = layui.type(parseData) === 'function'
             ? parseData.apply(parseDataThat, args) || args[0]
             : args[0];
-          util.promiseLikeResolve(maybePromise).then(function (res) {
-            return res;
-          },function(reason){
-            reason !== undefined && layui.hint().error(reason);
-            defer.reject(reason);
-          }).then(function (retData) {
+          util.promiseLikeResolve(maybePromise).then(function (retData) {
             var dataName = parseDataThat.response.dataName;
             // 处理 isSimpleData
             if (treeOptions.data.isSimpleData && !treeOptions.async.enable) { // 异步加载和 isSimpleData 不应该一起使用
@@ -182,7 +177,11 @@ layui.define(['table', 'util'], function (exports) {
   
             that.initData(retData[dataName]);
             defer.resolve(retData);
-          });
+          },function(reason){
+            reason !== undefined && layui.hint().error(reason);
+            defer.reject(reason);
+          })
+
           return defer.promise();
         }
         options.parseData.mod = true
@@ -751,6 +750,9 @@ layui.define(['table', 'util'], function (exports) {
                     asyncSuccessFn(res[asyncResponse.dataName]);
                   }
                 }, function (reason) {
+                  trData[LAY_ASYNC_STATUS] = 'error';
+                  // 异常处理 todo
+                  flexIconElem.html('<i class="layui-icon layui-icon-refresh"></i>');
                   reason !== undefined && layui.hint().error(reason);
                 })
             },

--- a/src/modules/treeTable.js
+++ b/src/modules/treeTable.js
@@ -749,7 +749,7 @@ layui.define(['table', 'util'], function (exports) {
                   trData[LAY_ASYNC_STATUS] = 'error';
                   // 异常处理 todo
                   flexIconElem.html('<i class="layui-icon layui-icon-refresh"></i>');
-                  reason !== undefined && layui.hint().error(reason);
+                  reason !== undefined && hint.error(reason);
                 })
             },
             error: function (e, msg) {

--- a/src/modules/upload.js
+++ b/src/modules/upload.js
@@ -3,13 +3,14 @@
  * 上传组件
  */
  
-layui.define(['lay', 'layer'], function(exports){
+layui.define(['lay', 'layer', 'util'], function(exports){
   "use strict";
   
   var $ = layui.$;
   var lay = layui.lay;
   var layer = layui.layer;
   var device = layui.device();
+  var util = layui.util;
 
   // 模块名
   var MOD_NAME = 'upload';
@@ -502,7 +503,7 @@ layui.define(['lay', 'layer'], function(exports){
       }
       // 上传前的回调 - 如果回调函数明确返回 false 或 Promise.reject，则停止上传
       if(typeof options.before === 'function'){
-        upload.util.promiseLikeResolve(options.before(args))
+        util.promiseLikeResolve(options.before(args))
           .then(function(result){
             if(result !== false){
               ready();
@@ -813,19 +814,6 @@ layui.define(['lay', 'layer'], function(exports){
       size = formatSize / Math.pow(1024, index);
       size = size % 1 === 0 ? size : parseFloat(size.toFixed(precision));//保留的小数位数
       return size + unitArr[index];
-    },
-    /**
-     * 将给定的值转换为一个 JQueryDeferred 对象
-     */
-    promiseLikeResolve:function(value){
-      var deferred = $.Deferred();
-
-      if(value && typeof value.then === 'function'){
-        value.then(deferred.resolve, deferred.reject);
-      }else{
-        deferred.resolve(value);
-      }
-      return deferred.promise();
     }
   }
 

--- a/src/modules/util.js
+++ b/src/modules/util.js
@@ -443,6 +443,23 @@ layui.define('jquery', function(exports){
       });
 
       return events;
+    },
+    /**
+     * 仅供内部使用，未文档化
+     * 将给定的值转换为一个 JQueryDeferred 对象,类似 Promise.Resolve
+     * @template T
+     * @param {T | PromiseLike<T>} value  值
+     * @return {JQueryDeferred<Awaited<T>>} 返回一个 JQueryDeferred 对象
+     */
+    promiseLikeResolve: function (value) {
+      var deferred = $.Deferred();
+
+      if (value && typeof value === 'object' && typeof value.then === 'function') {
+        value.then(deferred.resolve, deferred.reject);
+      } else {
+        deferred.resolve(value);
+      }
+      return deferred.promise();
     }
   };
 


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [ ] 问题修复
- [x] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- feat(table): parseDate 支持异步

  close #2381
  close #1648

- fix(table): 修复请求数据时的竞态问题 

  close #2304 
  
  parseDate 支持异步后，竞态问题可能会更明显(旧请求响应速度慢，请求成功后覆盖了最新请求的数据)。常用的请求锁定(loading)、防抖解决方案在快速切换分页的场景不适用，需要在 table 内部解决。这个 PR 使用时间戳作为每次请求的唯一 ID，若渲染数据时当前 ID 小于最新 ID，则忽略此次渲染。 treeTable 异步加载子节点不需要处理。
  
  弱网环境快速切换分页, 不能在开发者工具模拟
  https://stackblitz.com/edit/qshusisw-5szsrjjb?file=index.js
  ![image](https://github.com/user-attachments/assets/f8d0c3f4-4a59-44e5-8c7d-369171644845)


- fix(treeTable): 异步加载子节点失败后，无法点击重新加载

  close #2476 


[演示]https://stackblitz.com/edit/z6u1bkky?file=package.json


### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明
