### PR TITLE
refactor(component): 剔除 isRenderOnEvent, isRenderWithoutElem 选项

### DIFF
--- a/docs/component/detail/options.md
+++ b/docs/component/detail/options.md
@@ -53,34 +53,6 @@ CONST: {
 <td>-</td>
     </tr>
     <tr>
-<td>isRenderWithoutElem <br><sup>实验性</sup></td>
-<td>
-
-渲染是否无需指定目标元素。即无需设置 `elem` 选项，一般用于渲染即显示的组件类型。
-
-</td>
-<td>boolean</td>
-<td>
-
-`false`
-
-</td>
-    </tr>
-    <tr>
-<td>isRenderOnEvent <br><sup>实验性</sup></td>
-<td>
-
-渲染是否由事件触发。如 `dropdown` 这类通过点击触发的组件，那么应该设置为 `true`；而诸如 `tabs` 这类初始即展示的组件，则应该设置为 `false`。*推荐根据组件类型始终显式设置对应值*。
-
-</td>
-<td>boolean</td>
-<td>
-
-`true`
-
-</td>
-    </tr>
-    <tr>
 <td>isDeepReload <br><sup>实验性</sup></td>
 <td>
 

--- a/src/modules/component.js
+++ b/src/modules/component.js
@@ -13,8 +13,6 @@ layui.define(['jquery', 'lay'], function(exports) {
   exports('component', function(settings) {
     // 默认设置
     settings = $.extend(true, {
-      isRenderWithoutElem: false, // 渲染是否无需指定目标元素
-      isRenderOnEvent: true, // 渲染是否仅由事件触发。--- 推荐根据组件类型始终显式设置对应值
       isDeepReload: false // 是否默认为深度重载
     }, settings);
 
@@ -107,7 +105,7 @@ layui.define(['jquery', 'lay'], function(exports) {
     };
 
     // 初始化准备（若由事件触发渲染，则必经此步）
-    Class.prototype.init = function(rerender, type){
+    Class.prototype.init = function(rerender, type) {
       var that = this;
       var options = that.config;
       var elem = $(options.elem);
@@ -153,21 +151,11 @@ layui.define(['jquery', 'lay'], function(exports) {
         settings.beforeRender.call(that, options);
       }
 
-      // 执行渲染
-      var render = function() {
+      // 渲染
+      if (typeof settings.render === 'function') {
         component.cache.id[options.id] = null; // 记录所有实例 id，用于批量操作（如 resize）
         elem.attr(MOD_ID, options.id); // 目标元素已渲染过的标记
         that.render(rerender); // 渲染核心
-      };
-
-      // 若绑定元素不存在
-      if (!elem[0]) {
-        return settings.isRenderWithoutElem ? render() : null; // 渲染是否无需指定目标元素
-      };
-
-      // 执行渲染 - 是否初始即渲染组件
-      if((settings.isRenderOnEvent && options.show) || !settings.isRenderOnEvent) {
-        render();
       }
 
       // 事件
@@ -232,6 +220,7 @@ layui.define(['jquery', 'lay'], function(exports) {
     // 移除指定的实例对象
     component.removeInst = function(id) {
       delete instance.that[id];
+      delete component.cache.id[id];
     };
 
     // 组件缓存

--- a/src/modules/tabs.js
+++ b/src/modules/tabs.js
@@ -28,8 +28,6 @@ layui.define('component', function(exports) {
       CARD: 'layui-tabs-card'
     },
 
-    isRenderOnEvent: false,
-
     // 渲染
     render: function() {
       var that = this;


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [ ] 问题修复
- [x] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- 剔除 isRenderOnEvent, isRenderWithoutElem 选项。将定制权交给 `render` 函数，提升组件可扩展性
  - 关联：https://github.com/layui/layui/pull/2566#issuecomment-2727454117
- 为 `component.removeInst()` 增加对 `component.cache.id` 缓存的移除。此项不必写入更新日志中。

### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明
