### PR TITLE
docs: 更正 class 公共类文档错误 (#2544)

### DIFF
--- a/docs/class/index.md
+++ b/docs/class/index.md
@@ -12,7 +12,7 @@ toc: true
 | className | 描述 |
 | --- | --- |
 | layui-main | 设置一个固定宽度为 `1160px` 的水平居中块 |
-| layui-border-box | 设置元素及其所有子元素均为 `box-sizing: content-box` 模型的容器 |
+| layui-border-box | 设置元素及其所有子元素均为 `box-sizing: border-box` 模型的容器 |
 | layui-clear | 清除前面的同级元素产生的浮动 |
 | layui-clear-space <sup>2.8+</sup> | 清除容器内的空白符 |
 | layui-inline | 设置元素为内联块状结构 |


### PR DESCRIPTION
| layui-border-box | 设置元素及其所有子元素均为 `box-sizing: border-box` 模型的容器 |

### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [x] 问题修复
- [ ] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- 在此处列出本次 PR 的每一项改动内容


### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [ ] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [ ] 已对每一项的改动均测试通过
- [ ] 已提供具体的变化内容说明
