### PR TITLE
fix(table): 修复表头补丁宽度更新异常

### DIFF
--- a/src/modules/table.js
+++ b/src/modules/table.js
@@ -2547,25 +2547,25 @@ layui.define(
     Class.prototype.scrollPatch = function () {
       var that = this;
       var layMainTable = that.layMain.children('table');
-      var scrollWidth = that.layMain.width() - that.layMain.prop('clientWidth'); // 纵向滚动条宽度
+      var scrollWidth = that.getScrollWidth(that.layMain[0]); // 纵向滚动条宽度
       var scrollHeight =
-        that.layMain.height() - that.layMain.prop('clientHeight'); // 横向滚动条高度
-      // var getScrollWidth = that.getScrollWidth(that.layMain[0]); // 获取主容器滚动条宽度，如果有的话
+        that.layMain.prop('offsetHeight') - that.layMain.prop('clientHeight'); // 横向滚动条高度
       var outWidth = layMainTable.outerWidth() - that.layMain.width(); // 表格内容器的超出宽度
 
       // 添加补丁
       var addPatch = function (elem) {
         if (scrollWidth && scrollHeight) {
           elem = elem.eq(0);
-          if (!elem.find('.layui-table-patch')[0]) {
-            var patchElem = $(
+          var patchElem = elem.find('.layui-table-patch');
+          if (!patchElem[0]) {
+            patchElem = $(
               '<th class="layui-table-patch"><div class="layui-table-cell"></div></th>'
             ); // 补丁元素
-            patchElem.find('div').css({
-              width: scrollWidth
-            });
             elem.find('tr').append(patchElem);
           }
+          patchElem.find('div').css({
+            width: scrollWidth
+          });
         } else {
           elem.find('.layui-table-patch').remove();
         }


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [x] 问题修复
- [ ] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- fix(table): 修复表头补丁宽度更新异常  close #3062

  [演示]https://stackblitz.com/edit/uq7zzrzt?file=index.html

### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [x] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化表格滚动条补丁的尺寸计算，横向和纵向滚动时的显示更准确。
  * 改进补丁元素的创建与更新逻辑，减少滚动场景下的异常样式或宽度偏差。
  * 在无需滚动时，仍会正常移除补丁，保持界面更稳定。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->