### PR TITLE
fix(layui): 修复 layui.link 重复执行时不触发回调函数的问题

### DIFF
--- a/src/layui.js
+++ b/src/layui.js
@@ -421,7 +421,7 @@
   Class.prototype.link = function(href, callback, id) {
     var that = this;
     var head = document.getElementsByTagName('head')[0];
-    var link = document.createElement('link');
+    var hasCallback = typeof callback === 'function';
 
     // 若第二个参数为 string 类型，则该参数为 id
     if (typeof callback === 'string') {
@@ -444,22 +444,22 @@
     id = id || href.replace(/^(#|(http(s?)):\/\/|\/\/)|\.|\/|\?.+/g, '');
     id = 'layuicss-'+ id;
 
-    link.href = href + (config.debug ? '?v='+new Date().getTime() : '');
-    link.rel = 'stylesheet';
-    link.id = id;
-
-    // 插入节点
-    if (!document.getElementById(id)) {
+    var link = document.getElementById(id);
+    if (!link) {
+      link = document.createElement('link');
+      link.href = href + (config.debug ? '?v='+new Date().getTime() : '');
+      link.rel = 'stylesheet';
+      link.id = id;
       head.appendChild(link);
     }
 
-    // 是否执行回调
-    if (typeof callback !== 'function') {
+    if(link.__lay_readyState__ === 'complete'){
+      hasCallback && callback(link);
       return that;
     }
-
     onNodeLoad(link, function() {
-      callback(link);
+      link.__lay_readyState__ = 'complete';
+      hasCallback && callback(link);
     }, function() {
       error(href + ' load error', 'error');
       head.removeChild(link); // 移除节点

--- a/src/layui.js
+++ b/src/layui.js
@@ -445,6 +445,8 @@
     id = 'layuicss-'+ id;
 
     var link = document.getElementById(id);
+
+    // 初始创建节点
     if (!link) {
       link = document.createElement('link');
       link.href = href + (config.debug ? '?v='+new Date().getTime() : '');
@@ -453,10 +455,13 @@
       head.appendChild(link);
     }
 
+    // 若加载已完成，则直接执行回调函数
     if (link.__lay_readyState__ === 'complete') {
       hasCallback && callback(link);
       return that;
     }
+
+    // 初始加载
     onNodeLoad(link, function() {
       link.__lay_readyState__ = 'complete';
       hasCallback && callback(link);

--- a/src/layui.js
+++ b/src/layui.js
@@ -440,7 +440,7 @@
       });
     }
 
-    // 若为传入 id ，则取路径 `//` 后面的字符拼接为 id，不含.与参数
+    // 若未传入 id ，则取路径 `//` 后面的字符拼接为 id，不含.与参数
     id = id || href.replace(/^(#|(http(s?)):\/\/|\/\/)|\.|\/|\?.+/g, '');
     id = 'layuicss-'+ id;
 
@@ -453,7 +453,7 @@
       head.appendChild(link);
     }
 
-    if(link.__lay_readyState__ === 'complete'){
+    if (link.__lay_readyState__ === 'complete') {
       hasCallback && callback(link);
       return that;
     }


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [x] 问题修复
- [ ] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- fix(layui): 修复 layui.link 重复执行时不触发回调函数的问题

重复执行时新创建的 link 标签不会添加到页面中，加载完成事件无法触发，这会导致开发版本中 laydate 无法渲染。
这个 PR 在 link 元素对象上添加了一个私有的 `__lay_readyState__` 标识加载状态，若加载完成直接执行回调。


### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明
