### PR TITLE
fix(layer): 修复 layer.tips 在触发元素宽度较小时的定位

### DIFF
--- a/src/modules/layer.js
+++ b/src/modules/layer.js
@@ -693,7 +693,8 @@ Class.pt.tips = function(){
       goal.tipLeft = goal.left + goal.width - layArea[0];
       tipsG.css({right: 12, left: 'auto'});
     } else {
-      goal.tipLeft = goal.left;
+      goal.tipLeft = goal.left - (goal.width * 0.75 < 21 ? 21 - goal.width * 0.5 : 0);
+      goal.tipLeft = Math.max(goal.tipLeft, 0);
     }
   };
 


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [x] 问题修复
- [ ] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

使用 https://github.com/layui/layui/pull/1439 中的方案，修复 layer.tips 在触发元素宽度较小时的定位问题。当时没有注意到这个问题。

close #2866

https://stackblitz.com/edit/lfpyngkn?file=index.html
   

### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明
