### PR TITLE
fix(form-select): 修复 option 两端的 Unicode 空格(U+00A0)被去除的问题

### DIFF
--- a/src/modules/form.js
+++ b/src/modules/form.js
@@ -700,7 +700,7 @@ layui.define(['lay', 'layer', 'util'], function(exports){
             }
             layui.each(dds, function(){
               var othis = $(this);
-              var text = othis.attr('lay-label') || othis.text();
+              var text = othis.text();
               var isCreateOption = isCreatable && othis.hasClass(CREATE_OPTION);
 
               // 需要区分大小写
@@ -813,16 +813,18 @@ layui.define(['lay', 'layer', 'util'], function(exports){
 
             // 将新增的 option 元素添加到末尾
             if(isCreatable && othis.hasClass(CREATE_OPTION)){
-              dl.append(othis.removeClass(CREATE_OPTION));
-              var optionElem = $('<option>').attr('value', value).text(othis.text());
+              var optionElem = $('<option>').text(othis.text());
+              var displayValue = optionElem.prop('text');
+              optionElem.attr('value', displayValue);
               select.append(optionElem);
-              othis.attr('lay-label', optionElem.prop('text'));
+              othis.removeClass(CREATE_OPTION).attr('lay-value', displayValue).text(displayValue);
+              dl.append(othis);
             }
 
             if(othis.hasClass('layui-select-tips')){
               input.val('');
             } else {
-              input.val(othis.attr('lay-label'));
+              input.val(othis.text());
               othis.addClass(THIS);
             }
 
@@ -934,8 +936,7 @@ layui.define(['lay', 'layer', 'util'], function(exports){
                 var dd = $('<dd lay-value=""></dd>');
                 if (index === 0 && !item.value && tagName !== 'optgroup') {
                   dd.addClass('layui-select-tips');
-                  dd.text(item.innerText || TIPS);
-                  dd.attr('lay-label', item.text);
+                  dd.text(item.text || TIPS);
                   arr.push(dd.prop('outerHTML'));
                 } else if(tagName === 'optgroup') {
                   var dt = $('<dt></dt>');
@@ -949,8 +950,7 @@ layui.define(['lay', 'layer', 'util'], function(exports){
                   if (item.disabled) {
                     dd.addClass(DISABLED);
                   }
-                  dd.text(item.innerText);
-                  dd.attr('lay-label', item.text)
+                  dd.text(item.text);
                   arr.push(dd.prop('outerHTML'));
                 }
               });

--- a/src/modules/form.js
+++ b/src/modules/form.js
@@ -815,6 +815,7 @@ layui.define(['lay', 'layer', 'util'], function(exports){
             if(isCreatable && othis.hasClass(CREATE_OPTION)){
               var optionElem = $('<option>').text(othis.text());
               var displayValue = optionElem.prop('text');
+              value = displayValue;
               optionElem.attr('value', displayValue);
               select.append(optionElem);
               othis.removeClass(CREATE_OPTION).attr('lay-value', displayValue).text(displayValue);

--- a/src/modules/form.js
+++ b/src/modules/form.js
@@ -583,7 +583,7 @@ layui.define(['lay', 'layer', 'util'], function(exports){
 
               // 未查询到相关值
               if(none){
-                initValue = $(select[0].options[selectedIndex]).text(); // 重新获得初始选中值
+                initValue = $(select[0].options[selectedIndex]).prop('text'); // 重新获得初始选中值
 
                 // 如果是第一项，且文本值等于 placeholder，则清空初始值
                 if(selectedIndex === 0 && initValue === input.attr('placeholder')){
@@ -700,7 +700,7 @@ layui.define(['lay', 'layer', 'util'], function(exports){
             }
             layui.each(dds, function(){
               var othis = $(this);
-              var text = othis.text();
+              var text = othis.attr('lay-label') || othis.text();
               var isCreateOption = isCreatable && othis.hasClass(CREATE_OPTION);
 
               // 需要区分大小写
@@ -789,7 +789,7 @@ layui.define(['lay', 'layer', 'util'], function(exports){
             input.on('input propertychange', layui.debounce(search, 50)).on('blur', function(e){
               var selectedIndex = select[0].selectedIndex;
 
-              initValue = $(select[0].options[selectedIndex]).text(); // 重新获得初始选中值
+              initValue = $(select[0].options[selectedIndex]).prop('text'); // 重新获得初始选中值
 
               // 如果是第一项，且文本值等于 placeholder，则清空初始值
               if(selectedIndex === 0 && initValue === input.attr('placeholder')){
@@ -814,7 +814,7 @@ layui.define(['lay', 'layer', 'util'], function(exports){
             if(othis.hasClass('layui-select-tips')){
               input.val('');
             } else {
-              input.val(othis.text());
+              input.val(othis.attr('lay-label'));
               othis.addClass(THIS);
             }
 
@@ -823,6 +823,7 @@ layui.define(['lay', 'layer', 'util'], function(exports){
               dl.append(othis.removeClass(CREATE_OPTION));
               var optionElem = $('<option>').attr('value', value).text(othis.text());
               select.append(optionElem);
+              othis.attr('lay-label', optionElem.prop('text'));
             }
 
             othis.siblings().removeClass(THIS);
@@ -879,7 +880,7 @@ layui.define(['lay', 'layer', 'util'], function(exports){
           var isCreatable = typeof othis.attr('lay-creatable') === 'string' && isSearch;
           var isAppendTo = typeof othis.attr('lay-append-to') === 'string';
           var placeholder = optionsFirst
-            ? (optionsFirst.value ? TIPS : (optionsFirst.innerText || TIPS))
+            ? (optionsFirst.value ? TIPS : (optionsFirst.text || TIPS))
             : TIPS;
 
           // 用于替代 select 的外层容器
@@ -898,8 +899,8 @@ layui.define(['lay', 'layer', 'util'], function(exports){
             var elem = $('<input type="text" class="layui-input">');
 
             // 设置占位符和默认值
-            elem.prop('placeholder', $.trim(placeholder));
-            elem.val($.trim(value ? selected.text() : ''));
+            elem.prop('placeholder', placeholder);
+            elem.val(value ? selected.prop('text') : '');
 
             // 设置未开启搜索或禁用时的输入框只读状态
             if (!isSearch || disabled) {
@@ -933,7 +934,8 @@ layui.define(['lay', 'layer', 'util'], function(exports){
                 var dd = $('<dd lay-value=""></dd>');
                 if (index === 0 && !item.value && tagName !== 'optgroup') {
                   dd.addClass('layui-select-tips');
-                  dd.text($.trim(item.innerText || TIPS));
+                  dd.text(item.innerText || TIPS);
+                  dd.attr('lay-label', item.text);
                   arr.push(dd.prop('outerHTML'));
                 } else if(tagName === 'optgroup') {
                   var dt = $('<dt></dt>');
@@ -947,7 +949,8 @@ layui.define(['lay', 'layer', 'util'], function(exports){
                   if (item.disabled) {
                     dd.addClass(DISABLED);
                   }
-                  dd.text($.trim(item.innerText));
+                  dd.text(item.innerText);
+                  dd.attr('lay-label', item.text)
                   arr.push(dd.prop('outerHTML'));
                 }
               });

--- a/src/modules/form.js
+++ b/src/modules/form.js
@@ -811,19 +811,19 @@ layui.define(['lay', 'layer', 'util'], function(exports){
 
             if(othis.hasClass(DISABLED)) return false;
 
-            if(othis.hasClass('layui-select-tips')){
-              input.val('');
-            } else {
-              input.val(othis.attr('lay-label'));
-              othis.addClass(THIS);
-            }
-
             // 将新增的 option 元素添加到末尾
             if(isCreatable && othis.hasClass(CREATE_OPTION)){
               dl.append(othis.removeClass(CREATE_OPTION));
               var optionElem = $('<option>').attr('value', value).text(othis.text());
               select.append(optionElem);
               othis.attr('lay-label', optionElem.prop('text'));
+            }
+
+            if(othis.hasClass('layui-select-tips')){
+              input.val('');
+            } else {
+              input.val(othis.attr('lay-label'));
+              othis.addClass(THIS);
             }
 
             othis.siblings().removeClass(THIS);


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [x] 问题修复
- [ ] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- fix(form-select): 修复 option 两端的 Unicode 空格(U+00A0)被去除的问题  close #2670

  https://stackblitz.com/edit/vqbretlz?file=index.html

1. ddElement.innerText 取 optionElement.innerText 原始值，不做 trim，并将 optionElement.text 存储在 dd 元素的 lay-label 属性上
  option.text: https://html.spec.whatwg.org/multipage/form-elements.html#dom-option-text
3. input 显示值取 optionElement.text，和原生 select 保持一致
4. 搜索时由比较 innerText 变为比较 text，理论上对搜索不会有影响



### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明
