### PR TITLE
fix(form): 修复 label 和 checkbox/radio 关联时的问题

### DIFF
--- a/src/modules/form.js
+++ b/src/modules/form.js
@@ -1008,7 +1008,8 @@ layui.define(['lay', 'layer', 'util'], function(exports){
           var isPrimary = skin === 'primary';
 
           // 勾选
-          reElem.on('click', function(){
+          // 通过重新赋值触发美化元素样式更新
+          check.on('click', function(e){
             var filter = check.attr('lay-filter') // 获取过滤器
 
             // 禁用
@@ -1020,7 +1021,7 @@ layui.define(['lay', 'layer', 'util'], function(exports){
             }
 
             // 开关
-            check[0].checked = !check[0].checked
+            check[0].checked = check[0].checked;
 
             // 事件
             layui.event.call(check[0], MOD_NAME, RE_CLASS[2]+'('+ filter +')', {
@@ -1029,6 +1030,13 @@ layui.define(['lay', 'layer', 'util'], function(exports){
               othis: reElem
             });
           });
+
+          reElem.on('click', function(){
+             var hasLabel = check.closest('label').length;
+             if(!hasLabel){
+              check.trigger('click');
+             }
+          })
 
           that.syncAppearanceOnPropChanged(this, 'checked', function(){
             if(isSwitch){
@@ -1131,12 +1139,18 @@ layui.define(['lay', 'layer', 'util'], function(exports){
           var radio = $(this);
           var ANIM = 'layui-anim-scaleSpring';
 
-          reElem.on('click', function(){
+          radio.on('click', function(){
             var filter = radio.attr('lay-filter'); // 获取过滤器
 
             if(radio[0].disabled) return;
 
             radio[0].checked = true;
+            var forms = radio.parents(ELEM);
+            var sameRadios = forms.find('input[name='+ radio[0].name.replace(/(\.|#|\[|\])/g, '\\$1') +']'); // 找到相同name的兄弟
+              layui.each(sameRadios, function(){
+                if(radio[0] === this)return;
+                this.checked = false;
+            });
 
             layui.event.call(radio[0], MOD_NAME, 'radio('+ filter +')', {
               elem: radio[0],
@@ -1145,17 +1159,18 @@ layui.define(['lay', 'layer', 'util'], function(exports){
             });
           });
 
+          reElem.on('click', function(){
+             var hasLabel = radio.closest('label').length;
+             if(!hasLabel){
+              radio.trigger('click');
+             }
+          })
+
           that.syncAppearanceOnPropChanged(this, 'checked', function(){
             var radioEl = this;
             if(radioEl.checked){
               reElem.addClass(CLASS + 'ed');
               reElem.children('.layui-icon').addClass(ANIM + ' ' + ICON[0]);
-              var forms = radio.parents(ELEM);
-              var sameRadios = forms.find('input[name='+ radioEl.name.replace(/(\.|#|\[|\])/g, '\\$1') +']'); // 找到相同name的兄弟
-              layui.each(sameRadios, function(){
-                if(radioEl === this)return;
-                this.checked = false;
-              });
             }else{
               reElem.removeClass(CLASS + 'ed');
               reElem.children('.layui-icon').removeClass(ANIM + ' ' + ICON[0]).addClass(ICON[1]);


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [x] 问题修复
- [ ] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容
### 关于 Checkbox/Radio 与 Label 关联时的缺陷分析及改进方案

#### 问题描述
1.  **使用 `for` 属性关联时：** 当用户点击与 `checkbox`/`radio` 元素通过 `for` 属性关联的 `label` 元素时，会触发原生 `label` 的点击行为，导致关联控件的 `checked` 状态更新一次（通过触发其原生 `click` 事件）。然而，当前组件内部依赖于视觉装饰元素（美化元素）的点击事件来同步更新状态。因此，通过 `label` 触发的状态变更未能有效驱动视觉装饰元素的样式更新，导致视觉状态与实际 `checked` 状态不一致。
2.  **使用包含关系关联时：** 当 `label` 元素直接包含 `checkbox`/`radio` 元素时，用户点击 `label` 会同时触发原生 `label` 的点击行为和视觉装饰元素的点击事件。这导致关联控件的 `checked` 状态被连续更新两次（一次由原生行为触发，一次由装饰元素事件触发），最终造成状态翻转异常，组件功能失效。

#### 解决方案
重构 `layui` 的 `checkbox`/`radio` 组件内部状态更新机制：
*   移除当前通过视觉装饰元素点击事件更新 `checkbox`/`radio` 状态（`checked` 属性）的逻辑。
*   将状态更新的控制权交还给原生 `checkbox`/`radio` 元素本身。即，仅依赖原生元素的 `click` 事件来改变其自身的 `checked` 状态。
*   组件内部监听原生元素的 `click` 事件。当原生元素的 `checked` 状态发生变更时，根据其最新的 `checked` 值，同步更新视觉装饰元素的样式，确保视觉呈现始终与底层状态一致。



### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明
