### PR TITLE
feat: 新增了ESM Facade

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const path = require('path');
 const { Transform } = require('stream');
 const gulp = require('gulp');
@@ -119,7 +120,11 @@ const clean = () => {
 };
 
 // 默认任务
-exports.default = gulp.series(clean, gulp.parallel(js, csp, css, files));
+exports.default = gulp.series(
+  clean,
+  gulp.parallel(js, csp, css, files),
+  generateModuleFacade
+);
 exports.csp = csp;
 
 // 复制 dist 目录到指定路径
@@ -325,4 +330,17 @@ function validateBundle(type) {
       }
     }
   });
+}
+
+// 生成 module facade
+function generateModuleFacade(done) {
+  const esm = `${config.comment}
+import './layui.js';
+var layui = window.layui;
+export { layui };
+export default layui;
+`;
+
+  fs.writeFileSync(path.join(dest, 'layui.mjs'), esm);
+  done();
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -340,7 +340,14 @@ var layui = window.layui;
 export { layui };
 export default layui;
 `;
+  const csp = `${config.comment}
+import './layui.csp.js';
+var layui = window.layui;
+export { layui };
+export default layui;
+`;
 
   fs.writeFileSync(path.join(dest, 'layui.mjs'), esm);
+  fs.writeFileSync(path.join(dest, 'layui.csp.mjs'), csp);
   done();
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,10 @@
       "import": "./dist/layui.mjs",
       "default": "./dist/layui.js"
     },
+    "./csp": {
+      "import": "./dist/layui.csp.mjs",
+      "default": "./dist/layui.csp.js"
+    },
     "./css/*": "./dist/css/*",
     "./dist/*": "./dist/*",
     "./package.json": "./package.json"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,16 @@
     "url": "git+ssh://git@github.com/layui/layui.git"
   },
   "main": "dist/layui.js",
+  "module": "dist/layui.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/layui.mjs",
+      "default": "./dist/layui.js"
+    },
+    "./css/*": "./dist/css/*",
+    "./dist/*": "./dist/*",
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [ ] 问题修复
- [x] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

这个 PR 是 #3069 的一个补充分支，如果决定合入，应先将其合并到 #3069，再处理 #3069 。

- 新增 ESM 包装，改善 layui 在包管理器和打包器中的使用。只支持浏览器环境，不考虑 Node、Web Worker 以及模拟 DOM 的环境。
- 优化包导出配置，支持灵活的子路径导入方式（如./css/*和./dist/*）

目前可以通过在开发工具中配置依赖导入别名或自行添加 ESM 「代理包装」实现类似的效果，但是每次这么做有点麻烦，如果 layui 能内置就更好了。也可以降低在现代开发工具中使用 layui 2.x 的门槛。

### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增ES Module（ESM）支持，用户现可通过`import`方式导入库文件
  * 优化包导出配置，支持灵活的子路径导入方式（如`./css/*`和`./dist/*`）

<!-- end of auto-generated comment: release notes by coderabbit.ai -->