### PR TITLE
fix(colorpicker): 规范化 done 回调颜色值

### DIFF
--- a/src/modules/colorpicker.js
+++ b/src/modules/colorpicker.js
@@ -773,9 +773,12 @@ layui.define(['i18n', 'component'], function (exports) {
 
       //确认
       confirm: function (othis, change) {
-        var value = $.trim(elemPickerInput.val()),
-          colorValue,
-          hsb;
+        var value = $.trim(elemPickerInput.val());
+        var type = elemColorBoxSpan.attr('lay-type');
+        var colorValue;
+        var hsb;
+        var rgb;
+        var alpha;
 
         if (value.indexOf(',') > -1) {
           hsb = RGBToHSB(RGBSTo(value));
@@ -785,13 +788,14 @@ layui.define(['i18n', 'component'], function (exports) {
 
           if (
             (value.match(/[0-9]{1,3}/g) || []).length > 3 &&
-            elemColorBoxSpan.attr('lay-type') === 'rgba'
+            type === 'rgba'
           ) {
-            var left =
-              value.slice(value.lastIndexOf(',') + 1, value.length - 1) * 280;
+            alpha = parseFloat(
+              value.slice(value.lastIndexOf(',') + 1, value.length - 1)
+            );
             that.elemPicker
               .find('.' + CONST.PICKER_ALPHA_SLIDER)
-              .css('left', left);
+              .css('left', alpha * 280);
             elemColorBoxSpan[0].style.background = value;
             colorValue = value;
           }
@@ -810,9 +814,28 @@ layui.define(['i18n', 'component'], function (exports) {
           options.change && options.change(colorValue);
           return;
         }
-        that.color = value;
 
-        options.done && options.done(value);
+        // 按 format 规范化最终输出颜色值，保证 done 回调与 format 配置一致
+        rgb = HSBToRGB(hsb);
+        if (type === 'rgba') {
+          colorValue =
+            'rgba(' +
+            rgb.r +
+            ', ' +
+            rgb.g +
+            ', ' +
+            rgb.b +
+            ', ' +
+            (alpha === undefined ? 1 : alpha) +
+            ')';
+        } else if (type === 'torgb') {
+          colorValue = 'rgb(' + rgb.r + ', ' + rgb.g + ', ' + rgb.b + ')';
+        } else {
+          colorValue = '#' + HSBToHEX(hsb);
+        }
+        that.color = colorValue;
+
+        options.done && options.done(colorValue);
         that.removePicker();
       }
     };


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [x] 问题修复
- [ ] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- fix(colorpicker): 手动输入颜色时 done 回调颜色值未套用 format 选项的格式的问题  close #3041

  - 在调用 done 前，按 lay-type 将颜色规范化
  - that.color 同步存为规范化后的值，与 done 接收到的值保持一致
  - change 保持原有行为，不引入额外的兼容性变化

### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明
