### PR TITLE
refactor: 重构 dropdown 组件

### DIFF
--- a/src/components/dropdown.js
+++ b/src/components/dropdown.js
@@ -6,812 +6,661 @@
 import { lay } from '../core/lay.js';
 import { i18n } from '../core/i18n.js';
 import { $ } from 'jquery';
-import { laytpl } from '../core/laytpl.js';
+import { Component } from '../core/component.js';
 
-var device = lay.device();
-var clickOrMousedown = device.mobile ? 'touchstart' : 'mousedown';
+const device = lay.device();
+const clickOrMousedown = device.mobile ? 'touchstart' : 'mousedown';
 
-// 模块名
-var MOD_NAME = 'dropdown';
-var MOD_INDEX = 'layui_' + MOD_NAME + '_index'; // 模块索引名
-var MOD_INDEX_OPENED = MOD_INDEX + '_opened';
-var MOD_ID = 'lay-' + MOD_NAME + '-id';
+export class Dropdown extends Component {
+  // 默认配置项
+  static options = {
+    trigger: 'click', // 事件类型
+    data: [], // 菜单数据结构
+    isAllowSpread: true, // 是否允许菜单组展开收缩
+    isSpreadItem: true, // 是否初始展开子菜单
+    closeOnClick: true, // 面板打开后，再次点击目标元素时是否关闭面板。行为取决于所使用的触发事件类型
+    delay: [200, 300], // 延时显示或隐藏的毫秒数，若为 number 类型，则表示显示和隐藏的延迟时间相同，trigger 为 hover 时才生效
+    // content: '', // 自定义菜单内容
+    // className: '', // 自定义样式类名
+    // style: '', // 设置面板 style 属性
+    // defaultOpen: false, // 是否初始默认打开菜单面板
+    // isAccordion: false, // 是否开启菜单展开收缩的手风琴效果，仅菜单组生效。基础菜单需在容器上追加 `lay-accordion` 属性。
+    // shade: 0, // 遮罩
 
-var resizeObserver = lay.createSharedResizeObserver(MOD_NAME);
-
-// 外部接口
-var dropdown = {
-  config: {
+    // 自定义 data 字段名
     customName: {
-      // 自定义 data 字段名
       id: 'id',
       title: 'title',
-      children: 'child',
+      children: 'children',
     },
-  },
+  };
 
-  // 设置全局项
-  set: function (options) {
-    var that = this;
-    that.config = $.extend({}, that.config, options);
-    return that;
-  },
+  static get CONST() {
+    const consts = {
+      ...super.CONST,
+      ELEM: 'lay-dropdown',
+      ELEM_ITEM_UP: 'lay-menu-item-up',
+      ELEM_ITEM_DOWN: 'lay-menu-item-down',
+      ELEM_MENU_TITLE: 'lay-menu-body-title',
+      ELEM_ITEM_GROUP: 'lay-menu-item-group',
+      ELEM_ITEM_PARENT: 'lay-menu-item-parent',
+      ELEM_ITEM_DIV: 'lay-menu-item-divider',
+      ELEM_ITEM_CHECKED: 'lay-menu-item-checked',
+      ELEM_ITEM_CHECKED2: 'lay-menu-item-checked2',
+      ELEM_MENU_PANEL: 'lay-menu-body-panel',
+      ELEM_MENU_PANEL_L: 'lay-menu-body-panel-left',
+      ELEM_ELEM_SHADE: 'lay-dropdown-shade',
+    };
+
+    consts.ELEM_GROUP_TITLE = `.${consts.ELEM_ITEM_GROUP}>.${consts.ELEM_MENU_TITLE}`;
+
+    return consts;
+  }
+
+  // 关闭面板
+  static close(id) {
+    const inst = this.getInst(id);
+    if (!inst) return;
+
+    inst.remove();
+  }
+
+  // 打开面板
+  static open(id) {
+    const inst = this.getInst(id);
+    if (!inst) return;
+
+    inst.open();
+  }
+
+  // 仅重载数据
+  static reloadData(...args) {
+    // 重载时，过滤与数据无关的选项
+    const dataParams = new RegExp('^(data|template|content)$');
+    Object.keys(args[1] || {}).forEach((key) => {
+      if (!dataParams.test(key)) {
+        delete args[1][key];
+      }
+    });
+
+    args[1] = { ...args[1], _renderMode: 'reloadData' };
+
+    return this.reload(...args);
+  }
+
+  // 构造函数
+  constructor(options) {
+    super({
+      target: 'body', // 目标对象。非文档化选项
+      ...options,
+    });
+
+    Object.assign(this.options, {
+      $target: $(this.options.target),
+    });
+
+    this.stopClickOutsideEvent = $.noop;
+    this.stopResizeEvent = $.noop;
+  }
+
+  // 渲染
+  render() {
+    const options = this.options;
+
+    // 若传入 hover，则解析为 mouseenter
+    if (options.trigger === 'hover') {
+      options.trigger = 'mouseenter';
+    }
+
+    this.#events(); // 事件
+
+    // 初始打开面板的条件
+    if (options.defaultOpen || this.#isRootElemMounted()) {
+      this.open();
+    }
+  }
+
+  // 打开下拉菜单
+  open() {
+    const options = this.options;
+    const customName = options.customName;
+
+    // 默认菜单内容
+    const getDefaultView = () => {
+      const $elemUl = $('<ul class="lay-menu lay-dropdown-menu"></ul>');
+      if (options.data?.length > 0) {
+        eachItemView($elemUl, options.data);
+      } else {
+        $elemUl.html(
+          `<li class="lay-menu-item-none">${i18n.$t('dropdown.noData')}</li>`,
+        );
+      }
+      return $elemUl;
+    };
+
+    // 遍历菜单项
+    const eachItemView = ($views, data) => {
+      data.forEach((item) => {
+        // 是否存在子级
+        const isChild =
+          item[customName.children] && item[customName.children].length > 0;
+        const isSpreadItem =
+          'isSpreadItem' in item ? item.isSpreadItem : options.isSpreadItem;
+        const title = ((titleValue) => {
+          const template = item.template || options.template;
+          if (typeof template === 'function') {
+            titleValue = template.call(item, item);
+          }
+          return titleValue;
+        })(lay.escape(item[customName.title]));
+
+        // 初始类型
+        const type = (() => {
+          if (isChild) {
+            item.type = item.type || 'parent';
+          }
+          if (item.type) {
+            return (
+              {
+                group: 'group',
+                parent: 'parent',
+                '-': '-',
+              }[item.type] || 'parent'
+            );
+          }
+          return '';
+        })();
+
+        if (
+          type !== '-' &&
+          !item[customName.title] &&
+          !item[customName.id] &&
+          !isChild
+        )
+          return;
+
+        //列表元素
+        const className = {
+          group: `lay-menu-item-group${
+            options.isAllowSpread
+              ? isSpreadItem
+                ? ' lay-menu-item-down'
+                : ' lay-menu-item-up'
+              : ''
+          }`,
+          parent: CONST.ELEM_ITEM_PARENT,
+          '-': 'lay-menu-item-divider',
+        };
+        const liClass =
+          isChild || type
+            ? className[type]
+            : item.disabled
+              ? CONST.CLASS_DISABLED
+              : '';
+        const viewText =
+          'href' in item
+            ? `<a href="${item.href}" target="${item.target || '_self'}">${title}</a>`
+            : title;
+        const suffixIcon = (() => {
+          if (type === 'parent') {
+            return '<i class="lay-icon lay-icon-right"></i>';
+          }
+
+          if (type === 'group' && options.isAllowSpread) {
+            return `<i class="lay-icon lay-icon-${isSpreadItem ? 'up' : 'down'}"></i>`;
+          }
+
+          return '';
+        })();
+        const titleHtml = `<div class="${CONST.ELEM_MENU_TITLE}">${viewText}${
+          isChild ? suffixIcon : ''
+        }</div>`;
+        const $viewLi = $(`
+          <li${liClass ? ` class="${liClass}"` : ''}>
+            ${titleHtml}
+          </li>
+        `);
+
+        $viewLi.data('item', item);
+
+        // 子级区
+        if (isChild) {
+          const $elemPanel = $(
+            '<div class="lay-panel lay-menu-body-panel"></div>',
+          );
+          const $elemUl = $('<ul></ul>');
+
+          if (type === 'parent') {
+            $elemPanel.append(eachItemView($elemUl, item[customName.children]));
+            $viewLi.append($elemPanel);
+          } else {
+            $viewLi.append(eachItemView($elemUl, item[customName.children]));
+          }
+        }
+
+        $views.append($viewLi);
+      });
+      return $views;
+    };
+
+    // 主模板
+    let $rootElem = $(
+      `<div class="lay-dropdown lay-border-box lay-panel lay-anim lay-anim-downbit"></div>`,
+    );
+
+    // 面板内容
+    const content = options.content || getDefaultView();
+
+    // 是否仅重载数据
+    if (options._renderMode === 'reloadData' && this.#isRootElemMounted()) {
+      $rootElem = this.$rootElem;
+      this.$rootElem.html(content);
+    } else {
+      // 常规渲染
+      $rootElem.append(content); // 填充内容
+
+      // 初始化某些属性
+      $rootElem.addClass(options.className).attr('style', options.style);
+
+      // 生成面板
+      this.remove(); // 移除旧面板
+      options.$target.append($rootElem); // 插入新面板
+      this.$rootElem = $rootElem;
+
+      // 生成遮罩
+      const shade = options.shade
+        ? `<div class="${CONST.ELEM_ELEM_SHADE}" style="z-index:${
+            $rootElem.css('z-index') - 1
+          }; background-color: ${options.shade[1] || '#000'}; opacity: ${
+            options.shade[0] || options.shade
+          }"></div>`
+        : '';
+      const $shadeElem = $(shade);
+      // 处理移动端点击穿透问题
+      if (clickOrMousedown === 'touchstart') {
+        $shadeElem.on(clickOrMousedown, (e) => {
+          e.preventDefault();
+        });
+      }
+      $rootElem.before($shadeElem);
+
+      // 如果是鼠标移入事件，则鼠标移出时自动关闭
+      if (options.trigger === 'mouseenter') {
+        $rootElem
+          .on('mouseenter', () => {
+            clearTimeout(this.timer);
+          })
+          .on('mouseleave', () => {
+            this.#delayRemove();
+          });
+      }
+    }
+
+    this.#position(); // 定位坐标
+
+    // 阻止全局事件
+    $rootElem.find('.lay-menu').on(clickOrMousedown, (e) => {
+      e.stopPropagation();
+    });
+
+    // 触发菜单列表事件
+    $rootElem.find('.lay-menu li').on('click', (e) => {
+      const $this = $(e.currentTarget);
+      const data = $this.data('item') || {};
+      const isChild =
+        data[customName.children] && data[customName.children].length > 0;
+      const isClickAllScope = options.clickScope === 'all'; // 是否所有父子菜单均触发点击事件
+
+      if (data.disabled) return; // 菜单项禁用状态
+
+      // 普通菜单项点击后的回调及关闭面板
+      if ((!isChild || isClickAllScope) && data.type !== '-') {
+        const ret =
+          typeof options.click === 'function'
+            ? options.click(data, $this, e)
+            : null;
+
+        ret === false || isChild || this.remove();
+        e.stopPropagation();
+      }
+    });
+
+    // 触发菜单组展开收缩
+    $rootElem.find(CONST.ELEM_GROUP_TITLE).on('click', (e) => {
+      const $this = $(e.currentTarget);
+      const $groupElem = $this.parent();
+      const data = $groupElem.data('item') || {};
+
+      if (data.type === 'group' && options.isAllowSpread) {
+        toggleMenuGroup($groupElem, options.isAccordion);
+      }
+    });
+
+    this.#onClickOutside();
+    this.#autoUpdatePosition();
+
+    // 组件打开完毕的事件
+    options.ready?.(options, $rootElem);
+  }
+
+  // 移除面板
+  remove() {
+    const options = this.options;
+    const $rootElem = this.$rootElem;
+
+    this.stopClickOutsideEvent();
+    this.stopResizeEvent();
+
+    // 若存在已打开的面板元素，则移除
+    if (this.#isRootElemMounted()) {
+      $rootElem.prev(`.${CONST.ELEM_ELEM_SHADE}`).remove(); // 先移除遮罩
+      $rootElem.remove(); // 再移除面板
+
+      // 组件关闭完毕的回调
+      options.close?.(options);
+    }
+
+    delete this.$rootElem; // 移除面板根节点的引用
+    delete options._renderMode; // 移除私有选项
+  }
+
+  // 面板元素是否已存在于目标元素中
+  #isRootElemMounted() {
+    const options = this.options;
+    const $rootElem = this.$rootElem;
+
+    return $rootElem && options.$target[0]?.contains($rootElem[0]);
+  }
+
+  // 位置定位
+  #position() {
+    const options = this.options;
+
+    lay.position(options.$elem[0], this.$rootElem[0], {
+      position: options.position,
+      e: this.e,
+      clickType: options.trigger === 'contextmenu' ? 'right' : null,
+      align: options.align || null,
+    });
+  }
+
+  #normalizedDelay() {
+    const options = this.options;
+    const delay = [].concat(options.delay);
+
+    return {
+      show: delay[0],
+      hide: delay[1] !== undefined ? delay[1] : delay[0],
+    };
+  }
+
+  // 延迟移除面板
+  #delayRemove() {
+    clearTimeout(this.timer);
+
+    this.timer = setTimeout(() => {
+      this.remove();
+    }, this.#normalizedDelay().hide);
+  }
 
   // 事件
-  on: function (events, callback) {
-    return lay.onevent.call(this, MOD_NAME, events, callback);
-  },
-};
+  #events() {
+    const options = this.options;
+    const $elem = options.$elem;
 
-// 操作当前实例
-var thisModule = function () {
-  var that = this;
-  var options = that.config;
-  var id = options.id;
+    // 是否鼠标移入时触发
+    const isMouseEnter = options.trigger === 'mouseenter';
+    const eventNamespace = '.lay_dropdown_render';
+    const trigger = `${options.trigger}${eventNamespace}`;
 
-  return {
-    config: options,
-    // 重置实例
-    reload: function (options) {
-      that.reload.call(that, options);
-    },
-    reloadData: function (options) {
-      dropdown.reloadData(id, options);
-    },
-    close: function () {
-      that.remove();
-    },
-    open: function () {
-      that.render();
-    },
-  };
-};
+    // 始终先解除上一个触发元素的事件（如重载时改变 elem 的情况）
+    this.$activeElem?.off(eventNamespace);
+    $elem.off(eventNamespace);
+    this.$activeElem = $elem;
 
-// 字符常量
-var STR_ELEM = 'lay-dropdown';
-// var STR_HIDE = 'lay-hide';
-var STR_DISABLED = 'lay-disabled';
-// var STR_NONE = 'lay-none';
-var STR_ITEM_UP = 'lay-menu-item-up';
-var STR_ITEM_DOWN = 'lay-menu-item-down';
-var STR_MENU_TITLE = 'lay-menu-body-title';
-var STR_ITEM_GROUP = 'lay-menu-item-group';
-var STR_ITEM_PARENT = 'lay-menu-item-parent';
-var STR_ITEM_DIV = 'lay-menu-item-divider';
-var STR_ITEM_CHECKED = 'lay-menu-item-checked';
-var STR_ITEM_CHECKED2 = 'lay-menu-item-checked2';
-var STR_MENU_PANEL = 'lay-menu-body-panel';
-var STR_MENU_PANEL_L = 'lay-menu-body-panel-left';
-var STR_ELEM_SHADE = 'lay-dropdown-shade';
+    // 触发元素事件
+    $elem.on(trigger, (e) => {
+      clearTimeout(this.timer);
+      this.e = e;
 
-var STR_GROUP_TITLE = '.' + STR_ITEM_GROUP + '>.' + STR_MENU_TITLE;
+      // 主面板是否已打开
+      const opened = this.#isRootElemMounted();
 
-// 构造器
-var Class = function (options) {
-  var that = this;
-  that.index = dropdown.index = lay.autoIncrementer('dropdown');
-  that.config = $.extend({}, that.config, dropdown.config, options);
-  that.stopClickOutsideEvent = $.noop;
-  that.stopResizeEvent = $.noop;
-  that.init();
-};
-
-// 默认配置
-Class.prototype.config = {
-  trigger: 'click', // 事件类型
-  content: '', // 自定义菜单内容
-  className: '', // 自定义样式类名
-  style: '', // 设置面板 style 属性
-  show: false, // 是否初始即显示菜单面板
-  isAllowSpread: true, // 是否允许菜单组展开收缩
-  isSpreadItem: true, // 是否初始展开子菜单
-  data: [], // 菜单数据结构
-  delay: [200, 300], // 延时显示或隐藏的毫秒数，若为 number 类型，则表示显示和隐藏的延迟时间相同，trigger 为 hover 时才生效
-  shade: 0, // 遮罩
-  accordion: false, // 手风琴效果，仅菜单组生效。基础菜单需要在容器上追加 'lay-accordion' 属性。
-  closeOnClick: true, // 面板打开后，再次点击目标元素时是否关闭面板。行为取决于所使用的触发事件类型
-};
-
-// 重载实例
-Class.prototype.reload = function (options, type) {
-  var that = this;
-  that.config = $.extend({}, that.config, options);
-  that.init(true, type);
-};
-
-// 初始化准备
-Class.prototype.init = function (rerender, type) {
-  var that = this;
-  var options = that.config;
-
-  // 若 elem 非唯一
-  var elem = $(options.elem);
-  if (elem.length > 1) {
-    elem.each(function () {
-      dropdown.render(
-        $.extend({}, options, {
-          elem: this,
-        }),
-      );
-    });
-    return that;
-  }
-
-  // 合并 lay-options 属性上的配置信息
-  $.extend(options, lay.options(elem[0]));
-
-  // 若重复执行 render，则视为 reload 处理
-  if (!rerender && elem.attr(MOD_ID)) {
-    var newThat = thisModule.getThis(elem.attr(MOD_ID));
-    if (!newThat) return;
-    return newThat.reload(options, type);
-  }
-
-  options.elem = $(options.elem);
-  options.target = $('body'); // 后续考虑开放 target 元素
-
-  // 初始化 id 属性 - 优先取 options > 元素 id > 自增索引
-  options.id = 'id' in options ? options.id : elem.attr('id') || that.index;
-
-  thisModule.that[options.id] = that; // 记录当前实例对象
-  elem.attr(MOD_ID, options.id); // 目标元素已渲染过的标记
-
-  // 初始化自定义字段名
-  options.customName = $.extend(
-    {},
-    dropdown.config.customName,
-    options.customName,
-  );
-
-  // 若传入 hover，则解析为 mouseenter
-  if (options.trigger === 'hover') {
-    options.trigger = 'mouseenter';
-  }
-
-  // 初始即显示或者面板弹出之后执行了刷新数据
-  if (
-    options.show ||
-    (type === 'reloadData' &&
-      that.mainElem &&
-      options.target.find(that.mainElem.get(0)).length)
-  )
-    that.render(type);
-
-  // 若面板已经打开，则无需再绑定目标元素事件，避免 render 重复执行
-  if (!elem.data(MOD_INDEX_OPENED)) {
-    that.events(); // 事件
-  }
-};
-
-// 渲染
-Class.prototype.render = function (type) {
-  var that = this;
-  var options = that.config;
-  var customName = options.customName;
-
-  // 默认菜单内容
-  var getDefaultView = function () {
-    var elemUl = $('<ul class="lay-menu lay-dropdown-menu"></ul>');
-    if (options.data.length > 0) {
-      eachItemView(elemUl, options.data);
-    } else {
-      elemUl.html(
-        '<li class="lay-menu-item-none">' +
-          i18n.$t('dropdown.noData') +
-          '</li>',
-      );
-    }
-    return elemUl;
-  };
-
-  // 遍历菜单项
-  var eachItemView = function (views, data) {
-    // var views = [];
-
-    data.forEach(function (item) {
-      // 是否存在子级
-      var isChild =
-        item[customName.children] && item[customName.children].length > 0;
-      var isSpreadItem =
-        'isSpreadItem' in item ? item.isSpreadItem : options.isSpreadItem;
-      var title = (function (title) {
-        var templet = item.templet || options.templet;
-        if (templet) {
-          title =
-            typeof templet === 'function'
-              ? templet(item)
-              : laytpl(templet).render(item);
+      // 若为鼠标移入事件，则延迟触发
+      if (isMouseEnter) {
+        if (!opened) {
+          this.timer = setTimeout(() => {
+            this.open();
+          }, this.#normalizedDelay().show);
         }
-        return title;
-      })(lay.escape(item[customName.title]));
-
-      // 初始类型
-      var type = (function () {
-        if (isChild) {
-          item.type = item.type || 'parent';
-        }
-        if (item.type) {
-          return (
-            {
-              group: 'group',
-              parent: 'parent',
-              '-': '-',
-            }[item.type] || 'parent'
-          );
-        }
-        return '';
-      })();
-
-      if (
-        type !== '-' &&
-        !item[customName.title] &&
-        !item[customName.id] &&
-        !isChild
-      )
-        return;
-
-      //列表元素
-      var viewLi = $(
-        [
-          '<li' +
-            (function () {
-              var className = {
-                group:
-                  'lay-menu-item-group' +
-                  (options.isAllowSpread
-                    ? isSpreadItem
-                      ? ' lay-menu-item-down'
-                      : ' lay-menu-item-up'
-                    : ''),
-                parent: STR_ITEM_PARENT,
-                '-': 'lay-menu-item-divider',
-              };
-              if (isChild || type) {
-                return ' class="' + className[type] + '"';
-              }
-              return item.disabled ? ' class="' + STR_DISABLED + '"' : '';
-            })() +
-            '>',
-          //标题区
-          (function () {
-            //是否超文本
-            var viewText =
-              'href' in item
-                ? '<a href="' +
-                  item.href +
-                  '" target="' +
-                  (item.target || '_self') +
-                  '">' +
-                  title +
-                  '</a>'
-                : title;
-
-            //是否存在子级
-            if (isChild) {
-              return (
-                '<div class="' +
-                STR_MENU_TITLE +
-                '">' +
-                viewText +
-                (function () {
-                  if (type === 'parent') {
-                    return '<i class="lay-icon lay-icon-right"></i>';
-                  } else if (type === 'group' && options.isAllowSpread) {
-                    return (
-                      '<i class="lay-icon lay-icon-' +
-                      (isSpreadItem ? 'up' : 'down') +
-                      '"></i>'
-                    );
-                  } else {
-                    return '';
-                  }
-                })() +
-                '</div>'
-              );
-            }
-            return '<div class="' + STR_MENU_TITLE + '">' + viewText + '</div>';
-          })(),
-          '</li>',
-        ].join(''),
-      );
-
-      viewLi.data('item', item);
-
-      //子级区
-      if (isChild) {
-        var elemPanel = $('<div class="lay-panel lay-menu-body-panel"></div>');
-        var elemUl = $('<ul></ul>');
-
-        if (type === 'parent') {
-          elemPanel.append(eachItemView(elemUl, item[customName.children]));
-          viewLi.append(elemPanel);
+      } else {
+        // 若为 click 事件，则根据主面板状态，自动切换打开与关闭
+        if (options.closeOnClick && opened && options.trigger === 'click') {
+          this.remove();
         } else {
-          viewLi.append(eachItemView(elemUl, item[customName.children]));
+          this.open();
         }
       }
 
-      views.append(viewLi);
+      e.preventDefault();
     });
-    return views;
-  };
 
-  // 主模板
-  var TPL_MAIN = [
-    '<div class="lay-dropdown lay-border-box lay-panel lay-anim lay-anim-downbit" ' +
-      MOD_ID +
-      '="' +
-      options.id +
-      '">',
-    '</div>',
-  ].join('');
-
-  // 重载或插入面板内容
-  var mainElem;
-  var content = options.content || getDefaultView();
-  var mainElemExisted = thisModule.findMainElem(options.id);
-  if (type === 'reloadData' && mainElemExisted.length) {
-    // 是否仅重载数据
-    mainElem = that.mainElem = mainElemExisted;
-    mainElemExisted.html(content);
-  } else {
-    // 常规渲染
-    mainElem = that.mainElem = $(TPL_MAIN);
-    mainElem.append(content);
-
-    // 初始化某些属性
-    mainElem.addClass(options.className);
-    mainElem.attr('style', options.style);
-
-    // 辞旧迎新
-    that.remove(options.id);
-    options.target.append(mainElem);
-    options.elem.data(MOD_INDEX_OPENED, true); // 面板已打开的标记
-
-    // 遮罩
-    var shade = options.shade
-      ? '<div class="' +
-        STR_ELEM_SHADE +
-        '" style="' +
-        ('z-index:' +
-          (mainElem.css('z-index') - 1) +
-          '; background-color: ' +
-          (options.shade[1] || '#000') +
-          '; opacity: ' +
-          (options.shade[0] || options.shade)) +
-        '"></div>'
-      : '';
-    var shadeElem = $(shade);
-    // 处理移动端点击穿透问题
-    if (clickOrMousedown === 'touchstart') {
-      shadeElem.on(clickOrMousedown, function (e) {
-        e.preventDefault();
+    // 如果是鼠标移入事件
+    if (isMouseEnter) {
+      // 执行鼠标移出事件
+      $elem.on(`mouseleave${eventNamespace}`, () => {
+        this.#delayRemove();
       });
     }
-    mainElem.before(shadeElem);
-
-    // 如果是鼠标移入事件，则鼠标移出时自动关闭
-    if (options.trigger === 'mouseenter') {
-      mainElem
-        .on('mouseenter', function () {
-          clearTimeout(that.timer);
-        })
-        .on('mouseleave', function () {
-          that.delayRemove();
-        });
-    }
   }
 
-  that.position(); // 定位坐标
+  /**
+   * 点击面板外部时的事件
+   */
+  #onClickOutside() {
+    const options = this.options;
+    const isCtxMenu = options.trigger === 'contextmenu';
+    const isTopElem = lay.isTopElem(options.$elem[0]);
 
-  // 阻止全局事件
-  mainElem.find('.lay-menu').on(clickOrMousedown, function (e) {
-    e.stopPropagation();
-  });
+    this.stopClickOutsideEvent();
 
-  // 触发菜单列表事件
-  mainElem.find('.lay-menu li').on('click', function (e) {
-    var othis = $(this);
-    var data = othis.data('item') || {};
-    var isChild =
-      data[customName.children] && data[customName.children].length > 0;
-    var isClickAllScope = options.clickScope === 'all'; // 是否所有父子菜单均触发点击事件
+    const stop = lay.onClickOutside(
+      this.$rootElem[0],
+      (e) => {
+        // 点击面板外部时的事件
+        if (typeof options.onClickOutside === 'function') {
+          const shouldClose = options.onClickOutside(e);
+          if (shouldClose === false) return;
+        }
 
-    if (data.disabled) return; // 菜单项禁用状态
+        this.remove();
+      },
+      {
+        ignore: isCtxMenu || isTopElem ? null : [options.$elem[0]],
+        event: clickOrMousedown,
+        capture: false,
+        detectIframe: true,
+      },
+    );
 
-    // 普通菜单项点击后的回调及关闭面板
-    if ((!isChild || isClickAllScope) && data.type !== '-') {
-      var ret =
-        typeof options.click === 'function'
-          ? options.click(data, othis, e)
-          : null;
-
-      ret === false || isChild || that.remove();
-      e.stopPropagation();
-    }
-  });
-
-  // 触发菜单组展开收缩
-  mainElem.find(STR_GROUP_TITLE).on('click', function () {
-    var othis = $(this);
-    var elemGroup = othis.parent();
-    var data = elemGroup.data('item') || {};
-
-    if (data.type === 'group' && options.isAllowSpread) {
-      thisModule.spread(elemGroup, options.accordion);
-    }
-  });
-
-  that.onClickOutside();
-  that.autoUpdatePosition();
-
-  // 组件打开完毕的事件
-  typeof options.ready === 'function' && options.ready(mainElem, options.elem);
-};
-
-// 位置定位
-Class.prototype.position = function () {
-  var that = this;
-  var options = that.config;
-
-  lay.position(options.elem[0], that.mainElem[0], {
-    position: options.position,
-    e: that.e,
-    clickType: options.trigger === 'contextmenu' ? 'right' : null,
-    align: options.align || null,
-  });
-};
-
-// 移除面板
-Class.prototype.remove = function (id) {
-  id = id || this.config.id;
-  var that = thisModule.getThis(id); // 根据 id 查找对应的实例
-  if (!that) return;
-
-  var options = that.config;
-  var mainElem = thisModule.findMainElem(id);
-  that.stopClickOutsideEvent();
-  that.stopResizeEvent();
-
-  // 若存在已打开的面板元素，则移除
-  if (mainElem[0]) {
-    mainElem.prev('.' + STR_ELEM_SHADE).remove(); // 先移除遮罩
-    mainElem.remove();
-    options.elem.removeData(MOD_INDEX_OPENED);
-    typeof options.close === 'function' && options.close(options.elem);
+    this.stopClickOutsideEvent = () => {
+      stop();
+      this.stopClickOutsideEvent = $.noop;
+    };
   }
-};
 
-Class.prototype.normalizedDelay = function () {
-  var that = this;
-  var options = that.config;
-  var delay = [].concat(options.delay);
+  /**
+   * 窗口大小变化时自动更新位置
+   */
+  #autoUpdatePosition() {
+    const options = this.options;
 
-  return {
-    show: delay[0],
-    hide: delay[1] !== undefined ? delay[1] : delay[0],
-  };
-};
+    this.stopResizeEvent();
 
-// 延迟移除面板
-Class.prototype.delayRemove = function () {
-  var that = this;
-  // var options = that.config;
-  clearTimeout(that.timer);
-
-  that.timer = setTimeout(function () {
-    that.remove();
-  }, that.normalizedDelay().hide);
-};
-
-// 事件
-Class.prototype.events = function () {
-  var that = this;
-  var options = that.config;
-
-  // 是否鼠标移入时触发
-  var isMouseEnter = options.trigger === 'mouseenter';
-  var trigger = options.trigger + '.lay_dropdown_render';
-
-  // 始终先解除上一个触发元素的事件（如重载时改变 elem 的情况）
-  if (that.thisEventElem) that.thisEventElem.off(trigger);
-  that.thisEventElem = options.elem;
-
-  // 触发元素事件
-  options.elem.off(trigger).on(trigger, function (e) {
-    clearTimeout(that.timer);
-    that.e = e;
-
-    // 主面板是否已打开
-    var opened = options.elem.data(MOD_INDEX_OPENED);
-
-    // 若为鼠标移入事件，则延迟触发
-    if (isMouseEnter) {
-      if (!opened) {
-        that.timer = setTimeout(function () {
-          that.render();
-        }, that.normalizedDelay().show);
-      }
-    } else {
-      // 若为 click 事件，则根据主面板状态，自动切换打开与关闭
-      if (options.closeOnClick && opened && options.trigger === 'click') {
-        that.remove();
+    const windowResizeHandler = () => {
+      if (
+        this.$rootElem &&
+        (!this.$rootElem[0] || !this.$rootElem.is(':visible'))
+      )
+        return;
+      if (options.trigger === 'contextmenu') {
+        this.remove();
       } else {
-        that.render();
+        this.#position();
       }
-    }
+    };
+    $(window).on('resize.lay_dropdown_resize', windowResizeHandler);
 
-    e.preventDefault();
-  });
-
-  // 如果是鼠标移入事件
-  if (isMouseEnter) {
-    // 执行鼠标移出事件
-    options.elem.on('mouseleave', function () {
-      that.delayRemove();
-    });
-  }
-};
-
-/**
- * 点击面板外部时的事件
- */
-Class.prototype.onClickOutside = function () {
-  var that = this;
-  var options = that.config;
-  var isCtxMenu = options.trigger === 'contextmenu';
-  var isTopElem = lay.isTopElem(options.elem[0]);
-
-  that.stopClickOutsideEvent();
-
-  var stop = lay.onClickOutside(
-    that.mainElem[0],
-    function (e) {
-      // 点击面板外部时的事件
-      if (typeof options.onClickOutside === 'function') {
-        var shouldClose = options.onClickOutside(e);
-        if (shouldClose === false) return;
-      }
-
-      that.remove();
-    },
-    {
-      ignore: isCtxMenu || isTopElem ? null : [options.elem[0]],
-      event: clickOrMousedown,
-      capture: false,
-      detectIframe: true,
-    },
-  );
-
-  that.stopClickOutsideEvent = function () {
-    stop();
-    that.stopClickOutsideEvent = $.noop;
-  };
-};
-
-/**
- * 窗口大小变化时自动更新位置
- */
-Class.prototype.autoUpdatePosition = function () {
-  var that = this;
-  var options = that.config;
-
-  that.stopResizeEvent();
-
-  var windowResizeHandler = function () {
-    if (that.mainElem && (!that.mainElem[0] || !that.mainElem.is(':visible')))
-      return;
-    if (options.trigger === 'contextmenu') {
-      that.remove();
-    } else {
-      that.position();
-    }
-  };
-  $(window).on('resize.lay_dropdown_resize', windowResizeHandler);
-
-  var shouldObserveResize = resizeObserver && options.trigger !== 'contextmenu';
-  var triggerEl = options.elem[0];
-  var contentEl = that.mainElem[0];
-  if (shouldObserveResize) {
-    resizeObserver.observe(triggerEl, $.proxy(that.position, that));
-    resizeObserver.observe(contentEl, $.proxy(that.position, that));
-  }
-
-  that.stopResizeEvent = function () {
-    $(window).off('resize.lay_dropdown_resize', windowResizeHandler);
+    const shouldObserveResize =
+      resizeObserver && options.trigger !== 'contextmenu';
+    const triggerEl = options.$elem[0];
+    const contentEl = this.$rootElem[0];
+    const positionHandler = () => this.#position();
     if (shouldObserveResize) {
-      resizeObserver.unobserve(triggerEl);
-      resizeObserver.unobserve(contentEl);
+      resizeObserver.observe(triggerEl, positionHandler);
+      resizeObserver.observe(contentEl, positionHandler);
     }
 
-    that.stopResizeEvent = $.noop;
-  };
-};
+    this.stopResizeEvent = () => {
+      $(window).off('resize.lay_dropdown_resize', windowResizeHandler);
+      if (shouldObserveResize) {
+        resizeObserver.unobserve(triggerEl);
+        resizeObserver.unobserve(contentEl);
+      }
 
-// 记录所有实例
-thisModule.that = {}; // 记录所有实例对象
-
-// 获取当前实例对象
-thisModule.getThis = function (id) {
-  if (id === undefined) {
-    throw new Error('ID argument required');
+      this.stopResizeEvent = $.noop;
+    };
   }
-  return thisModule.that[id];
-};
+}
 
-// 根据 id 从页面查找组件主面板元素
-thisModule.findMainElem = function (id) {
-  return $('.' + STR_ELEM + '[' + MOD_ID + '="' + id + '"]');
-};
+const CONST = Dropdown.CONST;
+const resizeObserver = lay.createSharedResizeObserver(Dropdown.componentName);
 
-// 设置菜单组展开和收缩状态
-thisModule.spread = function (othis, isAccordion) {
-  var contentElem = othis.children('ul');
-  var needSpread = othis.hasClass(STR_ITEM_UP);
-  var ANIM_MS = 200;
+/**
+ * 设置菜单组展开和收缩状态
+ * @param {JQuery} $groupElem - 菜单组标题元素的 jQuery 对象
+ * @param {boolean} isAccordion - 是否为手风琴模式
+ * @returns
+ */
+const toggleMenuGroup = ($groupElem, isAccordion) => {
+  const $contentElem = $groupElem.children('ul');
+  const needSpread = $groupElem.hasClass(CONST.ELEM_ITEM_UP);
+  const ANIM_MS = 200;
 
   // 动画执行完成后的操作
-  var complete = function () {
+  const complete = function () {
     $(this).css({ display: '' }); // 剔除临时 style，以适配外部样式的状态重置;
   };
 
   // 动画是否正在执行
-  if (contentElem.is(':animated')) return;
+  if ($contentElem.is(':animated')) return;
 
   // 展开
   if (needSpread) {
-    othis.removeClass(STR_ITEM_UP).addClass(STR_ITEM_DOWN);
-    contentElem.hide().stop().slideDown(ANIM_MS, complete);
+    $groupElem.removeClass(CONST.ELEM_ITEM_UP).addClass(CONST.ELEM_ITEM_DOWN);
+    $contentElem.hide().stop().slideDown(ANIM_MS, complete);
   } else {
     // 收缩
-    contentElem.stop().slideUp(ANIM_MS, complete);
-    othis.removeClass(STR_ITEM_DOWN).addClass(STR_ITEM_UP);
+    $contentElem.stop().slideUp(ANIM_MS, complete);
+    $groupElem.removeClass(CONST.ELEM_ITEM_DOWN).addClass(CONST.ELEM_ITEM_UP);
   }
 
   // 手风琴
   if (needSpread && isAccordion) {
-    var groupSibs = othis.siblings('.' + STR_ITEM_DOWN);
-    groupSibs.children('ul').stop().slideUp(ANIM_MS, complete);
-    groupSibs.removeClass(STR_ITEM_DOWN).addClass(STR_ITEM_UP);
+    const $groupSibs = $groupElem.siblings(`.${CONST.ELEM_ITEM_DOWN}`);
+    $groupSibs.children('ul').stop().slideUp(ANIM_MS, complete);
+    $groupSibs.removeClass(CONST.ELEM_ITEM_DOWN).addClass(CONST.ELEM_ITEM_UP);
   }
 };
 
 // 全局事件
 (function () {
-  var _WIN = $(window);
-  var _DOC = $(document);
+  const $win = $(window);
+  const $doc = $(document);
 
   // 基础菜单的静态元素事件
-  var ELEM_LI = '.lay-menu:not(.lay-dropdown-menu) li';
-  _DOC.on('click', ELEM_LI, function () {
-    var othis = $(this);
-    var parent = othis.parents('.lay-menu').eq(0);
-    var isChild =
-      othis.hasClass(STR_ITEM_GROUP) || othis.hasClass(STR_ITEM_PARENT);
-    var filter = parent.attr('lay-filter') || parent.attr('id');
-    var options = lay.options(this);
+  const ELEM_LI = '.lay-menu:not(.lay-dropdown-menu) li';
+  $doc.on('click', ELEM_LI, function () {
+    const $this = $(this);
+    const $parent = $this.parents('.lay-menu').eq(0);
+    const isChild =
+      $this.hasClass(CONST.ELEM_ITEM_GROUP) ||
+      $this.hasClass(CONST.ELEM_ITEM_PARENT);
+    const filter = $parent.attr('lay-filter') || $parent.attr('id');
+    const options = lay.options(this);
 
     // 非触发元素
-    if (othis.hasClass(STR_ITEM_DIV)) return;
+    if ($this.hasClass(CONST.ELEM_ITEM_DIV)) return;
 
     // 非菜单组
     if (!isChild) {
       // 选中
-      parent.find('.' + STR_ITEM_CHECKED).removeClass(STR_ITEM_CHECKED); // 清除选中样式
-      parent.find('.' + STR_ITEM_CHECKED2).removeClass(STR_ITEM_CHECKED2); // 清除父级菜单选中样式
-      othis.addClass(STR_ITEM_CHECKED); //添加选中样式
-      othis.parents('.' + STR_ITEM_PARENT).addClass(STR_ITEM_CHECKED2); // 添加父级菜单选中样式
+      $parent
+        .find(`.${CONST.ELEM_ITEM_CHECKED}`)
+        .removeClass(CONST.ELEM_ITEM_CHECKED); // 清除选中样式
+      $parent
+        .find(`.${CONST.ELEM_ITEM_CHECKED2}`)
+        .removeClass(CONST.ELEM_ITEM_CHECKED2); // 清除父级菜单选中样式
+      $this.addClass(CONST.ELEM_ITEM_CHECKED); //添加选中样式
+      $this
+        .parents(`.${CONST.ELEM_ITEM_PARENT}`)
+        .addClass(CONST.ELEM_ITEM_CHECKED2); // 添加父级菜单选中样式
 
       options.title =
         options.title ||
-        othis
-          .children('.' + STR_MENU_TITLE)
-          .text()
-          .trim();
+        $this.children(`.${CONST.ELEM_MENU_TITLE}`).text().trim();
 
       // 触发事件
-      lay.event.call(this, MOD_NAME, 'click(' + filter + ')', options);
+      lay.event.call(this, 'menu', `click(${filter})`, options);
     }
   });
 
   // 基础菜单的展开收缩事件
-  _DOC.on('click', ELEM_LI + STR_GROUP_TITLE, function () {
-    var othis = $(this);
-    var elemGroup = othis.parents('.' + STR_ITEM_GROUP + ':eq(0)');
-    var options = lay.options(elemGroup[0]);
-    var isAccordion =
-      typeof othis.parents('.lay-menu').eq(0).attr('lay-accordion') ===
+  $doc.on('click', `${ELEM_LI}${CONST.ELEM_GROUP_TITLE}`, function () {
+    const $this = $(this);
+    const $elemGroup = $this.parents(`.${CONST.ELEM_ITEM_GROUP}:eq(0)`);
+    const options = lay.options($elemGroup[0]);
+    const isAccordion =
+      typeof $this.parents('.lay-menu').eq(0).attr('lay-accordion') ===
       'string';
 
     if ('isAllowSpread' in options ? options.isAllowSpread : true) {
-      thisModule.spread(elemGroup, isAccordion);
+      toggleMenuGroup($elemGroup, isAccordion);
     }
   });
 
   // 判断子级菜单是否超出屏幕
-  var ELEM_LI_PAR = '.lay-menu .' + STR_ITEM_PARENT;
-  _DOC
+  const ELEM_LI_PAR = `.lay-menu .${CONST.ELEM_ITEM_PARENT}`;
+  $doc
     .on('mouseenter', ELEM_LI_PAR, function () {
-      var othis = $(this);
-      var elemPanel = othis.find('.' + STR_MENU_PANEL);
+      const $this = $(this);
+      const $elemPanel = $this.find(`.${CONST.ELEM_MENU_PANEL}`);
 
-      if (!elemPanel[0]) return;
-      var rect = elemPanel[0].getBoundingClientRect();
+      if (!$elemPanel[0]) return;
+      let rect = $elemPanel[0].getBoundingClientRect();
 
       // 是否超出右侧屏幕
-      if (rect.right > _WIN.width()) {
-        elemPanel.addClass(STR_MENU_PANEL_L);
+      if (rect.right > $win.width()) {
+        $elemPanel.addClass(CONST.ELEM_MENU_PANEL_L);
         // 不允许超出左侧屏幕
-        rect = elemPanel[0].getBoundingClientRect();
+        rect = $elemPanel[0].getBoundingClientRect();
         if (rect.left < 0) {
-          elemPanel.removeClass(STR_MENU_PANEL_L);
+          $elemPanel.removeClass(CONST.ELEM_MENU_PANEL_L);
         }
       }
 
       // 是否超出底部屏幕
-      if (rect.bottom > _WIN.height()) {
-        elemPanel.eq(0).css('margin-top', -(rect.bottom - _WIN.height() + 5));
+      if (rect.bottom > $win.height()) {
+        $elemPanel.eq(0).css('margin-top', -(rect.bottom - $win.height() + 5));
       }
     })
     .on('mouseleave', ELEM_LI_PAR, function () {
-      var othis = $(this);
-      var elemPanel = othis.children('.' + STR_MENU_PANEL);
+      const $this = $(this);
+      const $elemPanel = $this.children(`.${CONST.ELEM_MENU_PANEL}`);
 
-      elemPanel.removeClass(STR_MENU_PANEL_L);
-      elemPanel.css('margin-top', 0);
+      $elemPanel.removeClass(CONST.ELEM_MENU_PANEL_L);
+      $elemPanel.css('margin-top', 0);
     });
 })();
 
-// 关闭面板
-dropdown.close = function (id) {
-  var that = thisModule.getThis(id);
-  if (!that) return this;
-
-  that.remove();
-  return thisModule.call(that);
-};
-
-// 打开面板
-dropdown.open = function (id) {
-  var that = thisModule.getThis(id);
-  if (!that) return this;
-
-  that.render();
-  return thisModule.call(that);
-};
-
-// 重载实例
-dropdown.reload = function (id, options, type) {
-  var that = thisModule.getThis(id);
-  if (!that) return this;
-
-  that.reload(options, type);
-  return thisModule.call(that);
-};
-
-// 仅重载数据
-dropdown.reloadData = function () {
-  var args = $.extend([], arguments);
-  args[2] = 'reloadData';
-
-  // 重载时，与数据相关的参数
-  var dataParams = new RegExp(
-    '^(' + ['data', 'templet', 'content'].join('|') + ')$',
-  );
-
-  // 过滤与数据无关的参数
-  Object.keys(args[1] || {}).forEach(function (key) {
-    if (!dataParams.test(key)) {
-      delete args[1][key];
-    }
-  });
-
-  return dropdown.reload.apply(null, args);
-};
-
-// 核心入口
-dropdown.render = function (options) {
-  var inst = new Class(options);
-  return thisModule.call(inst);
-};
-
-export { dropdown };
+export { Dropdown as dropdown };

--- a/src/components/dropdown.js
+++ b/src/components/dropdown.js
@@ -59,26 +59,9 @@ export class Dropdown extends Component {
     return consts;
   }
 
-  /**
-   * 关闭面板
-   * @param {string|number} id - 实例 id
-   */
-  static close(id) {
-    const inst = this.getInstance(id);
-    if (!inst) return;
-
-    inst.remove();
-  }
-
-  /**
-   * 打开面板
-   * @param {string|number} id - 实例 id
-   */
-  static open(id) {
-    const inst = this.getInstance(id);
-    if (!inst) return;
-
-    inst.open();
+  // 实例方法静态委托
+  static {
+    this.delegateInstanceMethods(['close', 'open']);
   }
 
   /**
@@ -86,20 +69,21 @@ export class Dropdown extends Component {
    * @param {string|number} id - 实例 id
    * @param {Object} options - 配置项；仅允许重载与数据相关的选项，如:
    * `data、template、content`，其他选项将被忽略
-   * @returns @see Component.reload
+   * @param  {...any} args - 保留参数，为了同 {@link Component.reload} 的参数一致
+   * @returns {*} 返回值同 {@link Component.reload}
    */
-  static reloadData(...args) {
-    const options = { ...args[1] };
+  static reloadData(id, options, ...args) {
+    const opts = { ...options };
     const allowedReloadKeys = new Set(['data', 'template', 'content']);
 
-    Object.keys(options).forEach((key) => {
+    Object.keys(opts).forEach((key) => {
       if (!allowedReloadKeys.has(key)) {
-        delete options[key];
+        delete opts[key];
       }
     });
 
-    args[1] = { ...options, _renderMode: 'reloadData' };
-    return this.reload(...args);
+    Object.assign(opts, { _renderMode: 'reloadData' });
+    return this.reload(id, opts, ...args);
   }
 
   // 构造函数
@@ -289,7 +273,7 @@ export class Dropdown extends Component {
       $rootElem.addClass(options.className).attr('style', options.style);
 
       // 生成面板
-      this.remove(); // 移除旧面板
+      this.close(); // 关闭旧面板
       options.$target.append($rootElem); // 插入新面板
       this.$rootElem = $rootElem;
 
@@ -323,7 +307,7 @@ export class Dropdown extends Component {
             clearTimeout(this.timer);
           })
           .on('mouseleave', () => {
-            this.#delayRemove();
+            this.#delayClose();
           });
       }
     }
@@ -352,7 +336,7 @@ export class Dropdown extends Component {
             ? options.click(data, $this, e)
             : null;
 
-        ret === false || isChild || this.remove();
+        ret === false || isChild || this.close();
         e.stopPropagation();
       }
     });
@@ -376,9 +360,9 @@ export class Dropdown extends Component {
   }
 
   /**
-   * 移除面板
+   * 关闭面板
    */
-  remove() {
+  close() {
     const options = this.options;
     const $rootElem = this.$rootElem;
 
@@ -428,12 +412,12 @@ export class Dropdown extends Component {
     };
   }
 
-  // 延迟移除面板
-  #delayRemove() {
+  // 延迟关闭面板
+  #delayClose() {
     clearTimeout(this.timer);
 
     this.timer = setTimeout(() => {
-      this.remove();
+      this.close();
     }, this.#normalizedDelay().hide);
   }
 
@@ -470,7 +454,7 @@ export class Dropdown extends Component {
       } else {
         // 若为 click 事件，则根据主面板状态，自动切换打开与关闭
         if (options.closeOnClick && opened && options.trigger === 'click') {
-          this.remove();
+          this.close();
         } else {
           this.open();
         }
@@ -483,7 +467,7 @@ export class Dropdown extends Component {
     if (isMouseEnter) {
       // 执行鼠标移出事件
       $elem.on(`mouseleave${eventNamespace}`, () => {
-        this.#delayRemove();
+        this.#delayClose();
       });
     }
   }
@@ -507,7 +491,7 @@ export class Dropdown extends Component {
           if (shouldClose === false) return;
         }
 
-        this.remove();
+        this.close();
       },
       {
         ignore: isCtxMenu || isTopElem ? null : [options.$elem[0]],
@@ -538,7 +522,7 @@ export class Dropdown extends Component {
       )
         return;
       if (options.trigger === 'contextmenu') {
-        this.remove();
+        this.close();
       } else {
         this.#position();
       }

--- a/src/components/dropdown.js
+++ b/src/components/dropdown.js
@@ -292,22 +292,28 @@ export class Dropdown extends Component {
       options.$target.append($rootElem); // 插入新面板
       this.$rootElem = $rootElem;
 
-      // 生成遮罩
-      const shade = options.shade
-        ? `<div class="${CONST.ELEM_ELEM_SHADE}" style="z-index:${
-            $rootElem.css('z-index') - 1
-          }; background-color: ${options.shade[1] || '#000'}; opacity: ${
-            options.shade[0] || options.shade
-          }"></div>`
-        : '';
-      const $shadeElem = $(shade);
-      // 处理移动端点击穿透问题
-      if (clickOrMousedown === 'touchstart') {
-        $shadeElem.on(clickOrMousedown, (e) => {
-          e.preventDefault();
+      // 若开启遮罩
+      if (options.shade) {
+        const shade = Array.isArray(options.shade)
+          ? options.shade
+          : [options.shade, '#000'];
+        const $shadeElem = $(`<div class="${CONST.ELEM_ELEM_SHADE}"></div>`);
+
+        $shadeElem.css({
+          'z-index': $rootElem.css('z-index') - 1,
+          'background-color': shade[1],
+          opacity: shade[0],
         });
+
+        // 处理移动端点击穿透问题
+        if (clickOrMousedown === 'touchstart') {
+          $shadeElem.on(clickOrMousedown, (e) => {
+            e.preventDefault();
+          });
+        }
+
+        $rootElem.before($shadeElem);
       }
-      $rootElem.before($shadeElem);
 
       // 如果是鼠标移入事件，则鼠标移出时自动关闭
       if (options.trigger === 'mouseenter') {

--- a/src/components/dropdown.js
+++ b/src/components/dropdown.js
@@ -265,6 +265,7 @@ export class Dropdown extends Component {
     if (options._renderMode === 'reloadData' && this.#isRootElemMounted()) {
       $rootElem = this.$rootElem;
       this.$rootElem.html(content);
+      delete options._renderMode;
     } else {
       // 常规渲染
       $rootElem.append(content); // 填充内容

--- a/src/components/dropdown.js
+++ b/src/components/dropdown.js
@@ -64,7 +64,7 @@ export class Dropdown extends Component {
    * @param {string|number} id - 实例 id
    */
   static close(id) {
-    const inst = this.getInst(id);
+    const inst = this.getInstance(id);
     if (!inst) return;
 
     inst.remove();
@@ -75,7 +75,7 @@ export class Dropdown extends Component {
    * @param {string|number} id - 实例 id
    */
   static open(id) {
-    const inst = this.getInst(id);
+    const inst = this.getInstance(id);
     if (!inst) return;
 
     inst.open();

--- a/src/components/dropdown.js
+++ b/src/components/dropdown.js
@@ -57,7 +57,10 @@ export class Dropdown extends Component {
     return consts;
   }
 
-  // 关闭面板
+  /**
+   * 关闭面板
+   * @param {string|number} id - 实例 id
+   */
   static close(id) {
     const inst = this.getInst(id);
     if (!inst) return;
@@ -65,7 +68,10 @@ export class Dropdown extends Component {
     inst.remove();
   }
 
-  // 打开面板
+  /**
+   * 打开面板
+   * @param {string|number} id - 实例 id
+   */
   static open(id) {
     const inst = this.getInst(id);
     if (!inst) return;
@@ -73,18 +79,24 @@ export class Dropdown extends Component {
     inst.open();
   }
 
-  // 仅重载数据
+  /**
+   * 仅重载数据
+   * @param {string|number} id - 实例 id
+   * @param {Object} options - 配置项；仅允许重载与数据相关的选项，如:
+   * `data、template、content`，其他选项将被忽略
+   * @returns @see Component.reload
+   */
   static reloadData(...args) {
-    // 重载时，过滤与数据无关的选项
-    const dataParams = new RegExp('^(data|template|content)$');
-    Object.keys(args[1] || {}).forEach((key) => {
-      if (!dataParams.test(key)) {
-        delete args[1][key];
+    const options = { ...args[1] };
+    const allowedReloadKeys = new Set(['data', 'template', 'content']);
+
+    Object.keys(options).forEach((key) => {
+      if (!allowedReloadKeys.has(key)) {
+        delete options[key];
       }
     });
 
-    args[1] = { ...args[1], _renderMode: 'reloadData' };
-
+    args[1] = { ...options, _renderMode: 'reloadData' };
     return this.reload(...args);
   }
 
@@ -120,7 +132,9 @@ export class Dropdown extends Component {
     }
   }
 
-  // 打开下拉菜单
+  /**
+   * 打开下拉菜单
+   */
   open() {
     const options = this.options;
     const customName = options.customName;
@@ -179,7 +193,7 @@ export class Dropdown extends Component {
         )
           return;
 
-        //列表元素
+        // 列表元素
         const className = {
           group: `lay-menu-item-group${
             options.isAllowSpread
@@ -197,10 +211,21 @@ export class Dropdown extends Component {
             : item.disabled
               ? CONST.CLASS_DISABLED
               : '';
-        const viewText =
-          'href' in item
-            ? `<a href="${item.href}" target="${item.target || '_self'}">${title}</a>`
-            : title;
+        const viewText = (() => {
+          if (!('href' in item)) {
+            return title;
+          }
+
+          const target = item.target || '_self';
+          const $link = $('<a></a>')
+            .attr({
+              href: item.href,
+              target,
+            })
+            .html(title);
+
+          return $link.prop('outerHTML');
+        })();
         const suffixIcon = (() => {
           if (type === 'parent') {
             return '<i class="lay-icon lay-icon-right"></i>';
@@ -343,7 +368,9 @@ export class Dropdown extends Component {
     options.ready?.(options, $rootElem);
   }
 
-  // 移除面板
+  /**
+   * 移除面板
+   */
   remove() {
     const options = this.options;
     const $rootElem = this.$rootElem;
@@ -601,7 +628,7 @@ const toggleMenuGroup = ($groupElem, isAccordion) => {
       $parent
         .find(`.${CONST.ELEM_ITEM_CHECKED2}`)
         .removeClass(CONST.ELEM_ITEM_CHECKED2); // 清除父级菜单选中样式
-      $this.addClass(CONST.ELEM_ITEM_CHECKED); //添加选中样式
+      $this.addClass(CONST.ELEM_ITEM_CHECKED); // 添加选中样式
       $this
         .parents(`.${CONST.ELEM_ITEM_PARENT}`)
         .addClass(CONST.ELEM_ITEM_CHECKED2); // 添加父级菜单选中样式

--- a/src/components/dropdown.js
+++ b/src/components/dropdown.js
@@ -12,19 +12,21 @@ const device = lay.device();
 const clickOrMousedown = device.mobile ? 'touchstart' : 'mousedown';
 
 export class Dropdown extends Component {
+  static componentName = 'dropdown';
+
   // 默认配置项
   static options = {
     trigger: 'click', // 事件类型
     data: [], // 菜单数据结构
-    isAllowSpread: true, // 是否允许菜单组展开收缩
-    isSpreadItem: true, // 是否初始展开子菜单
+    expanded: true, // 是否初始展开子菜单
+    allowExpand: true, // 是否允许菜单组展开收缩
     closeOnClick: true, // 面板打开后，再次点击目标元素时是否关闭面板。行为取决于所使用的触发事件类型
     delay: [200, 300], // 延时显示或隐藏的毫秒数，若为 number 类型，则表示显示和隐藏的延迟时间相同，trigger 为 hover 时才生效
     // content: '', // 自定义菜单内容
     // className: '', // 自定义样式类名
     // style: '', // 设置面板 style 属性
     // defaultOpen: false, // 是否初始默认打开菜单面板
-    // isAccordion: false, // 是否开启菜单展开收缩的手风琴效果，仅菜单组生效。基础菜单需在容器上追加 `lay-accordion` 属性。
+    // accordion: false, // 是否开启菜单展开收缩的手风琴效果，仅菜单组生效。基础菜单需在容器上追加 `lay-accordion` 属性。
     // shade: 0, // 遮罩
 
     // 自定义 data 字段名
@@ -158,8 +160,7 @@ export class Dropdown extends Component {
         // 是否存在子级
         const isChild =
           item[customName.children] && item[customName.children].length > 0;
-        const isSpreadItem =
-          'isSpreadItem' in item ? item.isSpreadItem : options.isSpreadItem;
+        const expanded = 'expanded' in item ? item.expanded : options.expanded;
         const title = ((titleValue) => {
           const template = item.template || options.template;
           if (typeof template === 'function') {
@@ -196,8 +197,8 @@ export class Dropdown extends Component {
         // 列表元素
         const className = {
           group: `lay-menu-item-group${
-            options.isAllowSpread
-              ? isSpreadItem
+            options.allowExpand
+              ? expanded
                 ? ' lay-menu-item-down'
                 : ' lay-menu-item-up'
               : ''
@@ -231,8 +232,8 @@ export class Dropdown extends Component {
             return '<i class="lay-icon lay-icon-right"></i>';
           }
 
-          if (type === 'group' && options.isAllowSpread) {
-            return `<i class="lay-icon lay-icon-${isSpreadItem ? 'up' : 'down'}"></i>`;
+          if (type === 'group' && options.allowExpand) {
+            return `<i class="lay-icon lay-icon-${expanded ? 'up' : 'down'}"></i>`;
           }
 
           return '';
@@ -362,8 +363,8 @@ export class Dropdown extends Component {
       const $groupElem = $this.parent();
       const data = $groupElem.data('item') || {};
 
-      if (data.type === 'group' && options.isAllowSpread) {
-        toggleMenuGroup($groupElem, options.isAccordion);
+      if (data.type === 'group' && options.allowExpand) {
+        toggleMenuGroup($groupElem, options.accordion);
       }
     });
 
@@ -572,10 +573,10 @@ const resizeObserver = lay.createSharedResizeObserver(Dropdown.componentName);
 /**
  * 设置菜单组展开和收缩状态
  * @param {JQuery} $groupElem - 菜单组标题元素的 jQuery 对象
- * @param {boolean} isAccordion - 是否为手风琴模式
+ * @param {boolean} accordion - 是否为手风琴模式
  * @returns
  */
-const toggleMenuGroup = ($groupElem, isAccordion) => {
+const toggleMenuGroup = ($groupElem, accordion) => {
   const $contentElem = $groupElem.children('ul');
   const needSpread = $groupElem.hasClass(CONST.ELEM_ITEM_UP);
   const ANIM_MS = 200;
@@ -599,7 +600,7 @@ const toggleMenuGroup = ($groupElem, isAccordion) => {
   }
 
   // 手风琴
-  if (needSpread && isAccordion) {
+  if (needSpread && accordion) {
     const $groupSibs = $groupElem.siblings(`.${CONST.ELEM_ITEM_DOWN}`);
     $groupSibs.children('ul').stop().slideUp(ANIM_MS, complete);
     $groupSibs.removeClass(CONST.ELEM_ITEM_DOWN).addClass(CONST.ELEM_ITEM_UP);
@@ -653,12 +654,12 @@ const toggleMenuGroup = ($groupElem, isAccordion) => {
     const $this = $(this);
     const $elemGroup = $this.parents(`.${CONST.ELEM_ITEM_GROUP}:eq(0)`);
     const options = lay.options($elemGroup[0]);
-    const isAccordion =
+    const accordion =
       typeof $this.parents('.lay-menu').eq(0).attr('lay-accordion') ===
       'string';
 
-    if ('isAllowSpread' in options ? options.isAllowSpread : true) {
-      toggleMenuGroup($elemGroup, isAccordion);
+    if ('allowExpand' in options ? options.allowExpand : true) {
+      toggleMenuGroup($elemGroup, accordion);
     }
   });
 

--- a/tests/visual/dropdown.html
+++ b/tests/visual/dropdown.html
@@ -7,12 +7,13 @@
       content="width=device-width, initial-scale=1, maximum-scale=1"
     />
     <title>下拉菜单 - layui</title>
-
     <link rel="stylesheet" href="./assets/dist/css/layui.css" />
   </head>
   <body>
-    <div class="lay-container">
-      <div class="lay-btn-container" style="padding: 30px 0">
+    <div class="lay-container lay-padding-3">
+      <h2>常规</h2>
+      <hr />
+      <div class="lay-btn-container" style="padding: 16px 0">
         <button class="lay-btn" id="demo1">
           按钮下拉
           <i class="lay-icon lay-icon-down lay-font-12"></i>
@@ -23,23 +24,35 @@
         </button>
       </div>
 
-      <div class="lay-text">
-        <a href="javascript:;" id="demo3"
-          >文字下拉 <i class="lay-icon lay-icon-down"></i
-        ></a>
-      </div>
-
-      <div class="lay-btn-container">
-        <a href="javascript:;" id="testopen"
-          >testopen <i class="lay-icon lay-icon-down"></i
-        ></a>
-        <button class="lay-btn" lay-on="open">open</button>
-        <button class="lay-btn" lay-on="close">close</button>
+      <div
+        style="
+          display: flex;
+          flex-wrap: wrap;
+          align-items: center;
+          column-gap: 32px;
+          row-gap: 11px;
+        "
+        ;
+      >
+        <div class="lay-text">
+          <a href="javascript:;" id="demo3"
+            >文字下拉 <i class="lay-icon lay-icon-down"></i
+          ></a>
+        </div>
+        <div
+          style="display: flex; align-items: center; gap: 11px; flex-wrap: wrap"
+        >
+          <span id="testopen"> 目标元素（通过外部打开或关闭面板） </span>
+          <div>
+            <button class="lay-btn" lay-on="open">open</button>
+            <button class="lay-btn" lay-on="close">close</button>
+          </div>
+        </div>
       </div>
 
       <div
         class="lay-bg-gray"
-        style="margin-top: 30px; width: 100%; height: 300px; text-align: center"
+        style="margin-top: 32px; width: 100%; height: 160px; text-align: center"
         id="ID-dropdown-demo-contextmenu"
       >
         <span class="lay-font-gray" style="position: relative; top: 50%"
@@ -49,184 +62,216 @@
       <button class="lay-btn" style="margin-top: 15px" lay-on="contextmenu">
         开启全局右键菜单
       </button>
+
+      <br /><br />
+      <h2>重载</h2>
+      <hr />
+      <div
+        class="lay-form"
+        style="display: flex; flex-wrap: wrap; column-gap: 32px; row-gap: 11px"
+      >
+        <div>
+          <button class="lay-btn" id="ID-dropdown-demo-reload">
+            <span>完整重载</span>
+            <i class="lay-icon lay-icon-down lay-font-12"></i>
+          </button>
+        </div>
+        <div>
+          <label>仅数据或内容重载：</label>
+          <div class="lay-inline">
+            <input
+              type="text"
+              autocomplete="off"
+              placeholder="输入关键字"
+              class="lay-input"
+              id="ID-dropdown-demo-reloadData"
+            />
+          </div>
+        </div>
+      </div>
     </div>
 
     <script src="./assets/dist/layui.js"></script>
     <script>
       layui.use(() => {
-        var dropdown = layui.dropdown;
-        var utils = layui.utils;
+        const { dropdown, utils, $ } = layui;
 
-        dropdown.render({
+        // 模拟数据
+        const DEMO_DATA = [
+          {
+            title: 'menu item 1',
+            template() {
+              return `<i class="lay-icon lay-icon-light"></i> ${this.title} <span class="lay-badge-dot"></span>`;
+            },
+            id: '',
+            href: '',
+            type: '', // 菜单类型，支持：normal|group|parent
+          },
+          {
+            title: 'menu item <strong>2</strong>',
+            template() {
+              return `<img src="https://unpkg.com/outeres@0.1.1/demo/avatar/0.png" style="width: 16px;"> ${this.title}`;
+            },
+            id: '',
+            href: 'https://example.com',
+            target: '_blank',
+          },
+          { type: '-' },
+          {},
+          {
+            title: 'menu item 3 <hello>',
+            id: '',
+            type: 'group',
+            children: [
+              {
+                title: 'menu item 3-1',
+                id: '',
+              },
+              {
+                title: 'menu item 3-2',
+                id: '',
+                children: [
+                  {
+                    title: 'menu item 3-2-1',
+                    id: '',
+                  },
+                  {
+                    title: 'menu item 3-2-2',
+                    id: '',
+                    type: 'group',
+                    children: [
+                      {
+                        title: 'menu item 3-2-2-1',
+                        id: '',
+                      },
+                      {
+                        title: 'menu item 3-2-2-2',
+                        id: '',
+                      },
+                    ],
+                  },
+                  {
+                    title: 'menu item 3-2-3',
+                    id: '',
+                  },
+                ],
+              },
+              {
+                title: 'menu item 3-3',
+                id: '',
+                type: 'group',
+                children: [
+                  {
+                    title: 'menu item 3-3-1',
+                    id: '',
+                  },
+                  {
+                    title: 'menu item 3-3-2',
+                    id: '',
+                    children: [
+                      {
+                        title: 'menu item 3-3-2-1',
+                        id: '',
+                      },
+                      {
+                        title: 'menu item 3-3-2-2',
+                        id: '',
+                      },
+                      {
+                        title: 'menu item 3-3-2-3',
+                        id: '',
+                      },
+                    ],
+                  },
+                  {
+                    title: 'menu item 3-3-3',
+                    id: '',
+                  },
+                ],
+              },
+            ],
+          },
+          { type: '-' },
+          {
+            title: 'menu item 4',
+            id: '',
+          },
+          {
+            title: 'menu item 5',
+            id: '',
+            children: [
+              {
+                title: 'menu item 5-1',
+                id: '',
+                children: [
+                  {
+                    title: 'menu item 5-1-1',
+                    id: '',
+                  },
+                  {
+                    title: 'menu item 5-1-2',
+                    id: '',
+                  },
+                  {
+                    title: 'menu item 5-1-3',
+                    id: '',
+                  },
+                ],
+              },
+              {
+                title: 'menu item 5-2',
+                id: '',
+              },
+              {
+                title: 'menu item 5-3',
+                id: '',
+              },
+            ],
+          },
+          { type: '-' },
+          {
+            title: 'menu item 6',
+            id: '',
+            type: 'group',
+            isSpreadItem: false,
+            children: [
+              {
+                title: 'menu item 6-1',
+                id: '',
+              },
+              {
+                title: 'menu item 6-2',
+                id: '',
+              },
+              {
+                title: 'menu item 6-3',
+                id: '',
+              },
+            ],
+          },
+        ];
+
+        const dropdownInst = dropdown.render({
           elem: '#demo1',
           shade: [0.1, '#ddd'],
-          //,align: 'right'
-          data: [
-            {
-              title: 'menu item 1',
-              templet:
-                '<i class="lay-icon lay-icon-light"></i> {{= d.title }} <span class="lay-badge-dot"></span>',
-              id: '',
-              href: '',
-              type: '', //菜单类型，支持：normal/group/parent
-            },
-            {
-              title: 'menu item <strong>2</strong>',
-              templet:
-                '<img src="https://unpkg.com/outeres@0.1.1/demo/avatar/0.png" style="width: 16px;"> {{- d.title }}',
-              id: '',
-              href: 'https://www.layui.com/',
-              target: '_blank',
-            },
-            { type: '-' },
-            {},
-            {
-              title: 'menu item 3 <hello>',
-              id: '',
-              type: 'group',
-              child: [
-                {
-                  title: 'menu item 3-1',
-                  id: '',
-                },
-                {
-                  title: 'menu item 3-2',
-                  id: '',
-                  child: [
-                    {
-                      title: 'menu item 3-2-1',
-                      id: '',
-                    },
-                    {
-                      title: 'menu item 3-2-2',
-                      id: '',
-                      type: 'group',
-                      child: [
-                        {
-                          title: 'menu item 3-2-2-1',
-                          id: '',
-                        },
-                        {
-                          title: 'menu item 3-2-2-2',
-                          id: '',
-                        },
-                      ],
-                    },
-                    {
-                      title: 'menu item 3-2-3',
-                      id: '',
-                    },
-                  ],
-                },
-                {
-                  title: 'menu item 3-3',
-                  id: '',
-                  type: 'group',
-                  child: [
-                    {
-                      title: 'menu item 3-3-1',
-                      id: '',
-                    },
-                    {
-                      title: 'menu item 3-3-2',
-                      id: '',
-                      child: [
-                        {
-                          title: 'menu item 3-3-2-1',
-                          id: '',
-                        },
-                        {
-                          title: 'menu item 3-3-2-2',
-                          id: '',
-                        },
-                        {
-                          title: 'menu item 3-3-2-3',
-                          id: '',
-                        },
-                      ],
-                    },
-                    {
-                      title: 'menu item 3-3-3',
-                      id: '',
-                    },
-                  ],
-                },
-              ],
-            },
-            { type: '-' },
-            {
-              title: 'menu item 4',
-              id: '',
-            },
-            {
-              title: 'menu item 5',
-              id: '',
-              child: [
-                {
-                  title: 'menu item 5-1',
-                  id: '',
-                  child: [
-                    {
-                      title: 'menu item 5-1-1',
-                      id: '',
-                    },
-                    {
-                      title: 'menu item 5-1-2',
-                      id: '',
-                    },
-                    {
-                      title: 'menu item 5-1-3',
-                      id: '',
-                    },
-                  ],
-                },
-                {
-                  title: 'menu item 5-2',
-                  id: '',
-                },
-                {
-                  title: 'menu item 5-3',
-                  id: '',
-                },
-              ],
-            },
-            { type: '-' },
-            {
-              title: 'menu item 6',
-              id: '',
-              type: 'group',
-              isSpreadItem: false,
-              child: [
-                {
-                  title: 'menu item 6-1',
-                  id: '',
-                },
-                {
-                  title: 'menu item 6-2',
-                  id: '',
-                },
-                {
-                  title: 'menu item 6-3',
-                  id: '',
-                },
-              ],
-            },
-          ],
-
-          id: 'demo1',
-
+          data: DEMO_DATA,
           // 触发点击事件的元素范围 --- default: 仅子菜单触发点击事件（默认，可不填）; all: 所有父子菜单均触发点击事件
           clickScope: 'all',
-
           // 菜单被点击的事件
-          click: (obj) => {
-            console.log(obj);
+          click(obj) {
+            console.log('click', obj);
           },
         });
 
-        var inst = dropdown.render({
+        console.log('dropdown: ');
+        console.dir(dropdown);
+        console.log('dropdown.render instance: ', dropdownInst);
+
+        dropdown.render({
           elem: '#demo2',
-          // ,show: true
+          // defaultOpen: true,
+          closeOnClick: false,
+          // align: 'right',
           data: [
             {
               title: 'menu item 1',
@@ -243,17 +288,17 @@
               href: '#3',
             },
           ],
-          click: (data, othis) => {
-            console.log(data);
+          click(data, $this) {
+            console.log(`click ${this.id}:`, data, $this);
             if (data.id === 'bbb') {
               return false;
             }
           },
-          ready: (...args) => {
-            console.log(args);
+          ready(...args) {
+            console.log(`ready ${this.id}`, args);
           },
-          close: function () {
-            console.log('demo2', this.elem);
+          close() {
+            console.log(`close ${this.id}`, this.$elem);
           },
         });
 
@@ -263,8 +308,8 @@
           style: 'background:#666;color:#fff;padding:15px;',
           align: 'center',
           trigger: 'hover',
-          close: function () {
-            console.log('demo3', this.elem);
+          closefunction() {
+            console.log(`close ${this.id}`, this.elem);
           },
         });
 
@@ -367,11 +412,82 @@
           { trigger: 'mouseenter' },
         );
 
-        return;
-
+        // 完整重载
         dropdown.render({
-          elem: document,
-          content: '123',
+          elem: '#ID-dropdown-demo-reload',
+          data: [
+            {
+              title: 'menu item 1',
+              id: 100,
+            },
+            {
+              title: '重载该面板',
+              id: 101,
+            },
+          ],
+          click(data) {
+            // 菜单项对应设置的 id 值
+            if (data.id === 101) {
+              // 重载方法
+              dropdown.reload(this.id, {
+                data: [
+                  {
+                    title: '新选项 1',
+                    id: 111,
+                  },
+                  {
+                    title: '新选项 2',
+                    id: 222,
+                  },
+                ],
+              });
+              return false; // 点击该选项，阻止面板关闭
+            }
+          },
+        });
+
+        // 仅数据或内容重载
+        const reloadDataInst = dropdown.render({
+          elem: '#ID-dropdown-demo-reloadData',
+          data: [
+            { id: 1, title: 'Python' },
+            { id: 2, title: 'JavaScript' },
+            { id: 3, title: 'Java' },
+            { id: 4, title: 'C++' },
+            { id: 5, title: 'PHP' },
+            { id: 6, title: 'Ruby' },
+            { id: 7, title: 'Swift' },
+            { id: 8, title: 'TypeScript' },
+            { id: 9, title: 'Kotlin' },
+            { id: 10, title: 'Go' },
+          ],
+          style: 'min-width: 190px; box-shadow: 1px 1px 11px rgb(0 0 0 / 11%);',
+          click(data) {
+            this.$elem.val(data.title);
+          },
+        });
+        const sourceData = reloadDataInst.options.data;
+
+        // 输入框输入事件
+        reloadDataInst.options.$elem.on('input', function () {
+          const $this = $(this);
+          const value = $this.val().trim();
+          // 匹配到对应内容时，重载数据
+          const dataNew = sourceData.filter(function (item) {
+            const exp = new RegExp(value.split('').join('|'), 'i');
+            return exp.test(item.title);
+          });
+
+          console.log(sourceData);
+          dropdown.reloadData(reloadDataInst.options.id, {
+            data: dataNew, // 匹配到的新数据
+            template(d) {
+              const exp = new RegExp(value.split('').join('|'), 'gi');
+              return d.title.replace(exp, function (str) {
+                return '<span style="color: red;">' + str + '</span>';
+              });
+            },
+          });
         });
       });
     </script>

--- a/tests/visual/dropdown.html
+++ b/tests/visual/dropdown.html
@@ -233,7 +233,7 @@
             title: 'menu item 6',
             id: '',
             type: 'group',
-            isSpreadItem: false,
+            expanded: false,
             children: [
               {
                 title: 'menu item 6-1',
@@ -317,7 +317,7 @@
         dropdown.render({
           elem: '#ID-dropdown-demo-contextmenu', // 也可绑定到 document，从而重置整个右键
           trigger: 'contextmenu', //contextmenu
-          isAllowSpread: false,
+          allowExpand: false,
           //,style: 'width: 200px'
           customName: {
             children: 'children',

--- a/tests/visual/dropdown.html
+++ b/tests/visual/dropdown.html
@@ -308,7 +308,7 @@
           style: 'background:#666;color:#fff;padding:15px;',
           align: 'center',
           trigger: 'hover',
-          closefunction() {
+          close() {
             console.log(`close ${this.id}`, this.elem);
           },
         });
@@ -461,17 +461,29 @@
             { id: 9, title: 'Kotlin' },
             { id: 10, title: 'Go' },
           ],
+          trigger: 'focus',
           style: 'min-width: 190px; box-shadow: 1px 1px 11px rgb(0 0 0 / 11%);',
           click(data) {
             this.$elem.val(data.title);
           },
         });
+        const reloadDataInstId = reloadDataInst.options.id;
         const sourceData = reloadDataInst.options.data;
 
         // 输入框输入事件
         reloadDataInst.options.$elem.on('input', function () {
           const $this = $(this);
           const value = $this.val().trim();
+
+          // 输入为空时，恢复初始渲染状态
+          if (!value) {
+            dropdown.reloadData(reloadDataInstId, {
+              data: sourceData,
+              template: null, // 恢复默认模板
+            });
+            return;
+          }
+
           // 匹配到对应内容时，重载数据
           const dataNew = sourceData.filter(function (item) {
             const exp = new RegExp(value.split('').join('|'), 'i');
@@ -479,7 +491,7 @@
           });
 
           console.log(sourceData);
-          dropdown.reloadData(reloadDataInst.options.id, {
+          dropdown.reloadData(reloadDataInstId, {
             data: dataNew, // 匹配到的新数据
             template(d) {
               const exp = new RegExp(value.split('').join('|'), 'gi');

--- a/tests/visual/menu.html
+++ b/tests/visual/menu.html
@@ -49,7 +49,7 @@
                   </li>
                   <li
                     class="lay-menu-item-group"
-                    lay-options="{type: 'group', isAllowSpread: false}"
+                    lay-options="{type: 'group', allowExpand: false}"
                   >
                     <div class="lay-menu-body-title">menu group 2</div>
                     <ul>
@@ -178,7 +178,7 @@
               <li class="lay-menu-item-divider"></li>
               <li
                 class="lay-menu-item-group lay-menu-item-down"
-                lay-options="{type: 'group', isAllowSpread: false}"
+                lay-options="{type: 'group', allowExpand: false}"
               >
                 <div class="lay-menu-body-title">menu group</div>
                 <ul>
@@ -193,7 +193,7 @@
               <li class="lay-menu-item-divider"></li>
               <li
                 class="lay-menu-item-group lay-menu-item-down"
-                lay-options="{type: 'group', isAllowSpread: false}"
+                lay-options="{type: 'group', allowExpand: false}"
               >
                 <div class="lay-menu-body-title">menu group 2</div>
                 <ul>


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [ ] 问题修复
- [x] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- 采用 Component 基类实现
- 优化 部分选项
- 优化 遮罩生成逻辑

**注**：该 PR 基于 #3059，需在 #3059 合并后，将基准分支改为 main 且满足所有条件再合并该 PR。

### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [ ] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [ ] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 下拉菜单升级为组件化 Dropdown，支持实例化与静态调用，覆盖渲染、打开/关闭与重载（完整/仅数据）等能力
  * 分组展开/收起支持手风琴与可配置展开行为，并支持子级展开指示
* **交互与表现**
  * 统一悬停触发为鼠标进入，优化延迟关闭与外部点击/窗口变化下的自动收起
  * 支持遮罩层，并在移动端拦截触控避免误触穿透；菜单项点击可通过返回结果决定是否保持打开
* **测试/示例**
  * 更新可视化示例布局与新增“重载”交互演示、匹配高亮展示
<!-- end of auto-generated comment: release notes by coderabbit.ai -->