### PR TITLE
fix(table): 修复设置 `even:true` 时，行选中背景色异常

### DIFF
--- a/src/css/layui.css
+++ b/src/css/layui.css
@@ -1032,7 +1032,8 @@ hr.layui-border-black{border-width: 0 0 1px;}
 .layui-table[lay-even] tbody tr:nth-child(even){background-color: #f8f8f8;}
 .layui-table-checked{background-color: #dbfbf0;}
 .layui-table-checked.layui-table-hover,
-.layui-table-checked.layui-table-click{background-color: #abf8dd;}
+.layui-table-checked.layui-table-click,
+.layui-table[lay-even] tbody tr:nth-child(even).layui-table-checked{background-color: #abf8dd;}
 .layui-table-disabled-transition *,
 .layui-table-disabled-transition *:before,
 .layui-table-disabled-transition *:after{-webkit-transition:none!important;-moz-transition:none!important;-o-transition:none!important;-ms-transition:none!important;transition:none!important}


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [x] 问题修复
- [ ] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- fix(table): 修复设置 `even:true` 时，行选中背景色异常, close #2767

  之前
  <img width="956" height="235" alt="image" src="https://github.com/user-attachments/assets/0d0a8e4c-683f-42a4-bb39-9ead5f6d8850" />
  之后
  <img width="975" height="242" alt="image" src="https://github.com/user-attachments/assets/992d6dbd-bd31-407c-af8c-deeab1941a0d" />



### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [ ] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明
