### PR TITLE
feat!: 重构 laypage 组件

### DIFF
--- a/src/components/laypage.js
+++ b/src/components/laypage.js
@@ -1,407 +1,438 @@
 /**
- * laypage 分页组件
+ * laypage
+ * 分页组件
  */
 
 import { lay } from '../core/lay.js';
 import { i18n } from '../core/i18n.js';
+import { $ } from 'jquery';
+import { Component } from '../core/component.js';
 
-var doc = document;
-var id = 'getElementById';
-var tag = 'getElementsByTagName';
+export class Laypage extends Component {
+  componentName = 'pagination';
 
-// 字符常量
-// var MOD_NAME = 'laypage';
-var DISABLED = 'lay-disabled';
+  // 默认配置项
+  static options = {
+    count: 0, // 数据总数
+    current: 1, // 当前页
+    limit: 10, // 每页条数
+    limits: [10, 20, 30, 40, 50], // 每页条数选择项
+    pageCount: 5, // 连续页码数
+    prev: '<i class="lay-icon lay-icon-left"></i>', // 上一页文本
+    next: '<i class="lay-icon lay-icon-right"></i>', // 下一页文本
+    layout: ['prev', 'page', 'next'], // 组件布局；内置组件：count|prev|page|simplePage|next|limits|refresh|jump ；亦可通过 templates 配置项自定义组件模板
+    // align: 'start', // 对齐方式；可选值：start|end|center
+    // className: '', // 根容器的额外类名
+    // css: '', // 自定义 CSS 样式
+    // disabled: false, // 是否禁用分页组件
+    // size: '', // 组件尺寸 可选值：sm|md|lg
+    // theme: '', // 内置主题风格 可选值：border|background
+    hideOnSinglePage: false, // 只有一页时是否隐藏分页组件
+  };
 
-// 构造器
-var Class = function (options) {
-  var that = this;
-  that.config = options || {};
-  that.index = laypage.index = lay.autoIncrementer('laypage');
-  that.render(true);
-};
-
-// 判断传入的容器类型
-Class.prototype.type = function () {
-  var config = this.config;
-  if (typeof config.elem === 'object') {
-    return config.elem.length === undefined ? 2 : 3;
-  }
-};
-
-// 分页视图
-Class.prototype.view = function () {
-  var that = this;
-  var config = that.config;
-
-  // 连续页码个数
-  var groups = (config.groups =
-    'groups' in config ? Number(config.groups) || 0 : 5);
-
-  // 排版
-  config.layout =
-    typeof config.layout === 'object'
-      ? config.layout
-      : ['prev', 'page', 'next'];
-
-  config.count = Number(config.count) || 0; // 数据总数
-  config.curr = Number(config.curr) || 1; // 当前页
-
-  // 每页条数的选择项
-  config.limits =
-    typeof config.limits === 'object' ? config.limits : [10, 20, 30, 40, 50];
-
-  // 默认条数
-  config.limit = Number(config.limit) || 10;
-
-  // 总页数
-  config.pages = Math.ceil(config.count / config.limit) || 1;
-
-  // 当前页不能超过总页数
-  if (config.curr > config.pages) {
-    config.curr = config.pages;
-  } else if (config.curr < 1) {
-    // 当前分页不能小于 1
-    config.curr = 1;
+  static get CONST() {
+    return {
+      ...super.CONST,
+      CLASS_ITEM: 'lay-pagination-item',
+      CLASS_LINK: 'lay-pagination-link',
+      CLASS_ELLIPSIS: 'lay-pagination-ellipsis',
+      CLASS_LIMITS: 'lay-pagination-limits',
+      CLASS_JUMP: 'lay-pagination-jump',
+    };
   }
 
-  // 连续分页个数不能低于 0 且不能大于总页数
-  if (groups < 0) {
-    groups = 1;
-  } else if (groups > config.pages) {
-    groups = config.pages;
+  // 实例方法静态委托
+  static {
+    this.delegateInstanceMethods(['jump']);
   }
 
-  config.prev = 'prev' in config ? config.prev : i18n.$t('laypage.prev'); // 上一页文本
-  config.next = 'next' in config ? config.next : i18n.$t('laypage.next'); // 下一页文本
+  // 构造函数
+  constructor(options) {
+    super(options);
 
-  // 计算当前组
-  var index =
-    config.pages > groups
-      ? Math.ceil(
-          (config.curr + (groups > 1 ? 1 : 0)) / (groups > 0 ? groups : 1),
-        )
-      : 1;
+    this.overrideArrayOptions(options);
+  }
 
-  // 视图片段
-  var views = {
-    // 上一页
-    prev: (function () {
-      return config.prev
-        ? '<a class="lay-laypage-prev' +
-            (config.curr == 1 ? ' ' + DISABLED : '') +
-            '" data-page="' +
-            (config.curr - 1) +
-            '">' +
-            config.prev +
-            '</a>'
-        : '';
-    })(),
+  // 渲染
+  render() {
+    const options = this.options;
+    const $elem = options.$elem;
 
-    // 页码
-    page: (function () {
-      var pager = [];
+    if (!$elem.length) return;
 
-      // 数据量为0时，不输出页码
-      if (config.count < 1) {
-        return '';
-      }
+    $elem.html(this.#buildPaginationHtml());
+    this.events();
+    options.afterRender?.(options); // 渲染完成后的回调
+  }
 
-      // 首页
-      if (index > 1 && config.first !== false && groups !== 0) {
-        pager.push(
-          '<a class="lay-laypage-first" data-page="1"  title="' +
-            i18n.$t('laypage.first') +
-            '">' +
-            (config.first || 1) +
-            '</a>',
-        );
-      }
+  /**
+   * 跳页
+   * @param {number} page - 目标页码
+   */
+  jump(page) {
+    const options = this.options;
+    const pageNum = Number(page);
 
-      // 计算当前页码组的起始页
-      var halve = Math.floor((groups - 1) / 2); // 页码数等分
-      var start = index > 1 ? config.curr - halve : 1;
-      var end =
-        index > 1
-          ? (function () {
-              var max = config.curr + (groups - halve - 1);
-              return max > config.pages ? config.pages : max;
-            })()
-          : groups;
+    // 重置页码
+    if (Number.isFinite(pageNum) && pageNum > 0) {
+      options.current = pageNum;
+    }
 
-      // 防止最后一组出现“不规定”的连续页码数
-      if (end - start < groups - 1) {
-        start = end - groups + 1;
-      }
+    this.render();
+    options?.onChange?.(options); // 页码或 limit 改变时的回调
+  }
 
-      // 输出左分割符
-      if (config.first !== false && start > 2) {
-        pager.push('<span class="lay-laypage-spr">...</span>');
-      }
+  // 规范化配置项
+  #normalizeOptions({ totalPages }) {
+    const options = this.options;
+    options.current = Number(options.current);
 
-      // 输出连续页码
-      for (; start <= end; start++) {
-        if (start === config.curr) {
-          // 当前页
-          pager.push(
-            '<span class="lay-laypage-curr"><em class="lay-laypage-em" ' +
-              (/^#/.test(config.theme)
-                ? 'style="background-color:' + config.theme + ';"'
-                : '') +
-              '></em><em>' +
-              start +
-              '</em></span>',
-          );
+    // 若页码不合法，则重置为 1
+    if (options.current < 1 || !Number.isFinite(options.current)) {
+      options.current = 1;
+    } else if (options.current > totalPages) {
+      // 当前页不能超过总页数
+      options.current = totalPages;
+    }
+
+    // 若当前页码 * 条数超过总数，则将当前页码重置为最后一页
+    if (options.current * options.limit > options.count) {
+      options.current = totalPages;
+    }
+
+    // 连续页码数的规范化处理
+    if (options.pageCount < 1) {
+      options.pageCount = 1;
+    } else if (options.pageCount > totalPages) {
+      options.pageCount = totalPages;
+    }
+  }
+
+  // 生成分页 HTML
+  #buildPaginationHtml() {
+    const options = this.options;
+
+    // 计算总页数
+    const totalPages = Math.ceil(options.count / options.limit) || 1;
+
+    this.#normalizeOptions({ totalPages });
+
+    const { current, pageCount } = options;
+    const ELLIPSIS = '···';
+
+    // 只有一页时根据配置决定是否输出分页结构
+    if (totalPages === 1 && options.hideOnSinglePage) {
+      return '';
+    }
+
+    // 根容器
+    const $rootElem = (this.$rootElem = $(
+      '<ul class="lay-pagination lay-border-box lay-unselect">',
+    ));
+
+    this.#applyRootElemStyles();
+
+    // 组件模板
+    const templates = {
+      ...options.templates, // 自定义模板
+
+      // 总数
+      count() {
+        const $li = $(`<li class="lay-pagination-count">`);
+        $li.text(i18n.$t('laypage.total', { total: options.count }));
+        return $li;
+      },
+
+      // 上一页
+      prev() {
+        const $li = $(`<li class="lay-pagination-prev">`);
+        const $a = $(`<a>`).appendTo($li);
+        if (current === 1) {
+          $a.addClass(CONST.CLASS_DISABLED);
         } else {
-          pager.push('<a data-page="' + start + '">' + start + '</a>');
+          $a.addClass(CONST.CLASS_LINK);
         }
-      }
+        $a.data('page', current - 1).html(options.prev);
+        return $li;
+      },
+      // 页码
+      page() {
+        const elems = [];
 
-      // 输出输出右分隔符 & 末页
-      if (
-        config.pages > groups &&
-        config.pages > end &&
-        config.last !== false
-      ) {
-        if (end + 1 < config.pages) {
-          pager.push('<span class="lay-laypage-spr">...</span>');
+        // 初始连续页码范围
+        let startPage = 1;
+        let endPage = totalPages;
+
+        // 总页数超过连续页码数时，分段计算连续页码范围
+        if (totalPages > pageCount) {
+          // 连续页码数等分
+          const halfVisiblePages = Math.floor((pageCount - 1) / 2);
+          // 末段页码的起始页
+          const lastStartPage = totalPages - pageCount + 1;
+
+          // 首段页码范围
+          if (current < pageCount) {
+            startPage = 1;
+            endPage = pageCount;
+          } else if (current > lastStartPage) {
+            // 末段页码范围
+            startPage = lastStartPage;
+            endPage = totalPages;
+          } else {
+            // 中间段页码范围
+            startPage = current - halfVisiblePages;
+            endPage = startPage + pageCount - 1;
+          }
         }
-        if (groups !== 0) {
-          pager.push(
-            '<a class="lay-laypage-last" title="' +
-              i18n.$t('laypage.last') +
-              '"  data-page="' +
-              config.pages +
-              '">' +
-              (config.last || config.pages) +
-              '</a>',
+
+        // 显示「首页」的条件
+        const showFirstPage = options.first !== false && startPage > 1;
+        // 显示「左侧省略号」的条件
+        const showLeftEllipsis = options.first !== false && startPage > 2;
+        // 显示「右侧省略号」的条件
+        const showRightEllipsis =
+          options.first !== false && endPage < totalPages - 1;
+        // 显示「末页」的条件
+        const showLastPage = options.first !== false && endPage < totalPages;
+
+        // 生成首页
+        if (showFirstPage) {
+          const $li = $(`<li class="${CONST.CLASS_ITEM}">`);
+          const $a = $(`<a class="${CONST.CLASS_LINK}">`);
+          $a.data('page', 1).html(1);
+          $li.append($a);
+          elems.push($li);
+        }
+
+        // 生成左侧省略号
+        if (showLeftEllipsis) {
+          elems.push(
+            `<li class="${CONST.CLASS_ELLIPSIS}"><span>${ELLIPSIS}</span></li>`,
           );
         }
-      }
 
-      return pager.join('');
-    })(),
-
-    // 下一页
-    next: (function () {
-      return config.next
-        ? '<a class="lay-laypage-next' +
-            (config.curr == config.pages ? ' ' + DISABLED : '') +
-            '" data-page="' +
-            (config.curr + 1) +
-            '">' +
-            config.next +
-            '</a>'
-        : '';
-    })(),
-
-    // 数据总数
-    count: (function () {
-      var countText =
-        typeof config.countText === 'object'
-          ? config.countText[0] + config.count + config.countText[1]
-          : i18n.$t('laypage.total', { total: config.count });
-
-      return '<span class="lay-laypage-count">' + countText + '</span>';
-    })(),
-
-    // 每页条数
-    limit: (function () {
-      var elemArr = ['<span class="lay-laypage-limits"><select lay-ignore>'];
-      var template = function (item) {
-        var def = item + ' ' + i18n.$t('laypage.pagesize');
-        return typeof config.limitTemplet === 'function'
-          ? config.limitTemplet(item) || def
-          : def;
-      };
-
-      // 条目选项列表
-      config.limits.forEach(function (item) {
-        elemArr.push(
-          '<option value="' +
-            item +
-            '"' +
-            (item === config.limit ? ' selected' : '') +
-            '>' +
-            template(item) +
-            '</option>',
-        );
-      });
-
-      return elemArr.join('') + '</select></span>';
-    })(),
-
-    // 刷新当前页
-    refresh: [
-      '<a data-page="' + config.curr + '" class="lay-laypage-refresh">',
-      '<i class="lay-icon lay-icon-refresh"></i>',
-      '</a>',
-    ].join(''),
-
-    // 跳页区域
-    skip: (function () {
-      var skipText =
-        typeof config.skipText === 'object'
-          ? config.skipText
-          : [
-              i18n.$t('laypage.goto'),
-              i18n.$t('laypage.page'),
-              i18n.$t('laypage.confirm'),
-            ];
-      return [
-        '<span class="lay-laypage-skip">' + skipText[0],
-        '<input type="text" min="1" value="' +
-          config.curr +
-          '" class="lay-input">',
-        skipText[1] +
-          '<button type="button" class="lay-laypage-btn">' +
-          skipText[2] +
-          '</button>',
-        '</span>',
-      ].join('');
-    })(),
-  };
-
-  return [
-    '<div class="lay-box lay-unselect lay-laypage lay-laypage-' +
-      (config.theme
-        ? /^#/.test(config.theme)
-          ? 'molv'
-          : config.theme
-        : 'default') +
-      '" id="lay-laypage-' +
-      that.index +
-      '">',
-    (function () {
-      var plate = [];
-      config.layout.forEach(function (item) {
-        if (views[item]) {
-          plate.push(views[item]);
+        // 生成连续页码
+        for (let page = startPage; page <= endPage; page++) {
+          const $li = $(`<li class="${CONST.CLASS_ITEM}">`);
+          const $a = $(`<a>`).appendTo($li);
+          if (page === current) {
+            $li.addClass(`${CONST.CLASS_ITEM}-active`);
+          } else {
+            $a.addClass(CONST.CLASS_LINK);
+          }
+          $a.data('page', page).html(page);
+          elems.push($li);
         }
-      });
-      return plate.join('');
-    })(),
-    '</div>',
-  ].join('');
-};
 
-// 跳页的回调
-Class.prototype.jump = function (elem, isskip) {
-  if (!elem) return;
+        // 生成右侧省略号
+        if (showRightEllipsis) {
+          elems.push(
+            `<li class="${CONST.CLASS_ELLIPSIS}"><span>${ELLIPSIS}</span></li>`,
+          );
+        }
 
-  var that = this;
-  var config = that.config;
-  var childs = elem.children;
-  var btn = elem[tag]('button')[0];
-  var input = elem[tag]('input')[0];
-  var select = elem[tag]('select')[0];
-  var skip = function () {
-    var curr = Number(input.value.replace(/\s|\D/g, ''));
-    if (curr) {
-      config.curr = curr;
-      that.render();
-    }
-  };
+        // 生成末页
+        if (showLastPage) {
+          const $li = $(`<li class="${CONST.CLASS_ITEM}">`);
+          const $a = $(`<a class="${CONST.CLASS_LINK}">`).appendTo($li);
+          $a.data('page', totalPages).html(totalPages);
+          elems.push($li);
+        }
 
-  if (isskip) return skip();
+        return elems;
+      },
 
-  // 页码
-  for (var i = 0, len = childs.length; i < len; i++) {
-    if (childs[i].nodeName.toLowerCase() === 'a') {
-      laypage.on(childs[i], 'click', function () {
-        var curr = Number(this.getAttribute('data-page'));
-        if (curr < 1 || curr > config.pages) return;
-        config.curr = curr;
-        that.render();
-      });
-    }
-  }
+      // 简约页码
+      simplePage() {
+        const $li = $(`<li class="lay-pagination-simple-page">`);
+        $li.text(`${current} / ${totalPages}`);
+        return $li;
+      },
 
-  // 条数
-  if (select) {
-    laypage.on(select, 'change', function () {
-      var value = this.value;
-      if (config.curr * value > config.count) {
-        config.curr = Math.ceil(config.count / value);
+      // 下一页
+      next() {
+        const $li = $(`<li class="lay-pagination-next">`);
+        const $a = $(`<a>`).appendTo($li);
+        if (current === totalPages) {
+          $a.addClass(CONST.CLASS_DISABLED);
+        } else {
+          $a.addClass(CONST.CLASS_LINK);
+        }
+        $a.data('page', current + 1).html(options.next);
+        return $li;
+      },
+
+      // 选择条数
+      limits() {
+        const $li = $(`<li class="${CONST.CLASS_LIMITS}">`);
+        const $select = $(`<select lay-ignore></select>`).appendTo($li);
+
+        options.limits.forEach((item) => {
+          const $option = $(`<option>`);
+          const optionText = `${item} ${i18n.$t('laypage.pagesize')}`;
+
+          $option.val(item).text(optionText);
+          if (item === options.limit) {
+            $option.prop('selected', true);
+          }
+
+          $option.appendTo($select);
+        });
+
+        return $li;
+      },
+
+      // 刷新当前页
+      refresh() {
+        const $li = $(`<li class="lay-pagination-refresh">`);
+        const $a = $(
+          `<a class="${CONST.CLASS_LINK}"><i class="lay-icon lay-icon-refresh"></i></a>`,
+        ).appendTo($li);
+        $a.data('page', current);
+        return $li;
+      },
+
+      // 跳页区域
+      jump() {
+        const $li = $(`<li class="${CONST.CLASS_JUMP}">`);
+        const jumpText = [
+          i18n.$t('laypage.goto'),
+          i18n.$t('laypage.page'),
+          i18n.$t('laypage.confirm'),
+        ];
+
+        $li.append(`<span>${jumpText[0]}</span>`);
+
+        const $input = $(
+          `<input type="text" min="1" class="lay-input">`,
+        ).appendTo($li);
+        $li.append(`<span>${jumpText[1]}</span>`);
+        const $button = $(`<button type="button">`).appendTo($li);
+
+        $input.val(current);
+        $button.text(jumpText[2]);
+        return $li;
+      },
+    };
+
+    // 根据 layout 数组顺序生成分页器结构
+    options.layout.forEach((item) => {
+      if (templates[item]) {
+        const templateResult = templates[item]({ ...options, totalPages });
+        if (Array.isArray(templateResult)) {
+          templateResult.forEach(($elem) => $rootElem.append($elem));
+        } else {
+          $rootElem.append(templateResult);
+        }
       }
-      config.limit = value;
-      that.render();
+    });
+
+    return $rootElem;
+  }
+
+  // 为根容器应用额外的类名和样式
+  #applyRootElemStyles() {
+    const options = this.options;
+    const $rootElem = this.$rootElem;
+
+    // 对齐方式
+    if (['start', 'center', 'end'].includes(options.align)) {
+      $rootElem.addClass(`lay-pagination-align-${options.align}`);
+    }
+
+    // 组件尺寸
+    if (['sm', 'md', 'lg'].includes(options.size)) {
+      $rootElem.addClass(`lay-size-${options.size}`);
+    }
+
+    // 内置主题风格
+    if (['border', 'background'].includes(options.theme)) {
+      $rootElem.addClass(`lay-pagination-theme-${options.theme}`);
+    }
+
+    // 是否禁用
+    if (options.disabled) {
+      $rootElem.addClass(CONST.CLASS_DISABLED);
+    }
+
+    // 自定义类名
+    $rootElem.addClass(options.className);
+
+    // 自定义样式
+    if (options.css) {
+      lay.style({
+        target: $rootElem[0],
+        text: `[lay-laypage-id="${options.id}"] { ${options.css} }`,
+      });
+    }
+  }
+
+  // 事件
+  events() {
+    const options = this.options;
+    const $elem = options.$elem;
+
+    // 根据输入的页码进行跳转
+    const submitJumpPage = () => {
+      const $jumper = $elem.find(`.${CONST.CLASS_JUMP}`);
+      const $jumperInput = $jumper.find('input');
+      const current = Number($jumperInput.val().replace(/\s|\D/g, ''));
+
+      if (current) {
+        this.jump(current);
+      }
+    };
+
+    // 事件命名空间
+    const eventNamespace = CONST.EVENT_NAMESPACE;
+
+    // 避免重复绑定事件
+    $elem.off(eventNamespace);
+
+    // 点击页码
+    $elem.on(`click${eventNamespace}`, `.${CONST.CLASS_LINK}`, (e) => {
+      const $this = $(e.currentTarget);
+      const current = $this.data('page');
+      this.jump(current);
+    });
+
+    // 选择条数
+    $elem.on(
+      `change${eventNamespace}`,
+      `.${CONST.CLASS_LIMITS} > select`,
+      (e) => {
+        options.limit = Number(e.currentTarget.value);
+        this.jump();
+        options?.onLimitChange?.(options); // 条数改变时的回调
+      },
+    );
+
+    // 跳转输入框键盘事件
+    $elem.on(`keyup${eventNamespace}`, `.${CONST.CLASS_JUMP} > input`, (e) => {
+      const value = e.currentTarget.value;
+      const keyCode = e.keyCode;
+
+      // 方向键不做处理
+      if (/^(37|38|39|40)$/.test(keyCode)) return;
+
+      // 限制仅允许输入数字
+      if (/\D/.test(value)) {
+        e.currentTarget.value = value.replace(/\D/g, '');
+      }
+
+      // 回车触发跳转
+      if (keyCode === 13) {
+        submitJumpPage();
+      }
+    });
+
+    // 跳转确定按钮事件
+    $elem.on(`click${eventNamespace}`, `.${CONST.CLASS_JUMP} > button`, () => {
+      submitJumpPage();
     });
   }
+}
 
-  // 确定
-  if (btn) {
-    laypage.on(btn, 'click', function () {
-      skip();
-    });
-  }
-};
+const CONST = Laypage.CONST;
 
-// 输入页数字控制
-Class.prototype.skip = function (elem) {
-  if (!elem) return;
-
-  var that = this;
-  var input = elem[tag]('input')[0];
-
-  if (!input) return;
-
-  // 键盘事件
-  laypage.on(input, 'keyup', function (e) {
-    var value = this.value;
-    var keyCode = e.keyCode;
-
-    if (/^(37|38|39|40)$/.test(keyCode)) return;
-
-    if (/\D/.test(value)) {
-      this.value = value.replace(/\D/, '');
-    }
-    if (keyCode === 13) {
-      that.jump(elem, true);
-    }
-  });
-};
-
-// 渲染分页
-Class.prototype.render = function (load) {
-  var that = this;
-  var config = that.config;
-  var type = that.type();
-  var view = that.view();
-
-  if (type === 2) {
-    config.elem && (config.elem.innerHTML = view);
-  } else if (type === 3) {
-    config.elem.html(view);
-  } else {
-    if (doc[id](config.elem)) {
-      doc[id](config.elem).innerHTML = view;
-    }
-  }
-
-  config.jump && config.jump(config, load);
-
-  var elem = doc[id]('lay-laypage-' + that.index);
-  that.jump(elem);
-
-  if (config.hash && !load) {
-    location.hash = '!' + config.hash + '=' + config.curr;
-  }
-
-  that.skip(elem);
-};
-
-// 外部接口
-var laypage = {
-  // 分页渲染
-  render: function (options) {
-    var o = new Class(options);
-    return o.index;
-  },
-  on: function (elem, even, fn) {
-    elem.addEventListener(even, fn, false);
-    return this;
-  },
-};
-
-export { laypage };
+export { Laypage as laypage };

--- a/src/components/laypage.js
+++ b/src/components/laypage.js
@@ -190,10 +190,9 @@ export class Laypage extends Component {
         // 显示「左侧省略号」的条件
         const showLeftEllipsis = options.first !== false && startPage > 2;
         // 显示「右侧省略号」的条件
-        const showRightEllipsis =
-          options.first !== false && endPage < totalPages - 1;
+        const showRightEllipsis = options.last !== false && endPage < totalPages - 1;
         // 显示「末页」的条件
-        const showLastPage = options.first !== false && endPage < totalPages;
+        const showLastPage = options.last !== false && endPage < totalPages;
 
         // 生成首页
         if (showFirstPage) {

--- a/src/components/laypage.js
+++ b/src/components/laypage.js
@@ -9,7 +9,7 @@ import { $ } from 'jquery';
 import { Component } from '../core/component.js';
 
 export class Laypage extends Component {
-  componentName = 'pagination';
+  static componentName = 'laypage';
 
   // 默认配置项
   static options = {
@@ -388,6 +388,9 @@ export class Laypage extends Component {
 
     // 避免重复绑定事件
     $elem.off(eventNamespace);
+
+    // 分页是否禁用
+    if (options.disabled) return;
 
     // 点击页码
     $elem.on(`click${eventNamespace}`, `.${CONST.CLASS_LINK}`, (e) => {

--- a/src/components/laypage.js
+++ b/src/components/laypage.js
@@ -61,7 +61,7 @@ export class Laypage extends Component {
     if (!$elem.length) return;
 
     $elem.html(this.#buildPaginationHtml());
-    this.events();
+    this.#events();
     options.afterRender?.(options); // 渲染完成后的回调
   }
 
@@ -368,7 +368,7 @@ export class Laypage extends Component {
   }
 
   // 事件
-  events() {
+  #events() {
     const options = this.options;
     const $elem = options.$elem;
 

--- a/src/components/laypage.js
+++ b/src/components/laypage.js
@@ -190,7 +190,8 @@ export class Laypage extends Component {
         // 显示「左侧省略号」的条件
         const showLeftEllipsis = options.first !== false && startPage > 2;
         // 显示「右侧省略号」的条件
-        const showRightEllipsis = options.last !== false && endPage < totalPages - 1;
+        const showRightEllipsis =
+          options.last !== false && endPage < totalPages - 1;
         // 显示「末页」的条件
         const showLastPage = options.last !== false && endPage < totalPages;
 

--- a/src/components/laypage.js
+++ b/src/components/laypage.js
@@ -20,7 +20,9 @@ export class Laypage extends Component {
     pageCount: 5, // 连续页码数
     prev: '<i class="lay-icon lay-icon-left"></i>', // 上一页文本
     next: '<i class="lay-icon lay-icon-right"></i>', // 下一页文本
-    layout: ['prev', 'page', 'next'], // 组件布局；内置组件：count|prev|page|simplePage|next|limits|refresh|jump ；亦可通过 templates 配置项自定义组件模板
+    // 组件布局。可选值：count|prev|page|simplePage|next|limits|refresh|jump
+    // 亦可通过 templates 配置项自定义组件模板
+    layout: ['prev', 'page', 'next'],
     // align: 'start', // 对齐方式；可选值：start|end|center
     // className: '', // 根容器的额外类名
     // css: '', // 自定义 CSS 样式
@@ -134,7 +136,8 @@ export class Laypage extends Component {
 
     // 组件模板
     const templates = {
-      ...options.templates, // 自定义模板
+      // 自定义模板。放在最前，避免覆盖内置模板
+      ...options.templates,
 
       // 总数
       count() {

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -402,7 +402,7 @@ Class.prototype.render = function (type) {
     options.limits = options.page.limits || options.limits;
     that.page = options.page.current = options.page.current || 1;
     delete options.page.elem;
-    delete options.page.jump;
+    delete options.page.onChange;
   }
 
   // 加载 i18n 自定义文本

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -1788,7 +1788,7 @@ Class.prototype.renderData = function (opts) {
   // 同步分页状态
   if (options.page) {
     const pageId = `lay-table-page${options.index}`;
-    const laypageInstance = laypage.getInstance(pageId);
+    // console.log(options.page);
 
     // 渲染分页组件
     options.page = $.extend(
@@ -1801,17 +1801,17 @@ Class.prototype.renderData = function (opts) {
         size: 'sm',
         layout: ['prev', 'page', 'next', 'limits', 'jump', 'count'],
         onChange: function (opts) {
-          // 分页本身并非需要做以下更新，下面参数的同步，主要是因为其它处理统一用到了它们
-          // 而并非用的是 options.page 中的参数（以确保分页未开启的情况仍能正常使用）
-          that.page = opts.current; // 更新页码
-          that.config.limit = opts.limit; // 更新每页条数
+          // Tip: 此处用 `that.config`（而不是 `options`）对选项进行赋值，是因为 table 的 `reload` 方法中对 `this.config` 进行了重置。
+          // 后续 table 基于 Component 基类重构，则不存在该问题
+          that.page = that.config.page.current = opts.current; // 更新页码
+          that.config.limit = that.config.page.limit = opts.limit; // 更新每页条数
 
           that.pullData(opts.current);
         },
       },
       options.page,
-      laypageInstance?.options,
     );
+    that.config.page.count = count; // 更新总条数
     laypage.render(options.page);
   }
 };

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -400,7 +400,7 @@ Class.prototype.render = function (type) {
   if (options.page !== null && typeof options.page === 'object') {
     options.limit = options.page.limit || options.limit;
     options.limits = options.page.limits || options.limits;
-    that.page = options.page.curr = options.page.curr || 1;
+    that.page = options.page.current = options.page.current || 1;
     delete options.page.elem;
     delete options.page.jump;
   }
@@ -1306,7 +1306,7 @@ Class.prototype.errorView = function (html) {
 Class.prototype.page = 1;
 
 // 获得数据
-Class.prototype.pullData = function (curr, opts) {
+Class.prototype.pullData = function (current, opts) {
   var that = this;
   var options = that.config;
   // 同步表头父列的相关值
@@ -1328,7 +1328,7 @@ Class.prototype.pullData = function (curr, opts) {
     that.setColsWidth();
     that.loading(false);
     typeof options.done === 'function' &&
-      options.done(res, curr, res[response.countName], origin);
+      options.done(res, current, res[response.countName], origin);
     typeof opts.done === 'function' && opts.done();
   };
 
@@ -1355,7 +1355,7 @@ Class.prototype.pullData = function (curr, opts) {
 
     (that.renderData({
       res: res,
-      curr: curr,
+      current: current,
       count: res[response.countName],
       type: opts.type,
       sort: true,
@@ -1366,7 +1366,7 @@ Class.prototype.pullData = function (curr, opts) {
     var params = {};
     // 当 page 开启，默认自动传递 page、limit 参数
     if (options.page) {
-      params[request.pageName] = curr;
+      params[request.pageName] = current;
       params[request.limitName] = options.limit;
     }
 
@@ -1410,13 +1410,13 @@ Class.prototype.pullData = function (curr, opts) {
           // 当前页不能超过总页数
           var count = res[response.countName];
           var pages = Math.ceil(count / options.limit) || 1;
-          if (curr > pages) {
-            curr = pages;
+          if (current > pages) {
+            current = pages;
           }
           that.totalRow = res[response.totalRowName];
           (that.renderData({
             res: res,
-            curr: curr,
+            current: current,
             count: count,
             type: opts.type,
           }),
@@ -1450,7 +1450,7 @@ Class.prototype.pullData = function (curr, opts) {
   } else if (lay.type(options.data) === 'array') {
     //已知数据
     res = {};
-    var startLimit = curr * options.limit - options.limit;
+    var startLimit = current * options.limit - options.limit;
     var newData = options.data.concat();
 
     res[response.dataName] = options.page
@@ -1466,7 +1466,7 @@ Class.prototype.pullData = function (curr, opts) {
 
     (that.renderData({
       res: res,
-      curr: curr,
+      current: current,
       count: res[response.countName],
       type: opts.type,
     }),
@@ -1494,19 +1494,19 @@ Class.prototype.col = function (key) {
   }
 };
 
-Class.prototype.getTrHtml = function (data, sort, curr, trsObj) {
+Class.prototype.getTrHtml = function (data, sort, current, trsObj) {
   var that = this;
   var options = that.config;
   var trs = (trsObj && trsObj.trs) || [];
   var trs_fixed = (trsObj && trsObj.trs_fixed) || [];
   var trs_fixed_r = (trsObj && trsObj.trs_fixed_r) || [];
-  curr = curr || 1;
+  current = current || 1;
 
   data.forEach(function (item1, i1) {
     var tds = [];
     var tds_fixed = [];
     var tds_fixed_r = [];
-    var numbers = i1 + options.limit * (curr - 1) + 1; // 序号
+    var numbers = i1 + options.limit * (current - 1) + 1; // 序号
 
     // 数组值是否为 object，如果不是，则自动转为 object
     if (typeof item1 !== 'object') {
@@ -1687,7 +1687,7 @@ Class.prototype.renderData = function (opts) {
   var options = that.config;
 
   var res = opts.res;
-  var curr = opts.curr;
+  var current = opts.current;
   var count = (that.count = opts.count);
   var sort = opts.sort;
 
@@ -1709,7 +1709,7 @@ Class.prototype.renderData = function (opts) {
       });
     }
 
-    that.getTrHtml(data, sort, curr, {
+    that.getTrHtml(data, sort, current, {
       trs: trs,
       trs_fixed: trs_fixed,
       trs_fixed_r: trs_fixed_r,
@@ -1763,7 +1763,7 @@ Class.prototype.renderData = function (opts) {
   that.layPage
     .find(ELEM_PAGE_VIEW)
     [
-      !options.page || count == 0 || (data.length === 0 && curr == 1)
+      !options.page || count == 0 || (data.length === 0 && current == 1)
         ? 'addClass'
         : 'removeClass'
     ](HIDE_V);
@@ -1785,32 +1785,33 @@ Class.prototype.renderData = function (opts) {
   that.renderTotal(data, totalRowData); //数据合计
   that.layTotal && that.layTotal.removeClass(HIDE);
 
-  //同步分页状态
+  // 同步分页状态
   if (options.page) {
+    const pageId = `lay-table-page${options.index}`;
+    const laypageInstance = laypage.getInstance(pageId);
+
+    // 渲染分页组件
     options.page = $.extend(
       {
-        elem: 'lay-table-page' + options.index,
+        elem: `#${pageId}`,
         count: count,
         limit: options.limit,
         limits: options.limits || [10, 20, 30, 40, 50, 60, 70, 80, 90],
-        groups: 3,
-        layout: ['prev', 'page', 'next', 'skip', 'count', 'limit'],
-        prev: '<i class="lay-icon">&#xe603;</i>',
-        next: '<i class="lay-icon">&#xe602;</i>',
-        jump: function (obj, first) {
-          if (!first) {
-            //分页本身并非需要做以下更新，下面参数的同步，主要是因为其它处理统一用到了它们
-            //而并非用的是 options.page 中的参数（以确保分页未开启的情况仍能正常使用）
-            that.page = obj.curr; //更新页码
-            options.limit = obj.limit; //更新每页条数
+        pageCount: 3,
+        size: 'sm',
+        layout: ['prev', 'page', 'next', 'limits', 'jump', 'count'],
+        onChange: function (opts) {
+          // 分页本身并非需要做以下更新，下面参数的同步，主要是因为其它处理统一用到了它们
+          // 而并非用的是 options.page 中的参数（以确保分页未开启的情况仍能正常使用）
+          that.page = opts.current; // 更新页码
+          that.config.limit = opts.limit; // 更新每页条数
 
-            that.pullData(obj.curr);
-          }
+          that.pullData(opts.current);
         },
       },
       options.page,
+      laypageInstance?.options,
     );
-    options.page.count = count; //更新总条数
     laypage.render(options.page);
   }
 };
@@ -2234,7 +2235,7 @@ Class.prototype.sort = function (opts) {
   // 重载数据
   that.renderData({
     res: res,
-    curr: that.page,
+    current: that.page,
     count: that.count,
     sort: true,
     type: opts.reloadType,

--- a/src/components/treeTable.js
+++ b/src/components/treeTable.js
@@ -1833,7 +1833,7 @@ treeTable.addNodes = function (id, opts) {
         options.data.splice.apply(
           options.data,
           [
-            pageOptions.limit * (pageOptions.curr - 1),
+            pageOptions.limit * (pageOptions.current - 1),
             pageOptions.limit,
           ].concat(table.cache[id]),
         );

--- a/src/core/i18n.js
+++ b/src/core/i18n.js
@@ -109,10 +109,6 @@ var zhCN = {
     },
   },
   laypage: {
-    prev: '上一页',
-    next: '下一页',
-    first: '首页',
-    last: '尾页',
     total: '共 {total} 条',
     pagesize: '条/页',
     goto: '到第',

--- a/src/css/modules/laypage.css
+++ b/src/css/modules/laypage.css
@@ -1,136 +1,143 @@
 /** 分页 **/
-.lay-laypage {
-  display: inline-block;
-  vertical-align: middle;
-  margin: 10px 0;
-  font-size: 0;
-}
-.lay-laypage > a:first-child,
-.lay-laypage > a:first-child em {
-  border-radius: var(--lay-border-radius) 0 0 var(--lay-border-radius);
-}
-.lay-laypage > a:last-child,
-.lay-laypage > a:last-child em {
-  border-radius: 0 var(--lay-border-radius) var(--lay-border-radius) 0;
-}
-.lay-laypage > *:first-child {
-  margin-left: 0 !important;
-}
-.lay-laypage > *:last-child {
-  margin-right: 0 !important;
-}
-.lay-laypage a,
-.lay-laypage span,
-.lay-laypage input,
-.lay-laypage button,
-.lay-laypage select {
-  border: 1px solid var(--lay-border-color);
-}
-.lay-laypage a,
-.lay-laypage span {
-  display: inline-block;
-  vertical-align: middle;
-  padding: 0 15px;
-  height: 28px;
-  line-height: 28px;
-  margin: 0 -1px 5px 0;
-  background-color: #fff;
-  color: #333;
-  font-size: 12px;
-}
-.lay-laypage a[data-page] {
-  color: #333;
-}
-.lay-laypage a {
-  text-decoration: none !important;
-  cursor: pointer;
-}
-.lay-laypage a:hover {
-  color: var(--lay-color-primary);
-}
-.lay-laypage em {
-  font-style: normal;
-}
-.lay-laypage .lay-laypage-spr {
-  color: #999;
-  font-weight: 700;
-}
-.lay-laypage .lay-laypage-curr {
-  position: relative;
-}
-.lay-laypage .lay-laypage-curr em {
-  position: relative;
-  color: #fff;
-}
-.lay-laypage .lay-laypage-curr .lay-laypage-em {
-  position: absolute;
-  left: -1px;
-  top: -1px;
-  padding: 1px;
-  width: 100%;
-  height: 100%;
-  background-color: var(--lay-color-primary);
-}
-.lay-laypage-em {
-  border-radius: var(--lay-border-radius);
-}
-.lay-laypage-prev em,
-.lay-laypage-next em {
-  font-family: Sim sun;
-  font-size: 16px;
+.lay-pagination {
+  --lay-height: 32px;
+  --lay-input-width: 45px;
+  --lay-btn-spacing: 11px;
+
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  row-gap: 8px;
+  font-size: 0.875rem;
 }
 
-.lay-laypage .lay-laypage-count,
-.lay-laypage .lay-laypage-limits,
-.lay-laypage .lay-laypage-refresh,
-.lay-laypage .lay-laypage-skip {
-  margin-left: 10px;
-  margin-right: 10px;
-  padding: 0;
-  border: none;
+.lay-pagination {
+  > li {
+    min-width: var(--lay-height);
+    height: var(--lay-height);
+    line-height: var(--lay-height);
+    margin: 0 3px;
+    text-align: center;
+  }
+  > li > a {
+    display: block;
+    padding: 0 var(--lay-spacing-sm);
+    border: 1px solid transparent;
+    border-radius: var(--lay-border-radius);
+    transition: all 0.3s;
+  }
+  .lay-pagination-link {
+    cursor: pointer;
+  }
+  :where(.lay-pagination-link):hover {
+    background-color: var(--lay-gray-200);
+    color: var(--lay-color-primary);
+  }
+  :is(select, input, button) {
+    height: var(--lay-height);
+    line-height: var(--lay-height);
+    border-radius: var(--lay-border-radius);
+    border: 1px solid var(--lay-border-color);
+    background: none;
+  }
+  select {
+    padding: 0 3px;
+    cursor: pointer;
+  }
+  input {
+    width: var(--lay-input-width);
+    padding: 0 3px;
+    text-align: center;
+  }
+  :is(button, .lay-btn) {
+    height: inherit;
+    line-height: inherit;
+    padding: 0 var(--lay-btn-spacing);
+    cursor: pointer;
+  }
+  :where(select, button):hover {
+    border-color: var(--lay-border-color-accent);
+  }
+  :where(select, input):focus {
+    border-color: var(--lay-color-primary);
+  }
 }
-.lay-laypage .lay-laypage-limits,
-.lay-laypage .lay-laypage-refresh {
-  vertical-align: top;
+
+.lay-pagination-item-active > a {
+  background-color: var(--lay-color-primary);
+  color: #fff;
+  font-weight: 700;
 }
-.lay-laypage .lay-laypage-refresh i {
-  font-size: 18px;
-  cursor: pointer;
+.lay-pagination-simple-page {
+  padding: 0 var(--lay-spacing-sm);
 }
-.lay-laypage select {
-  height: 22px;
-  padding: 3px;
-  border-radius: var(--lay-border-radius);
-  cursor: pointer;
+.lay-pagination-ellipsis {
+  color: var(--lay-gray-500);
 }
-.lay-laypage .lay-laypage-skip {
-  height: 30px;
-  line-height: 30px;
-  color: #999;
-}
-.lay-laypage input,
-.lay-laypage button {
-  height: 30px;
-  line-height: 30px;
-  border-radius: var(--lay-border-radius);
-  vertical-align: top;
-  background-color: #fff;
-  box-sizing: border-box;
-}
-.lay-laypage input {
-  display: inline-block;
-  width: 40px;
-  margin: 0 10px;
+.lay-pagination-jump {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
   padding: 0 3px;
-  text-align: center;
-  transition: none;
 }
-.lay-laypage input:focus,
-.lay-laypage select:focus {
-  border-color: var(--lay-color-primary) !important;
+
+/* 对齐方式 */
+.lay-pagination-align-start {
+  justify-content: start;
 }
-.lay-laypage button {
-  margin-left: 10px;
-  padding: 0 10px;
-  cursor: pointer;
+.lay-pagination-align-center {
+  justify-content: center;
+}
+.lay-pagination-align-end {
+  justify-content: end;
+}
+
+/* 组件尺寸 */
+.lay-pagination.lay-size-sm {
+  --lay-height: 24px;
+  --lay-input-width: 38px;
+  --lay-btn-spacing: 8px;
+
+  font-size: 0.75rem;
+}
+.lay-pagination.lay-size-lg {
+  --lay-height: 38px;
+  --lay-input-width: 55px;
+
+  font-size: 1rem;
+}
+
+/* 禁用状态 */
+.lay-pagination.lay-disabled {
+  opacity: 0.55;
+  cursor: not-allowed !important;
+  color: inherit !important;
+
+  * {
+    pointer-events: none;
+  }
+  :is(select, input, button) {
+    border-color: var(--lay-border-color-accent);
+    background-color: var(--lay-gray-300);
+  }
+}
+
+/* 主题风格 */
+.lay-pagination-theme-border {
+  --lay-color-primary: var(--lay-color-accent);
+
+  > li:not(.lay-pagination-item-active) > a {
+    border-color: var(--lay-border-color);
+  }
+  .lay-pagination-item-active > a {
+    border-color: var(--lay-color-primary);
+    background-color: transparent;
+    color: var(--lay-color-primary);
+  }
+}
+.lay-pagination-theme-background {
+  > li:not(.lay-pagination-item-active) > a {
+    background-color: var(--lay-gray-300);
+  }
 }

--- a/src/css/modules/table.css
+++ b/src/css/modules/table.css
@@ -480,47 +480,7 @@
 .lay-table-page > div {
   height: 26px;
 }
-.lay-table-page .lay-laypage {
-  margin: 0;
-}
-.lay-table-page .lay-laypage a,
-.lay-table-page .lay-laypage span {
-  height: 26px;
-  line-height: 26px;
-  margin-bottom: 10px;
-  border: none;
-  background: none;
-}
-.lay-table-page .lay-laypage a,
-.lay-table-page .lay-laypage span.lay-laypage-curr {
-  padding: 0 12px;
-}
-.lay-table-page .lay-laypage span {
-  margin-left: 0;
-  padding: 0;
-}
-.lay-table-page .lay-laypage .lay-laypage-prev {
-  margin-left: -11px !important;
-}
-.lay-table-page .lay-laypage .lay-laypage-curr .lay-laypage-em {
-  left: 0;
-  top: 0;
-  padding: 0;
-}
-.lay-table-page .lay-laypage input,
-.lay-table-page .lay-laypage button {
-  height: 26px;
-  line-height: 26px;
-}
-.lay-table-page .lay-laypage input {
-  width: 40px;
-}
-.lay-table-page .lay-laypage button {
-  padding: 0 10px;
-}
-.lay-table-page select {
-  height: 18px;
-}
+
 .lay-table-pagebar {
   float: right;
   line-height: 23px;

--- a/tests/visual/assets/i18n/en.js
+++ b/tests/visual/assets/i18n/en.js
@@ -104,10 +104,6 @@ export default {
     },
   },
   laypage: {
-    prev: 'Prev',
-    next: 'Next',
-    first: 'First',
-    last: 'Last',
     total: 'Total {total} items',
     pagesize: 'items/page',
     goto: 'Go to',

--- a/tests/visual/assets/i18n/fr.js
+++ b/tests/visual/assets/i18n/fr.js
@@ -105,10 +105,6 @@ export default {
     },
   },
   laypage: {
-    prev: 'Page précédente',
-    next: 'Page suivante',
-    first: 'Première',
-    last: 'Dernière',
     total: 'Total {total} éléments',
     pagesize: 'éléments/page',
     goto: 'Aller à',

--- a/tests/visual/assets/i18n/zh-HK.js
+++ b/tests/visual/assets/i18n/zh-HK.js
@@ -101,10 +101,6 @@ export default {
     },
   },
   laypage: {
-    prev: '上一頁',
-    next: '下一頁',
-    first: '首頁',
-    last: '尾頁',
     total: '共 {total} 條',
     pagesize: '條/頁',
     goto: '到第',

--- a/tests/visual/i18n.html
+++ b/tests/visual/i18n.html
@@ -480,7 +480,7 @@
 
         // laypage
         laypage.render({
-          elem: 'demo-laypage-all',
+          elem: '#demo-laypage-all',
           count: 100,
           layout: [
             'count',
@@ -489,7 +489,7 @@
             'next',
             'limits',
             'refresh',
-            'count',
+            'jump',
           ],
         });
 

--- a/tests/visual/i18n.html
+++ b/tests/visual/i18n.html
@@ -482,7 +482,15 @@
         laypage.render({
           elem: 'demo-laypage-all',
           count: 100,
-          layout: ['count', 'prev', 'page', 'next', 'limit', 'refresh', 'skip'],
+          layout: [
+            'count',
+            'prev',
+            'page',
+            'next',
+            'limits',
+            'refresh',
+            'count',
+          ],
         });
 
         // table

--- a/tests/visual/laypage.html
+++ b/tests/visual/laypage.html
@@ -75,7 +75,7 @@
         const { laypage, layer } = layui;
 
         // 常规示例
-        laypage.render({
+        const laypageInst = laypage.render({
           elem: '#demo-normal',
           count: 100,
           // pageCount: 3,
@@ -89,6 +89,9 @@
             console.log(`${this.id} → afterRender → `, options);
           },
         });
+
+        console.dir(laypage);
+        console.log('laypage.render() → ', laypageInst);
 
         // 显示完整功能
         laypage.render({

--- a/tests/visual/laypage.html
+++ b/tests/visual/laypage.html
@@ -6,137 +6,225 @@
       name="viewport"
       content="width=device-width, initial-scale=1, maximum-scale=1"
     />
-    <title>分页 - layui</title>
-
+    <title>laypage 分页 - layui</title>
     <link rel="stylesheet" href="./assets/dist/css/layui.css" />
-
     <style>
-      body {
-        padding: 10px;
+      div + h2 {
+        margin-top: 32px;
+      }
+      .demo-contriner {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
       }
     </style>
   </head>
   <body>
-    总页数低于页码总数：
-    <div id="demo0"></div>
-    总页数大于页码总数：
-    <div id="demo1"></div>
-    自定义主题：
-    <div id="demo2"></div>
-    自定义首页、尾页、上一页、下一页文本：
-    <div id="demo3"></div>
-    不显示首页尾页：
-    <div id="demo4"></div>
-    开启HASH：
-    <div id="demo5"></div>
-    只显示上一页、下一页：
-    <div id="demo6"></div>
-    显示完整功能：
-    <div id="demo7"></div>
-    自定义排版：
-    <div id="demo8"></div>
+    <div class="lay-padding-5">
+      <h2>常规示例</h2>
+      <hr />
+      <div id="demo-normal"></div>
 
-    <fieldset class="lay-elem-field lay-field-title" style="margin-top: 50px">
-      <legend>将一段已知数组分页展示</legend>
-    </fieldset>
+      <h2>显示完整功能</h2>
+      <hr />
+      <div id="demo-show-all"></div>
 
-    <div id="demo9"></div>
+      <h2>组件尺寸</h2>
+      <hr />
+      <div class="demo-contriner">
+        <div id="demo-size-sm"></div>
+        <div id="demo-size-md"></div>
+        <div id="demo-size-lg"></div>
+      </div>
 
-    <ul id="biuuu_city_list"></ul>
+      <h2>设置主题</h2>
+      <hr />
+      <div class="demo-contriner">
+        <h3>• 内置主题</h3>
+        <div id="demo-theme-border"></div>
+        <div id="demo-theme-background"></div>
+        <h3>• 自定义主题</h3>
+        <div id="demo-theme-custom-1"></div>
+        <div id="demo-theme-custom-2"></div>
+      </div>
+
+      <h2>自定义组件布局</h2>
+      <hr />
+      <div class="demo-contriner">
+        <h3>• 简约布局</h3>
+        <div id="demo-layout-simple"></div>
+        <h3>• 自定义组件模板</h3>
+        <div id="demo-layout-custom"></div>
+      </div>
+
+      <h2>记录分页锚点</h2>
+      <hr />
+      <div id="demo-anchor"></div>
+
+      <h2>将一段数组分页展示</h2>
+      <hr />
+      <div class="lay-text" style="padding: 0 16px 16px">
+        <ul id="demo-data-page-show"></ul>
+      </div>
+      <div id="demo9"></div>
+    </div>
 
     <script src="./assets/dist/layui.js"></script>
     <script>
       layui.use(() => {
-        var laypage = layui.laypage,
-          layer = layui.layer;
+        const { laypage, layer } = layui;
 
-        //总页数低于页码总数
+        // 常规示例
         laypage.render({
-          elem: 'demo0',
-          count: 50, //数据总数
-        });
-
-        //总页数大于页码总数
-        laypage.render({
-          elem: 'demo1',
-          count: 70, //数据总数
-          jump: (obj) => {
-            console.log(obj);
+          elem: '#demo-normal',
+          count: 100,
+          // pageCount: 3,
+          // align: 'center',
+          // size: 'sm',
+          // hideOnSinglePage: true,
+          onChange(options) {
+            console.log(`${this.id} → onChange  → `, options);
+          },
+          afterRender(options) {
+            console.log(`${this.id} → afterRender → `, options);
           },
         });
 
-        //自定义样式
+        // 显示完整功能
         laypage.render({
-          elem: 'demo2',
-          count: 100,
-          theme: '#1E9FFF',
-        });
-
-        //自定义首页、尾页、上一页、下一页文本
-        laypage.render({
-          elem: 'demo3',
-          count: 100,
-          first: '首页',
-          last: '尾页',
-          prev: '<em>←</em>',
-          next: '<em>→</em>',
-        });
-
-        //不显示首页尾页
-        laypage.render({
-          elem: 'demo4',
-          count: 100,
-          first: false,
-          last: false,
-        });
-
-        //开启HASH
-        laypage.render({
-          elem: 'demo5',
-          count: 500,
-          curr: location.hash.replace('#!fenye=', ''), //获取hash值为fenye的当前页
-          hash: 'fenye', //自定义hash值
-        });
-
-        //只显示上一页、下一页
-        laypage.render({
-          elem: 'demo6',
-          count: 50,
-          layout: ['prev', 'next'],
-          jump: (obj, first) => {
-            if (!first) {
-              layer.msg('第 ' + obj.curr + ' 页');
-            }
-          },
-        });
-
-        //完整功能
-        laypage.render({
-          elem: 'demo7',
-          count: 100,
-          //,groups: 0
-          layout: ['count', 'prev', 'page', 'next', 'limit', 'refresh', 'skip'],
-          /*,limitTemplet: function(item) {
-      return item + ' / page';
-    }*/
-          // ,skipText: ['Go to', '', 'Confirm']
-          jump: (obj) => {
-            console.log(obj);
-          },
-        });
-
-        //自定义排版
-        laypage.render({
-          elem: 'demo8',
+          elem: '#demo-show-all',
           count: 1000,
-          layout: ['limit', 'prev', 'page', 'next'],
-          //,limits: [100, 200, 300]
-          limit: 200,
+          // size: 'sm',
+          layout: [
+            'count',
+            'prev',
+            'page',
+            'next',
+            'limits',
+            'refresh',
+            'jump',
+          ],
+          onChange(options) {
+            console.log(options);
+          },
         });
 
-        //将一段数组分页展示
+        // 组件尺寸
+        ['sm', 'md', 'lg'].forEach((size) => {
+          laypage.render({
+            elem: `#demo-size-${size}`,
+            count: 1000,
+            size,
+          });
+        });
 
-        //测试数据
+        // 内置主题
+        laypage.render({
+          elem: '#demo-theme-border',
+          count: 1000,
+          theme: 'border',
+        });
+        laypage.render({
+          elem: '#demo-theme-background',
+          count: 1000,
+          theme: 'background',
+        });
+
+        // 自定义主题
+        laypage.render({
+          elem: '#demo-theme-custom-1',
+          count: 1000,
+          css: `
+--lay-color-primary: #1e9fff;
+
+.lay-pagination-item-active > a {
+  border: 1px solid var(--lay-color-primary);
+  background: none;
+  color: var(--lay-color-primary);
+}
+          `,
+        });
+        laypage.render({
+          elem: '#demo-theme-custom-2',
+          count: 1000,
+          css: `
+--lay-color-primary: #1e9fff;
+
+li:not(.lay-pagination-item-active) > a {
+  background-color: #f1f2f5;
+}
+.lay-pagination-item-active > a {
+  background: var(--lay-color-primary);
+  color: #fff;
+}
+          `,
+        });
+
+        // 自定义组件布局：简约布局
+        laypage.render({
+          elem: '#demo-layout-simple',
+          count: 100,
+          pageCount: 1,
+          layout: ['prev', 'simplePage', 'next'],
+          // theme: 'border',
+          onChange(options) {
+            layer.msg(`第 ${options.current} 页`);
+          },
+        });
+
+        // 自定义组件布局：自定义组件模板
+        laypage.render({
+          elem: '#demo-layout-custom',
+          count: 1688,
+          layout: ['randomPage', 'prev', 'page', 'next', 'customTotal'],
+          templates: {
+            // 自定义随机页码组件
+            randomPage(options) {
+              const li = document.createElement('li');
+              const btn = document.createElement('a');
+
+              btn.classList.add(
+                'lay-btn',
+                'lay-btn-primary',
+                'lay-border-green',
+              );
+              btn.textContent = '随机页';
+              btn.onclick = () => {
+                const randomPage =
+                  Math.floor(Math.random() * options.totalPages) + 1;
+                laypage.jump(options.id, randomPage); // 跳转到随机页
+              };
+              li.appendChild(btn);
+              return li;
+            },
+
+            // 自定义统计文本
+            customTotal(options) {
+              const li = document.createElement('li');
+              li.style = 'color: var(--lay-gray-700);';
+              li.textContent = `（共 ${options.count} 条）`;
+              return li;
+            },
+          },
+        });
+
+        // 记录分页锚点
+        laypage.render({
+          elem: '#demo-anchor',
+          count: 500,
+          current: location.hash.replace('#!current=', ''), // 获取分页锚点
+          onChange(options) {
+            // 记录分页锚点
+            location.hash = `!current=${options.current}`;
+
+            layer.msg(
+              '观察浏览器地址栏变化。刷新页面时，会保持分页切换状态。',
+              { offset: '16px' },
+            );
+          },
+        });
+
+        // 将一段数组分页展示
         var data = [
           '北京',
           '上海',
@@ -177,20 +265,21 @@
           '台北',
         ];
 
-        //调用分页
+        // 调用分页
         laypage.render({
-          elem: 'demo9',
+          elem: '#demo9',
           count: data.length,
-          layout: ['prev', 'page', 'next', 'refresh', 'skip'],
-          jump: (obj) => {
-            //模拟渲染
-            document.getElementById('biuuu_city_list').innerHTML = (() => {
-              var arr = [],
-                thisData = data
-                  .concat()
-                  .splice(obj.curr * obj.limit - obj.limit, obj.limit);
-              thisData.forEach((item) => {
-                arr.push('<li>' + item + '</li>');
+          theme: 'border',
+          afterRender(options) {
+            // 模拟渲染
+            const ul = document.getElementById('demo-data-page-show');
+            ul.innerHTML = (() => {
+              const arr = [];
+              const currentData = data
+                .concat()
+                .splice(options.limit * (options.current - 1), options.limit);
+              currentData.forEach((item) => {
+                arr.push(`<li>${item}</li>`);
               });
               return arr.join('');
             })();

--- a/tests/visual/laypage.html
+++ b/tests/visual/laypage.html
@@ -95,6 +95,7 @@
           elem: '#demo-show-all',
           count: 1000,
           // size: 'sm',
+          // disabled: true,
           layout: [
             'count',
             'prev',

--- a/tests/visual/table-test-border.html
+++ b/tests/visual/table-test-border.html
@@ -98,11 +98,11 @@
           //,contentType: 'application/json' // 参数为 json 格式传递
           page: {
             // 详细参数可参考 laypage 组件文档
-            curr: 5,
-            groups: 1,
+            current: 5,
+            pageCount: 1,
             first: false,
             last: false,
-            layout: ['limit', 'prev', 'page', 'next', 'count'], //自定义分页布局
+            layout: ['limits', 'prev', 'page', 'next', 'count'], // 自定义分页布局
           },
           // , totalRow: true
           height: 300,
@@ -127,11 +127,11 @@
           //,contentType: 'application/json' // 参数为 json 格式传递
           page: {
             // 详细参数可参考 laypage 组件文档
-            curr: 5,
-            groups: 1,
+            current: 5,
+            pageCount: 1,
             first: false,
             last: false,
-            layout: ['limit', 'prev', 'page', 'next', 'count'], //自定义分页布局
+            layout: ['limits', 'prev', 'page', 'next', 'count'], //自定义分页布局
           },
           totalRow: true,
           height: 300,

--- a/tests/visual/table-test.html
+++ b/tests/visual/table-test.html
@@ -353,7 +353,7 @@
             options.where.AAAAA = 123;
             // console.log(options)
           },
-          done: function (res, curr, count) {
+          done: function (res, current, count) {
             var id = this.id;
 
             // 设置选中行状态
@@ -475,7 +475,7 @@
                           test: '新的 test1',
                         },
                         //,defaultToolbar: ['print'] // 重载头部工具栏右侧图标
-                        page: { curr: 5, limit: 20 },
+                        page: { current: 5, limit: 20 },
                         //,cols: ins1.config.cols
                       },
                       true,
@@ -492,7 +492,7 @@
                       height: 2000, // 测试无效参数
                       // url: '404',
                       // elem: null,
-                      // page: {curr: 5, limit: 20},
+                      // page: {current: 5, limit: 20},
                       scrollPos: 'fixed', // 保持滚动条位置不变
                     });
                     break;
@@ -568,7 +568,7 @@
 
           /*
     request: { // 自定义请求参数名称
-      pageName: 'curr', // 页码的参数名称，默认：page
+      pageName: 'current', // 页码的参数名称，默认：page
       limitName: 'nums' // 每页数据量的参数名，默认：limit
     },
     parseData: function(res){ // 任意数据格式的解析
@@ -596,7 +596,7 @@
           // 服务端排序
           table.reloadData('test', {
             // initSort: obj,
-            // page: {curr: 1}, // 重新从第一页开始
+            // page: { current: 1 }, // 重新从第一页开始
             where: {
               // 向服务端传入排序参数
               key: obj.field, // 排序字段

--- a/tests/visual/table.html
+++ b/tests/visual/table.html
@@ -193,11 +193,11 @@
             ? false
             : {
                 // 详细参数可参考 laypage 组件文档
-                curr: 5,
-                groups: 1,
+                current: 5,
+                pageCount: 1,
                 first: false,
                 last: false,
-                layout: ['limit', 'prev', 'page', 'next', 'count'], //自定义分页布局
+                layout: ['limits', 'prev', 'page', 'next', 'count'], //自定义分页布局
               },
           height: 300,
           cellMinWidth: 80,


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [x] 功能新增
- [ ] 问题修复
- [x] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- 采用 Component 基类实现
- 重构 页码计算核心逻辑
- 重构 组件主题，内置多个不同风格的主题，并支持自定义主题
- 新增 组件尺寸设置，支持小、中、大三种尺寸
- 新增 简约布局组件模板
- 新增 自定义组件模板功能
- 优化 部分选项

### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [ ] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [ ] 已对每一项的改动均测试通过
- [ ] 已提供具体的变化内容说明


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 分页组件升级为类实例：支持统一布局装配、尺寸/对齐/主题与禁用态样式；跳转交互与分页回调能力增强，并对外保留 `laypage` 符号。
* **Bug 修复**
  * 统一分页字段命名为 `current`：修正分页偏移、渲染序号、AJAX/本地数据请求页码一致性，并同步到表格与树表分页。
* **样式/文案与测试**
  * 分页样式体系切换为 `lay-pagination`；移除 `zhCN` 文案项 `prev/next/first/last`；同步更新可视化演示与表格分页用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->