### PR TITLE
fix(form-select): 修复 `checkbox/radio` 在 WebKit/537.36 的异常

### DIFF
--- a/src/modules/form.js
+++ b/src/modules/form.js
@@ -10,7 +10,6 @@ layui.define(['lay', 'layer', 'util'], function(exports){
   var util = layui.util;
   var hint = layui.hint();
   var device = layui.device();
-  var needCheckboxFallback = lay.ie && parseFloat(lay.ie) === 8;
 
   var MOD_NAME = 'form';
   var ELEM = '.layui-form';
@@ -20,6 +19,11 @@ layui.define(['lay', 'layer', 'util'], function(exports){
   var DISABLED = 'layui-disabled';
   var OUT_OF_RANGE = 'layui-input-number-out-of-range';
   var BAD_INPUT = 'layui-input-number-invalid';
+
+  // ie8 中可以获取到 input 元素的 'indeterminate' 属性描述符，但重新定义 getter/setter 无效，无报错
+  // AppleWebKit/537.36 无法获取 input 元素任意属性的属性描述符(包括lookupGetter)，但可以重新定义 getter/setter
+  var needCheckboxFallback = (lay.ie && parseFloat(lay.ie) === 8)
+    || typeof Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'checked') === 'undefined'
 
   var Form = function(){
     this.config = {

--- a/src/modules/lay.js
+++ b/src/modules/lay.js
@@ -680,15 +680,15 @@
   }();
 
   /**
-   * 监听指定元素外部的点击
-   * @param {HTMLElement} target - 被监听的元素
+   * 绑定指定元素外部的点击事件
+   * @param {HTMLElement} target - 响应事件的元素
    * @param {(e: Event) => void} handler - 事件触发时执行的函数
    * @param {object} [options] - 选项
-   * @param {string} [options.event="pointerdown"] - 监听的事件类型
-   * @param {HTMLElement | Window} [options.scope=document] - 监听范围
-   * @param {Array<HTMLElement | string>} [options.ignore] - 忽略监听的元素或选择器字符串
-   * @param {boolean} [options.capture=true] - 对内部事件侦听器使用捕获阶段
-   * @returns {() => void} - 返回一个停止事件监听的函数
+   * @param {string} [options.event="pointerdown"] - 事件类型
+   * @param {HTMLElement | Window} [options.scope=document] - 事件范围
+   * @param {Array<HTMLElement | string>} [options.ignore] - 忽略触发事件的元素或选择器字符串
+   * @param {boolean} [options.capture=true] - 对内部事件 listener 使用捕获阶段
+   * @returns {() => void} - 返回一个停止事件响应的函数
    */
   lay.onClickOutside = function(target, handler, options){
     options = options || {};

--- a/src/modules/lay.js
+++ b/src/modules/lay.js
@@ -680,15 +680,15 @@
   }();
 
   /**
-   * 绑定指定元素外部的点击事件
-   * @param {HTMLElement} target - 响应事件的元素
+   * 监听指定元素外部的点击
+   * @param {HTMLElement} target - 被监听的元素
    * @param {(e: Event) => void} handler - 事件触发时执行的函数
    * @param {object} [options] - 选项
-   * @param {string} [options.event="pointerdown"] - 事件类型
-   * @param {HTMLElement | Window} [options.scope=document] - 事件范围
-   * @param {Array<HTMLElement | string>} [options.ignore] - 忽略触发事件的元素或选择器字符串
-   * @param {boolean} [options.capture=true] - 对内部事件 listener 使用捕获阶段
-   * @returns {() => void} - 返回一个停止事件响应的函数
+   * @param {string} [options.event="pointerdown"] - 监听的事件类型
+   * @param {HTMLElement | Window} [options.scope=document] - 监听范围
+   * @param {Array<HTMLElement | string>} [options.ignore] - 忽略监听的元素或选择器字符串
+   * @param {boolean} [options.capture=true] - 对内部事件侦听器使用捕获阶段
+   * @returns {() => void} - 返回一个停止事件监听的函数
    */
   lay.onClickOutside = function(target, handler, options){
     options = options || {};


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [x] 问题修复
- [ ] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- fix(form-select): 修复 `checkbox/radio` 在 WebKit/537.36 的异常

### WebKit/537
无法获取元素属性描述符，回退到 IE8 的解决方案即可

只测试了 WebKit/537，WebKit/538 应该没理由会把 input 元素的属性描述符 configurable 设置为 false，
因此这和 #2633 可能是两个不同的问题，需要等待进一步的确认。

  ![image](https://github.com/user-attachments/assets/f3e8b741-697b-4c50-ab29-badefc1be068)

  #### 之前

  ![image](https://github.com/user-attachments/assets/e53ca2d0-4a4f-46f8-b74b-688c518fa5d6)

  #### 之后

  ![image](https://github.com/user-attachments/assets/699e15f7-63b9-488a-8d8a-7c765e0bd3f4)

### 错误信息
```
jQuery.Deferred exception: Cannot read property 'set' of undefined TypeError: Cannot read property 'set' of undefined
    at <error: TypeError: Accessing selectionDirection on an input element that cannot have a selection.>
    at HTMLFormElement.<anonymous> (http://127.0.0.1:5501/src/modules/form.js:122:31)
    at Function.jQuery.extend.each (http://127.0.0.1:5501/src/modules/jquery.js:383:19)
    at jQuery.fn.jQuery.each (http://127.0.0.1:5501/src/modules/jquery.js:205:17)
    at Form.val (http://127.0.0.1:5501/src/modules/form.js:105:14)
    at null.<anonymous> (http://127.0.0.1:5501/examples/form.html:432:26)
    at HTMLDocument.<anonymous> (http://127.0.0.1:5501/src/layui.js:262:22)
    at mightThrow (http://127.0.0.1:5501/src/modules/jquery.js:3489:29)
    at process (http://127.0.0.1:5501/src/modules/jquery.js:3557:12) undefined [jquery.js:3783](http://127.0.0.1:5501/src/modules/jquery.js)
🔽Uncaught TypeError: Cannot read property 'set' of undefined [form.js:1231](http://127.0.0.1:5501/src/modules/form.js)
Object.defineProperty.lay.extend.set [form.js:1231](http://127.0.0.1:5501/src/modules/form.js)
(anonymous function) [form.js:122](http://127.0.0.1:5501/src/modules/form.js)
jQuery.extend.each [jquery.js:383](http://127.0.0.1:5501/src/modules/jquery.js)
jQuery.fn.jQuery.each [jquery.js:205](http://127.0.0.1:5501/src/modules/jquery.js)
Form.val [form.js:105](http://127.0.0.1:5501/src/modules/form.js)
(anonymous function) [form.html:432](http://127.0.0.1:5501/examples/form.html)
(anonymous function) [layui.js:262](http://127.0.0.1:5501/src/layui.js)
mightThrow [jquery.js:3489](http://127.0.0.1:5501/src/modules/jquery.js)
process
```


### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明
