### PR TITLE
fix(css): monospace font fallback

### DIFF
--- a/src/css/layui.css
+++ b/src/css/layui.css
@@ -668,7 +668,7 @@ hr.layui-border-black{border-width: 0 0 1px;}
 .layui-text a:not(.layui-btn){color: #01AAED;}
 .layui-text a:not(.layui-btn):hover{text-decoration: underline;}
 .layui-text blockquote:not(.layui-elem-quote){margin: 15px 0; padding: 5px 15px; border-left: 5px solid #eee;}
-.layui-text pre > code:not(.layui-code){display: block; padding: 15px; font-family: "Courier New",Consolas,"Lucida Console";}
+.layui-text pre > code:not(.layui-code){display: block; padding: 15px; font-family: "Courier New",Consolas,"Lucida Console", monospace;}
 
 /* 字体大小 */
 .layui-font-12{font-size: 12px !important;}
@@ -1505,7 +1505,7 @@ body .layui-util-face  .layui-layer-content{padding:0; background-color:#fff; co
 .layui-util-face ul li:hover{position: relative; z-index: 2; border: 1px solid #eb7350; background: #fff9ec;}
 
 /** 代码文本修饰 **/
-.layui-code{display: block; position: relative; padding: 15px; line-height: 20px; border: 1px solid #eee; border-left-width: 6px; background-color: #fff; color: #333; font-family: "Courier New",Consolas,"Lucida Console"; font-size: 12px;}
+.layui-code{display: block; position: relative; padding: 15px; line-height: 20px; border: 1px solid #eee; border-left-width: 6px; background-color: #fff; color: #333; font-family: "Courier New",Consolas,"Lucida Console", monospace; font-size: 12px;}
 
 /** 穿梭框 **/
 .layui-transfer-box,

--- a/src/css/modules/code.css
+++ b/src/css/modules/code.css
@@ -5,7 +5,7 @@
 html #layuicss-skincodecss{display: none; position: absolute; width: 1989px;}
 
 /* 字体  */
-.layui-code-wrap{font-size: 13px; font-family: "Courier New",Consolas,"Lucida Console";}
+.layui-code-wrap{font-size: 13px; font-family: "Courier New",Consolas,"Lucida Console", monospace;}
 
 /* 基础结构 */
 .layui-code-view{display: block; position: relative; padding: 0 !important; border: 1px solid #eee; border-left-width: 6px; background-color: #fff; color: #333;}


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [ ] 问题修复
- [x] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- 在 CSS 每一处使用了等距字体的 `font-family` 末尾增加了 `monospace` 作为前面字体未生效的 fallback, 以优化在部分 Linux 桌面的使用体验

### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明
