### PR TITLE
fix(laydate): 优化 `lang: 'en'` 时的报错提示

### DIFF
--- a/src/modules/i18n.js
+++ b/src/modules/i18n.js
@@ -329,10 +329,11 @@ layui.define('lay', function(exports) {
     var locale = (options && options.locale) || config.locale;
     var i18nMessages = config.messages[locale];
     var namespace = locale + ':';
-    var fallbackMessage = (options && lay.hasOwn(options, 'default')) ? options.default : undefined;
+    var hasDefault = options && lay.hasOwn(options, 'default');
+    var fallbackMessage = hasDefault ? options.default : undefined;
 
-    if (!i18nMessages) {
-      hint.errorOnce("Locale '" + locale + "' not found. Please add i18n messages for this locale first.", 'error');
+    if (!i18nMessages && !hasDefault) {
+      hint.errorOnce("Locale '" + locale + "' not found. Please add i18n messages for this locale first.", 'warn');
     }
 
     var result = resolveValue(namespace + keypath, i18nMessages, fallbackMessage);

--- a/src/modules/laydate.js
+++ b/src/modules/laydate.js
@@ -264,7 +264,8 @@ layui.define(['lay', 'i18n'], function(exports) {
         })
       },
       monthBeforeYear: i18n.$t('laydate.monthBeforeYear', null, {
-        locale: locale
+        locale: locale,
+        default: null
       }),
       selectDate: i18n.$t('laydate.selectDate', null, {
         locale: locale,
@@ -1067,7 +1068,7 @@ layui.define(['lay', 'i18n'], function(exports) {
         that.hint(
           lang.formatErrorPrompt(
             options.range ? (options.format + ' '+ that.rangeStr +' ' + options.format) : options.format
-          ) + 
+          ) +
           lang.autoResetPrompt
         );
         error = true;
@@ -1916,7 +1917,7 @@ layui.define(['lay', 'i18n'], function(exports) {
             disabledType: 'datetime' // 按钮，检测日期和时间
           });
         }
-        
+
         that.setBtnStatus(); //同步按钮可点状态
 
         //若为月选择器，只有当选择月份时才自动关闭；


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [ ] 问题修复
- [x] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

**之前：**

`laydate.render({ lang: 'en' })` 页面报错提示：
<img width="572" height="30" alt="image" src="https://github.com/user-attachments/assets/7ef5f71c-bbe6-4c35-9dbd-804b006fdc33" />

该提示由 i18n 抛出，在一般场景上是合理的，而在 laydate 设置 `lang: 'en'` 中容易引起困惑。

**之后：**

- 约定规则：如果 i18n.$t 传递了 `default` 选项，则不抛出提示，因为本身可输出默认值。
- 将 `Locale {*} not found` 的提示由 `console.error` 改为 `console.warn`

<img width="578" height="28" alt="image" src="https://github.com/user-attachments/assets/6594608e-2be8-48d7-95dc-17d770c72225" />


### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明
