### PR TITLE
layer按钮添加样式参数

### DIFF
--- a/src/modules/layer.js
+++ b/src/modules/layer.js
@@ -379,7 +379,16 @@ Class.pt.vessel = function(conType, callback){
         var button = '';
         typeof config.btn === 'string' && (config.btn = [config.btn]);
         for(var i = 0, len = config.btn.length; i < len; i++){
-          button += '<a class="'+ doms[6] +''+ i +'">'+ config.btn[i] +'</a>'
+          var currentBtn = config.btn[i];
+          var btnClass = doms[6] + i;
+          var btnText = '';
+          if(typeof currentBtn !== 'string' && currentBtn){
+            btnClass += currentBtn.className ? ' ' + currentBtn.className : '';
+            btnText = currentBtn.text;
+          } else {
+            btnText = currentBtn;
+          }
+          button += '<a class="'+ btnClass +'">'+ btnText +'</a>'
         }
         return '<div class="'+ function(){
           var className = [doms[6]];


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [ ] 问题修复
- [x] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- 扩展 弹出层属性`btn`的用法：
  在原来的string的基础上增加对象控制方式，示例如下：
```javascript
layer.open({
  btn:[{
    text:'通过', //按钮文字
    className: 'layui-layer-btn-audit-pass', //按钮样式
    callback: function(){} //按钮点击后的回调，参考原来的btn1...btnN的用法
  },{
    text:'不通过', //按钮文字
    className: 'layui-layer-btn-audit-fail', //按钮样式
    callback: function(){} //按钮点击后的回调，参考原来的btn1...btnN的用法
  }]
})
```
次修改兼容原来的使用说明

### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [ ] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [ ] 已提供具体的变化内容说明
