### PR TITLE
chore: 重命名` lay._createResizeObserver` 为 `lay.createSharedResizeObserver`

### DIFF
--- a/docs/versions.md
+++ b/docs/versions.md
@@ -17,30 +17,28 @@ toc: true
   <span class="layui-badge-rim" style="color: #ff5722;">预览版</span>
 </h2>
 
-> 本次更新全部由 @Sight-wcg 完成 🎉
-
 - #### 新特性
-  - 新增 i18n 模块，用于提供国际化多语言支持 #2698 @Sight-wcg
+  - 新增 i18n 模块，用于提供国际化多语言支持 #2698 @sentsim @Sight-wcg
 - #### table
-  - 新增 `ajax` 选项，用于自定义 Ajax 请求 #2752
-  - 新增 `syncFixedRowHeight` 选项，用于行高自适应时同步固定列行高 #2825
-  - 修复 checkbox/radio 列触发行事件问题 #2836
+  - 新增 `ajax` 选项，用于自定义 Ajax 请求 #2752 @Sight-wcg
+  - 新增 `syncFixedRowHeight` 选项，用于行高自适应时同步固定列行高 #2825 @Sight-wcg
+  - 修复 checkbox/radio 列触发行事件问题 #2836 @Sight-wcg
 - #### code
-  - 新增 `highlightLine` 选项，用于实现行高亮功能 #2763
+  - 新增 `highlightLine` 选项，用于实现行高亮功能 #2763 @Sight-wcg
 - #### slider
-  - 使用 component 模块重构组件，并继承其全部基础接口 #2781
+  - 使用 component 模块重构组件，并继承其全部基础接口 #2781 @Sight-wcg
 - #### dropdown
-  - 新增 同时打开多个下拉面板的功能支持 #2827
-  - 优化 目标元素尺寸变化时重新定位 #2827
-  - 优化 点击目标元素的外部区域关闭面板的逻辑 #2827
+  - 新增 同时打开多个下拉面板的功能支持 #2827 @Sight-wcg
+  - 优化 目标元素尺寸变化时重新定位 #2827 @Sight-wcg
+  - 优化 点击目标元素的外部区域关闭面板的逻辑 #2827 @Sight-wcg
 - #### form
-  - 优化 select 面板在大小出现变化时定位问题 #2824
+  - 优化 select 面板在大小出现变化时定位问题 #2824 @Sight-wcg
 - #### layer
-  - 修复 `layer.iframeAuto()` 最大高度未限制在浏览器高度内的问题 #2839
+  - 修复 `layer.iframeAuto()` 最大高度未限制在浏览器高度内的问题 #2839 @Sight-wcg
 - #### laydate
-  - 优化 左下角预览区域过渡色未与主题色保持一致的问题 #2840
+  - 优化 左下角预览区域过渡色未与主题色保持一致的问题 #2840 @Sight-wcg
 - #### nav
-  - 修复 纵向菜单出现滚动条时，滑块位置异常 #2826
+  - 修复 纵向菜单出现滚动条时，滑块位置异常 #2826 @Sight-wcg
 
 ### 下载： [layui-v2.12.0-alpha.0.zip](https://gitee.com/layui/layui/attach_files/2365521/download)
 

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -22,7 +22,7 @@ toc: true
 - #### table
   - 新增 `ajax` 选项，用于自定义 Ajax 请求 #2752 @Sight-wcg
   - 新增 `syncFixedRowHeight` 选项，用于行高自适应时同步固定列行高 #2825 @Sight-wcg
-  - 修复 checkbox/radio 列触发行事件问题 #2836 @Sight-wcg
+  - 修复 checkbox/radio 列触发行事件的问题 #2836 @Sight-wcg
 - #### code
   - 新增 `highlightLine` 选项，用于实现行高亮功能 #2763 @Sight-wcg
 - #### slider

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -38,7 +38,7 @@ toc: true
 - #### laydate
   - 优化 左下角预览区域过渡色未与主题色保持一致的问题 #2840 @Sight-wcg
 - #### nav
-  - 修复 纵向菜单出现滚动条时，滑块位置异常 #2826 @Sight-wcg
+  - 修复 纵向菜单出现滚动条时滑块位置异常的问题 #2826 @Sight-wcg
 
 ### 下载： [layui-v2.12.0-alpha.0.zip](https://gitee.com/layui/layui/attach_files/2365521/download)
 

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -18,7 +18,7 @@ toc: true
 </h2>
 
 - #### 新特性
-  - 新增 i18n 模块，用于提供国际化多语言支持 #2698 @sentsim @Sight-wcg
+  - 新增 i18n 模块，用于提供国际化多语言支持 #2698 @Sight-wcg @sentsim
 - #### table
   - 新增 `ajax` 选项，用于自定义 Ajax 请求 #2752 @Sight-wcg
   - 新增 `syncFixedRowHeight` 选项，用于行高自适应时同步固定列行高 #2825 @Sight-wcg

--- a/src/modules/dropdown.js
+++ b/src/modules/dropdown.js
@@ -21,7 +21,7 @@ layui.define(['i18n', 'jquery', 'laytpl', 'lay', 'util'], function(exports) {
   var MOD_INDEX_OPENED = MOD_INDEX + '_opened';
   var MOD_ID = 'lay-' + MOD_NAME + '-id';
 
-  var resizeObserver = lay._createResizeObserver(MOD_NAME);
+  var resizeObserver = lay.createSharedResizeObserver(MOD_NAME);
 
   // 外部接口
   var dropdown = {

--- a/src/modules/form.js
+++ b/src/modules/form.js
@@ -22,7 +22,7 @@ layui.define(['lay', 'i18n', 'layer', 'util'], function(exports){
   var OUT_OF_RANGE = 'layui-input-number-out-of-range';
   var BAD_INPUT = 'layui-input-number-invalid';
 
-  var resizeObserver = lay._createResizeObserver(MOD_NAME);
+  var resizeObserver = lay.createSharedResizeObserver(MOD_NAME);
 
   // ie8 中可以获取到 input 元素的 'indeterminate' 属性描述符，但重新定义 getter/setter 无效，无报错
   // AppleWebKit/537.36 无法获取 input 元素任意属性的属性描述符(包括lookupGetter)，但可以重新定义 getter/setter

--- a/src/modules/lay.js
+++ b/src/modules/lay.js
@@ -838,8 +838,8 @@
 
   /**
    * 生成唯一的 ID 字符串
-   * @param {string} prefix ID前缀，默认为'id'
-   * @returns {string} 唯一ID字符串
+   * @param {string} prefix ID 前缀，默认为'id'
+   * @returns {string} 唯一 ID 字符串
    */
   var generateUniqueId = (function () {
     var counter = 0;
@@ -858,7 +858,7 @@
         lastTimestamp = timestamp;
       }
 
-      // 结合时间戳、随机数和计数器生成ID
+      // 结合时间戳、随机数和计数器生成 ID
       var random = Math.floor(Math.random() * 10000);
 
       return prefix + '-' + timestamp + '-' + random + '-' + counter;
@@ -866,16 +866,17 @@
   })();
 
   /**
-   * 创建全局 ResizeObserver 实例
+   * 创建共享的 ResizeObserver 实例
    * @param {string} namespace 命名空间，用于区分不同的 ResizeObserver 实例
-   * @returns {ResizeObserver | null} 全局 ResizeObserver 实例或 null（如果不支持）
+   * @returns {ResizeObserver | null} ResizeObserver 实例或 null（如果不支持）
    */
-  lay._createResizeObserver = function (namespace) {
+  lay.createSharedResizeObserver = function (namespace) {
     if (typeof window.ResizeObserver === 'undefined') {
-      window.console && console.log('ResizeObserver is not supported in this browser');
+      window.console && console.log('ResizeObserver is not supported in this browser.');
       return null;
     }
 
+    namespace = namespace || '';
     var ATTR_NAME = 'lay-' + namespace + '-resizeobserver-key';
     var handlerCache = {};
 
@@ -895,7 +896,7 @@
     return Object.freeze({
       observe: function (element, callback) {
         if (!element || !(element instanceof Element)) {
-          window.console && console.log('createResizeObserver: Cannot observe non-Element.');
+          window.console && console.log('createSharedResizeObserver: Cannot observe non-Element.');
           return;
         }
 
@@ -911,7 +912,7 @@
       },
       unobserve: function (element) {
         if (!element || !(element instanceof Element)) {
-          window.console && console.log('createResizeObserver: Cannot unobserve non-Element.');
+          window.console && console.log('createSharedResizeObserver: Cannot unobserve non-Element.');
           return;
         }
 

--- a/src/modules/table.js
+++ b/src/modules/table.js
@@ -155,7 +155,7 @@ layui.define(['lay', 'i18n', 'laytpl', 'laypage', 'form', 'util'], function(expo
 
   var DATA_MOVE_NAME = 'LAY_TABLE_MOVE_DICT';
 
-  var resizeObserver = lay._createResizeObserver(MOD_NAME);
+  var resizeObserver = lay.createSharedResizeObserver(MOD_NAME);
 
   // thead 区域模板
   var TPL_HEADER = function(options){


### PR DESCRIPTION
…ver`

### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [ ] 问题修复
- [ ] 功能优化
- [ ] 分支合并
- [x] 其他改动：重命名

### 🌱 本次 PR 的变化内容

- chore: 重命名` lay._createResizeObserver` 为 `lay.createSharedResizeObserver`


### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明
