### PR TITLE
fix: 修复 menu 菜单标题若存在嵌套元素时未溢出隐藏的问题

### DIFF
--- a/src/css/layui.css
+++ b/src/css/layui.css
@@ -4241,6 +4241,8 @@ body .layui-table-tips .layui-layer-content {
 .layui-menu-body-title a {
   display: block;
   margin: -5px -15px;
+  overflow: hidden;
+  text-overflow: ellipsis;
   color: rgba(0, 0, 0, 0.8);
 }
 .layui-menu-body-title a:hover {


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [x] 问题修复
- [ ] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

**之前：**

<img width="394" height="185" alt="image" src="https://github.com/user-attachments/assets/83a7eec4-afe9-41b0-8ca4-82707cdd41c4" />

**之后：**

<img width="386" height="143" alt="image" src="https://github.com/user-attachments/assets/468c9f1a-ed1e-40a3-98eb-232f438f85ab" />

### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明
