### PR TITLE
style: 优化 font-family, 让页面字体更清晰均匀

### DIFF
--- a/src/css/layui.css
+++ b/src/css/layui.css
@@ -89,12 +89,8 @@ body {
   color: rgba(0, 0, 0, 0.85);
   font-size: 14px;
   font-family:
-    Helvetica Neue,
-    Helvetica,
-    PingFang SC,
-    Tahoma,
-    Arial,
-    sans-serif;
+    -apple-system, BlinkMacSystemFont, system-ui, "Segoe UI", "PingFang SC",
+    "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 hr {
   height: 0;
@@ -2194,7 +2190,7 @@ hr.layui-border-black {
   display: inline-block;
   vertical-align: middle;
   height: 38px;
-  line-height: 38px;
+  line-height: 36px;
   border: 1px solid transparent;
   padding: 0 18px;
   background-color: #16baaa;
@@ -2288,21 +2284,21 @@ hr.layui-border-black {
 /* 大型 */
 .layui-btn-lg {
   height: 44px;
-  line-height: 44px;
+  line-height: 42px;
   padding: 0 25px;
   font-size: 16px;
 }
 /* 小型 */
 .layui-btn-sm {
   height: 30px;
-  line-height: 30px;
+  line-height: 28px;
   padding: 0 10px;
   font-size: 12px;
 }
 /* 超小 */
 .layui-btn-xs {
   height: 22px;
-  line-height: 22px;
+  line-height: 20px;
   padding: 0 5px;
   font-size: 12px;
 }


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [ ] 问题修复
- [x] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- 优化 font-family, 让页面字体更清晰均匀。
优先采用系统字体，减少不同语言环境中的字体差异 ( resolves #2894 )

之前：

<img width="841" height="195" alt="image" src="https://github.com/user-attachments/assets/2beac3d9-5831-4f09-9880-9eb2fe2fc399" />

之后：

<img width="830" height="198" alt="image" src="https://github.com/user-attachments/assets/07b8c5d5-c287-4337-acc8-70d6e1e060a9" />

### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明
