### PR TITLE
fix: 修复 `lay.flatToTree` 对缺少 children 的数据项无法转树的问题

### DIFF
--- a/src/modules/lay.js
+++ b/src/modules/lay.js
@@ -1168,8 +1168,8 @@
     var map = data.reduce(function (acc, currNode) {
       var id = currNode[options.idKey];
       acc[id] = currNode;
-      // 给当前节点已有的 childrenKey 数组初始化为空数组
-      if (Array.isArray(currNode[options.childrenKey])) {
+      // 给当前节点已有的 childrenKey 初始化为空数组
+      if (options.childrenKey in currNode) {
         acc[id][options.childrenKey] = [];
       }
       return acc;
@@ -1191,16 +1191,12 @@
         // 若为子节点，则添加到对应父节点的 childrenKey 中
         var parentNode = map[parentId];
 
-        // 若父节点不存在 childrenKey 属性，则初设一个空数组
-        if (!parentNode[options.childrenKey]) {
+        // 若父节点的 childrenKey 不是数组,则初设一个空数组
+        if (!Array.isArray(parentNode[options.childrenKey])) {
           parentNode[options.childrenKey] = [];
         }
 
-        var parentNodeChildren = parentNode[options.childrenKey];
-
-        if (Array.isArray(parentNodeChildren)) {
-          parentNodeChildren.push(currNode);
-        }
+        parentNode[options.childrenKey].push(currNode);
       }
 
       return acc;

--- a/src/modules/lay.js
+++ b/src/modules/lay.js
@@ -1168,6 +1168,7 @@
     var map = data.reduce(function (acc, currNode) {
       var id = currNode[options.idKey];
       acc[id] = currNode;
+      // 给当前节点已有的 childrenKey 数组初始化为空数组
       if (Array.isArray(currNode[options.childrenKey])) {
         acc[id][options.childrenKey] = [];
       }
@@ -1187,8 +1188,16 @@
       if (parentId === null || !map[parentId]) {
         acc.push(map[id]);
       } else {
-        // 若为子节点，则添加到父节点的 childrenKey 中
-        var parentNodeChildren = map[parentId][options.childrenKey];
+        // 若为子节点，则添加到对应父节点的 childrenKey 中
+        var parentNode = map[parentId];
+
+        // 若父节点不存在 childrenKey 属性，则初设一个空数组
+        if (!parentNode[options.childrenKey]) {
+          parentNode[options.childrenKey] = [];
+        }
+
+        var parentNodeChildren = parentNode[options.childrenKey];
+
         if (Array.isArray(parentNodeChildren)) {
           parentNodeChildren.push(currNode);
         }


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [x] 问题修复
- [ ] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- resolves #3052

### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [ ] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [ ] 已对每一项的改动均测试通过
- [ ] 已提供具体的变化内容说明


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 增强了树形数据结构生成的稳定性，改进了数据节点间的关联处理机制，提高了系统在处理复杂数据场景时的可靠性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/layui/layui/pull/3060?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->