### PR TITLE
fix(form-checkbox): 优化 checkbox 标签风格选中且禁用时的显示

### DIFF
--- a/src/css/layui.css
+++ b/src/css/layui.css
@@ -930,6 +930,8 @@ hr.layui-border-black{border-width: 0 0 1px;}
 .layui-checkbox-disabled > div{color: #c2c2c2!important;}
 .layui-checkbox-disabled > i{border-color: #eee !important;}
 .layui-checkbox-disabled:hover > i{color: #fff !important;}
+.layui-form-checkbox[lay-skin="tag"].layui-form-checked.layui-checkbox-disabled > i{color:#c2c2c2;}
+.layui-form-checkbox[lay-skin="tag"].layui-form-checked.layui-checkbox-disabled:hover > i{color: #c2c2c2!important;}
 
 /* 单选框 */
 .layui-form-radio{display: inline-block; vertical-align: middle; line-height: 28px; margin: 6px 10px 0 0; padding-right: 10px; cursor: pointer; font-size: 0;}


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [x] 问题修复
- [ ] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- 优化checkbox标签风格选中且禁用时的显示
- 之前：选中禁用时仍显示绿色，且hover时会让选中看不见
![1](https://github.com/user-attachments/assets/d38a64d7-4e86-4731-a60b-28e5e2ea6b31)
- 现在：选中禁用时优化为灰色，且hover时不影响显示
![2](https://github.com/user-attachments/assets/8d94260c-5009-4bb6-87ce-e4b5e3a04367)


### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明
