### PR TITLE
feat(tabs): 为 tabs.add 新增 active 选项

### DIFF
--- a/docs/tabs/index.md
+++ b/docs/tabs/index.md
@@ -110,11 +110,11 @@ tabs.render({
 | id | 标签的 `lay-id` 属性值 | string | - |
 | index | 活动标签的索引或 `lay-id` 属性值，默认取当前选中标签的索引 | number | - |
 | mode | 标签的插入方式。支持以下可选值：<ul><li>`append` 插入标签到最后</li> <li>`prepend` 插入标签到最前</li> <li>`before` 在活动标签前插入</li> <li>`after` 在活动标签后插入</li></ul> | string | `append` |
+| active | 是否将新增项设置为活动标签 | boolean | `true` |
 | closable | 标签是否可关闭。初始值取决于 `options.closable` | boolean | `false` |
 | headerItem | 自定义标签头部元素，如 `headerItem: '<li></li>'` | string | - |
 | bodyItem | 自定义标签内容元素，如 `bodyItem: '<div></div>'` | string | - |
 | done | 标签添加成功后执行的回调函数 | Function | - |
-| change | 是否将插入项切换为当前标签 | boolean | true |
 
 该方法用于给对应的 tabs 实例新增一个标签
 

--- a/docs/tabs/index.md
+++ b/docs/tabs/index.md
@@ -114,6 +114,7 @@ tabs.render({
 | headerItem | 自定义标签头部元素，如 `headerItem: '<li></li>'` | string | - |
 | bodyItem | 自定义标签内容元素，如 `bodyItem: '<div></div>'` | string | - |
 | done | 标签添加成功后执行的回调函数 | Function | - |
+| change | 是否将插入项切换为当前标签 | boolean | true |
 
 该方法用于给对应的 tabs 实例新增一个标签
 

--- a/src/modules/tabs.js
+++ b/src/modules/tabs.js
@@ -173,11 +173,11 @@ layui.define('component', function(exports) {
    * @param {string} opts.id - 标签的 lay-id 属性值
    * @param {string} [opts.index] - 活动标签索引，默认取当前选中标签的索引
    * @param {('append'|'prepend'|'after'|'before')} [opts.mode='append'] - 标签插入方式
+   * @param {boolean} [opts.active] - 是否将新增项设置为活动标签
    * @param {string} [opts.closable] - 标签是否可关闭。初始值取决于 options.closable
    * @param {string} [opts.headerItem] - 自定义标签头部元素
    * @param {string} [opts.bodyItem] - 自定义标签内容元素
    * @param {Function} [opts.done] - 标签添加成功后执行的回调函数
-   * @param {boolean} opts.change - 是否添加即切换
    */
   Class.prototype.add = function(opts) {
     var that = this;
@@ -185,6 +185,11 @@ layui.define('component', function(exports) {
     var container = that.getContainer();
     var newHeaderItem = that.renderHeaderItem(opts);
     var newBodyItem = that.renderBodyItem(opts);
+
+    // 选项默认值
+    opts = $.extend({
+      active: true
+    }, opts);
 
     // 插入方式
     if (/(before|after)/.test(opts.mode)) { // 在活动标签前后插入
@@ -203,9 +208,11 @@ layui.define('component', function(exports) {
       container.body.elem[mode](newBodyItem);
     }
 
-    // 是否将插入项切换为当前标签
-    if (opts.change || true) {
+    // 是否将新增项设置为活动标签
+    if (opts.active) {
       that.change(newHeaderItem, true);
+    } else {
+      that.roll('auto');
     }
 
     // 回调

--- a/src/modules/tabs.js
+++ b/src/modules/tabs.js
@@ -177,6 +177,7 @@ layui.define('component', function(exports) {
    * @param {string} [opts.headerItem] - 自定义标签头部元素
    * @param {string} [opts.bodyItem] - 自定义标签内容元素
    * @param {Function} [opts.done] - 标签添加成功后执行的回调函数
+   * @param {boolean} opts.change - 是否添加即切换
    */
   Class.prototype.add = function(opts) {
     var that = this;
@@ -202,8 +203,10 @@ layui.define('component', function(exports) {
       container.body.elem[mode](newBodyItem);
     }
 
-    // 将插入项切换为当前标签
-    that.change(newHeaderItem, true);
+    // 是否将插入项切换为当前标签
+    if (opts.change || true) {
+      that.change(newHeaderItem, true);
+    }
 
     // 回调
     var params = that.data();

--- a/src/modules/tabs.js
+++ b/src/modules/tabs.js
@@ -174,7 +174,7 @@ layui.define('component', function(exports) {
    * @param {string} [opts.index] - 活动标签索引，默认取当前选中标签的索引
    * @param {('append'|'prepend'|'after'|'before')} [opts.mode='append'] - 标签插入方式
    * @param {boolean} [opts.active] - 是否将新增项设置为活动标签
-   * @param {string} [opts.closable] - 标签是否可关闭。初始值取决于 options.closable
+   * @param {boolean} [opts.closable] - 标签是否可关闭。初始值取决于 options.closable
    * @param {string} [opts.headerItem] - 自定义标签头部元素
    * @param {string} [opts.bodyItem] - 自定义标签内容元素
    * @param {Function} [opts.done] - 标签添加成功后执行的回调函数


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [x] 功能新增
- [ ] 问题修复
- [ ] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- 新增 `tabs.add()` 的 `active` 选项，用于是否将新增项设置为活动标签
  - closes #2604


### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明
