### PR TITLE
refactor(i18n): laydate 国际化方案迁移至 i18n.$t

### DIFF
--- a/src/layui.js
+++ b/src/layui.js
@@ -53,14 +53,30 @@
   }();
 
   // 异常提示
-  var error = function(msg, type) {
+  var error = function(msg, type, isDebug) {
     type = type || 'log';
-    msg = 'Layui message: ' + msg;
+    msg = '[Layui]: ' + msg;
 
     if (window.console) {
       console[type] ? console[type](msg) : console.log(msg);
     }
+    if(isDebug && layui && layui.cache.debug) {
+      debugger
+    }
   };
+  var warned = Object.create(null);
+
+  var errorOnce = function (msg, type, isDebug) {
+    if(warned._size && warned._size > 500){
+      warned = Object.create(null);
+      warned._size = 0;
+    }
+    if (!warned[msg]) {
+      warned[msg] = true;
+      warned._size = (warned._size || 0) + 1;
+      error(msg, type, isDebug)
+    }
+  }
 
   // 内置模块
   var builtinModules = config.builtin = {
@@ -715,7 +731,8 @@
   // 提示
   Class.prototype.hint = function() {
     return {
-      error: error
+      error: error,
+      errorOnce: errorOnce
     };
   };
 

--- a/src/modules/laydate.js
+++ b/src/modules/laydate.js
@@ -111,6 +111,9 @@ layui.define(['lay', 'i18n'], function(exports) {
     // 初始化属性
     options = lay.extend(that.config, lay.options(elem[0])); // 继承节点上的属性
 
+    // 更新 i18n 消息对象
+    that.i18nMessages = that.getI18nMessages();
+
     // 若重复执行 render，则视为 reload 处理
     if(elem[0] && elem.attr(MOD_ID)){
       var newThat = thisModule.getThis(elem.attr(MOD_ID));
@@ -163,7 +166,7 @@ layui.define(['lay', 'i18n'], function(exports) {
     showBottom: true, // 是否显示底部栏
     isPreview: true, // 是否显示值预览
     btns: ['clear', 'now', 'confirm'], // 右下角显示的按钮，会按照数组顺序排列
-    // 为实现 lang 选项就近生效，去除此处的默认值，原型 lang() 方法中有兜底值
+    // 为实现 lang 选项就近生效，去除此处的默认值，$t 设置了英文回退值
     lang: '', // 语言，只支持 cn/en，即中文和英文
     theme: 'default', // 主题
     position: null, // 控件定位方式定位, 默认absolute，支持：fixed/absolute/static
@@ -177,51 +180,81 @@ layui.define(['lay', 'i18n'], function(exports) {
     shade: 0
   };
 
-  // 多语言
-  Class.prototype.lang = function() {
+  Class.prototype.getI18nMessages = function () {
     var that = this;
     var options = that.config;
-    var locale = i18n.config.locale.replace(/^\s+|\s+$/g, '');
-    var i18nMessages = i18n.config.messages[locale];
-    var laydateMessages = {
-      // 保留原版 en
-      en: {
-        month: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
-        weeks: ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'],
-        time: ['Hour', 'Minute', 'Second'],
-        selectDate: 'Select Date',
-        selectTime: 'Select Time',
-        startTime: 'Start Time',
-        endTime: 'End Time',
-        tools: {
-          confirm: 'Confirm',
-          clear: 'Clear',
-          now: 'Now',
-          reset: 'Reset'
-        },
-        timeout: 'End time cannot be less than start Time\nPlease re-select',
-        invalidDate: 'Invalid date',
-        formatError: ['The date format error\nMust be followed：\n', '\nIt has been reset'],
-        preview: 'The selected result'
-      }
-    };
-
-    // 同步 message
-    if (i18nMessages) {
-      laydateMessages[locale] = i18nMessages.laydate;
-    }
 
     // 纠正旧版「简体中文」语言码
     if (options.lang === 'cn') {
       options.lang = zhCN;
-    } else if (!options.lang) { // 若未传 lang 选项，则取 locale
-      options.lang = locale;
     }
+    var locale = options.lang || i18n.config.locale;
 
-    // 获取当前语言的 laydate 消息
-    // 若无消息数据，则取上述内置 en，确保组件正常显示。注：此非默认值逻辑，默认值已由 i18n 统一控制
-    return laydateMessages[options.lang] || laydateMessages['en'];;
-  };
+    return {
+      month: i18n.$t('laydate.month', null, {
+        locale: locale,
+        default: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+      }),
+      weeks: i18n.$t('laydate.weeks', null, {
+        locale: locale,
+        default: ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa']
+      }),
+      time: i18n.$t('laydate.time', null, {
+        locale: locale,
+        default: ['Hour', 'Minute', 'Second']
+      }),
+      selectDate: i18n.$t('laydate.selectDate', null, {
+        locale: locale,
+        default: 'Select Date'
+      }),
+      selectTime: i18n.$t('laydate.selectTime', null, {
+        locale: locale,
+        default: 'Select Time'
+      }),
+      startTime: i18n.$t('laydate.startTime', null, {
+        locale: locale,
+        default: 'Start Time'
+      }),
+      endTime: i18n.$t('laydate.endTime', null, {
+        locale: locale,
+        default: 'End Time'
+      }),
+      tools: {
+        confirm: i18n.$t('laydate.tools.confirm', null, {
+          locale: locale,
+          default: 'Confirm'
+        }),
+        clear: i18n.$t('laydate.tools.clear', null, {
+          locale: locale,
+          default: 'Clear'
+        }),
+        now: i18n.$t('laydate.tools.now', null, {
+          locale: locale,
+          default: 'Now'
+        }),
+        reset: i18n.$t('laydate.tools.reset', null, {
+          locale: locale,
+          default: 'Reset'
+        })
+      },
+      timeout: i18n.$t('laydate.timeout', null, {
+        locale: locale,
+        default: 'End time cannot be less than start Time\nPlease re-select'
+      }),
+      invalidDate: i18n.$t('laydate.invalidDate', null, {
+        locale: locale,
+        default: 'Invalid date'
+      }),
+      formatError: i18n.$t('laydate.formatError', null, {
+        locale: locale,
+        default: ['The date format error\nMust be followed：\n', '\nIt has been reset']
+      }),
+      preview: i18n.$t('laydate.preview', null, {
+        locale: locale,
+        default: 'The selected result'
+      })
+    }
+  }
 
   // 仅简体中文生效，不做国际化
   Class.prototype.markerOfChineseFestivals = {
@@ -317,7 +350,7 @@ layui.define(['lay', 'i18n'], function(exports) {
     // 设置了一周的开始是周几，此处做一个控制
     if (options.weekStart) {
       if (!/^[0-6]$/.test(options.weekStart)) {
-        var lang = that.lang();
+        var lang = that.i18nMessages;
         options.weekStart = lang.weeks.indexOf(options.weekStart);
         if (options.weekStart === -1) options.weekStart = 0;
       }
@@ -434,7 +467,7 @@ layui.define(['lay', 'i18n'], function(exports) {
   Class.prototype.render = function(){
     var that = this
     ,options = that.config
-    ,lang = that.lang()
+    ,lang = that.i18nMessages
     ,isStatic = options.position === 'static'
 
     //主面板
@@ -830,7 +863,7 @@ layui.define(['lay', 'i18n'], function(exports) {
     var that = this
     ,thisDate = new Date()
     ,options = that.config
-    ,lang = that.lang()
+    ,lang = that.i18nMessages
     ,dateTime = options.dateTime = options.dateTime || that.systemDate()
     ,thisMaxDate, error
 
@@ -1431,7 +1464,7 @@ layui.define(['lay', 'i18n'], function(exports) {
     ,options = that.config
     ,dateTime = value || that.thisDateTime(index)
     ,thisDate = new Date(), startWeek, prevMaxDate, thisMaxDate
-    ,lang = that.lang()
+    ,lang = that.i18nMessages
 
     ,isAlone = options.type !== 'date' && options.type !== 'datetime'
     ,tds = lay(that.table[index]).find('td')
@@ -1577,7 +1610,7 @@ layui.define(['lay', 'i18n'], function(exports) {
     var that = this
     ,options = that.config
     ,dateTime = that.rangeLinked ? options.dateTime : [options.dateTime, that.endDate][index]
-    ,lang = that.lang()
+    ,lang = that.i18nMessages
     ,isAlone = options.range && options.type !== 'date' && options.type !== 'datetime' //独立范围选择器
 
     ,ul = lay.elem('ul', {
@@ -1900,7 +1933,7 @@ layui.define(['lay', 'i18n'], function(exports) {
   Class.prototype.setBtnStatus = function(tips, start, end){
     var that = this
     ,options = that.config
-    ,lang = that.lang()
+    ,lang = that.i18nMessages
     ,isOut
     ,elemBtn = lay(that.footer).find(ELEM_CONFIRM)
     ,timeParams = options.type === 'datetime' || options.type === 'time' ? ['hours', 'minutes', 'seconds'] : undefined;
@@ -2307,7 +2340,7 @@ layui.define(['lay', 'i18n'], function(exports) {
   Class.prototype.tool = function(btn, type){
     var that = this
     ,options = that.config
-    ,lang = that.lang()
+    ,lang = that.i18nMessages
     ,dateTime = options.dateTime
     ,isStatic = options.position === 'static'
     ,active = {
@@ -2316,13 +2349,13 @@ layui.define(['lay', 'i18n'], function(exports) {
         if(lay(btn).hasClass(DISABLED)) return;
         that.list('time', 0);
         options.range && that.list('time', 1);
-        lay(btn).attr('lay-type', 'date').html(that.lang().selectDate);
+        lay(btn).attr('lay-type', 'date').html(that.i18nMessages.selectDate);
       }
 
       //选择日期
       ,date: function(){
         that.closeList();
-        lay(btn).attr('lay-type', 'datetime').html(that.lang().selectTime);
+        lay(btn).attr('lay-type', 'datetime').html(that.i18nMessages.selectTime);
       }
 
       //清空、重置


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [ ] 问题修复
- [x] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

TODO
- [ ] 考虑改进或重新设计 laydate 国际化消息



- laydate
  - laydate 国际化方案迁移至 i18n.$t，一致的国际化方案，降低维护成本
  - 出于兼容性和可维护性的考虑，这个方案会在实例化时直接获取所有 messages，初始渲染性能会略微下降，但在渲染之后有更好的运行时性能

- i18n 
  - $t 翻译函数新增第三个参数，现在可以设置局部的 locale 和未找到 message 时的默认值。$t 有意设计为最简化，所以一开始没有实现这类功能。第三个参数目前仅用于 laydate，如果将来有需要，也可以用于实现国际化作用域功能，例如全局、组件级和组件实例级的国际化。
  - 优化了开发环境控制台异常提示
  - 移除了可变长参数重载，第二个参数现在仅支持对象和数组
- layui
  - layui.hint 新增了 errorOnce 函数，可以减少控制台大量的重复异常信息
  - error 新增了第三个 isDebug 参数，方便开发环境调试


### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明
