### PR TITLE
fix(form): 优化 `getValue` 方法以正确支持同名 name 的数组值处理

### DIFF
--- a/examples/form.html
+++ b/examples/form.html
@@ -28,7 +28,7 @@
             <div class="layui-input-split layui-input-prefix">前置信息</div>
             <input
               type="text"
-              name="arr[]"
+              name="colors"
               required
               lay-verify="required"
               placeholder="请输入"
@@ -43,7 +43,7 @@
           <div class="layui-input-wrap">
             <input
               type="text"
-              name="arr[]"
+              name="colors"
               required
               placeholder="请输入"
               autocomplete="off"
@@ -187,7 +187,7 @@
             <div class="layui-input-prefix">
               <i class="layui-icon layui-icon-username"></i>
             </div>
-            <select name="selectdemo">
+            <select name="select-city">
               <option value="">在 select 中使用</option>
               <option value="北京">北京</option>
               <option value="上海">上海</option>
@@ -269,7 +269,11 @@
         </div>
         <div class="layui-col-md12">
           <div class="layui-input-wrap">
-            <textarea class="layui-textarea" lay-affix="clear"></textarea>
+            <textarea
+              class="layui-textarea"
+              name="textarea"
+              lay-affix="clear"
+            ></textarea>
           </div>
         </div>
         <div class="layui-col-md12">
@@ -660,7 +664,7 @@
     });
     */
 
-        //方法提交
+        // 方法提交
         $('#testSubmit').on('click', function () {
           form.submit('top', function (data) {
             layer.confirm('确定提交么？', function (index) {
@@ -670,6 +674,12 @@
               setTimeout(function () {
                 alert(JSON.stringify(data.field));
               });
+
+              /* $.ajax({
+                url: '',
+                data: data.field,
+                type: 'post'
+              }); */
             });
           });
           return false;

--- a/src/modules/form.js
+++ b/src/modules/form.js
@@ -188,12 +188,15 @@ layui.define(['lay', 'i18n', 'layer', 'util'], function (exports) {
     // 遍历表单域元素
     fieldElem.each(function (_, item) {
       var othis = $(this);
-      var name = (item.name || '').replace(/^\s*|\s*$/, '');
+      var name = (item.name || '').replace(/^\s*|\s*$/g, '');
       var value;
 
       if (!name) return;
       // 复选框和单选框未选中，不记录字段
       if (/^(checkbox|radio)$/.test(item.type) && !item.checked) return;
+
+      // 排除 disabled 表单域
+      if (item.disabled) return;
 
       // select 多选用 jQuery 方式取值，未选中 option 时，
       // jQuery v2.2.4 及以下版本返回 null，以上(3.x) 返回 []。

--- a/src/modules/form.js
+++ b/src/modules/form.js
@@ -159,39 +159,58 @@ layui.define(['lay', 'i18n', 'layer', 'util'], function (exports) {
   Form.prototype.getValue = function (filter, itemForm) {
     itemForm = itemForm || this.getFormElem(filter);
 
-    var nameIndex = {}, // 数组 name 索引
-      field = {},
-      fieldElem = itemForm.find('input,select,textarea'); // 获取所有表单域
+    // 获取所有表单域
+    var fieldElem = itemForm.find('input,select,textarea');
+    var result = {};
 
-    layui.each(fieldElem, function (_, item) {
-      var othis = $(this),
-        init_name; // 初始 name
-
-      item.name = (item.name || '').replace(/^\s*|\s*&/, '');
-      if (!item.name) return;
-
-      // 用于支持数组 name
-      if (/^.*\[\]$/.test(item.name)) {
-        var key = item.name.match(/^(.*)\[\]$/g)[0];
-        nameIndex[key] = nameIndex[key] | 0;
-        init_name = item.name.replace(
-          /^(.*)\[\]$/,
-          '$1[' + nameIndex[key]++ + ']'
-        );
+    // 将表单值添加到结果对象中
+    var appendResultValue = function (name, value) {
+      // 若字段未在结果对象中，直接添加原始值
+      if (!lay.hasOwn(result, name)) {
+        result[name] = value;
+        return;
       }
 
-      if (/^(checkbox|radio)$/.test(item.type) && !item.checked) return; // 复选框和单选框未选中，不记录字段
+      // 若字段已在结果对象中，且值不是数组，则初始化为数组
+      if (!layui.isArray(result[name])) {
+        result[name] = [result[name]];
+      }
+
+      // 若新值本身为数组，则合并到结果数组中
+      if (layui.isArray(value)) {
+        result[name] = result[name].concat(value);
+      } else {
+        // 若新值非数组，则直接追加到结果数组中
+        result[name].push(value);
+      }
+    };
+
+    // 遍历表单域元素
+    fieldElem.each(function (_, item) {
+      var othis = $(this);
+      var name = (item.name || '').replace(/^\s*|\s*$/, '');
+      var value;
+
+      if (!name) return;
+      // 复选框和单选框未选中，不记录字段
+      if (/^(checkbox|radio)$/.test(item.type) && !item.checked) return;
+
       // select 多选用 jQuery 方式取值，未选中 option 时，
       // jQuery v2.2.4 及以下版本返回 null，以上(3.x) 返回 []。
       // 统一规范化为 []，参考 https://github.com/jquery/jquery/issues/2562
-      field[init_name || item.name] =
+      if (
         this.tagName === 'SELECT' &&
         typeof this.getAttribute('multiple') === 'string'
-          ? othis.val() || []
-          : this.value;
+      ) {
+        value = othis.val() || [];
+      } else {
+        value = this.value;
+      }
+
+      appendResultValue(name, value);
     });
 
-    return field;
+    return result;
   };
 
   // 表单控件渲染


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [x] 问题修复
- [x] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- **此前**： `form.getValue` 对 name="arr[]" 格式的同名表单会自动追加下标，导致最终提交的数据格式为 `arr[0]: value1、arr[1]: value2`，部分后端框架可能无法正确解析数组。同时对非 `arr[]` 格式的同名表单也未进行支持。
- **此后**：能正确解析和提交任意格式的同名 name 表单。获取的数据示例：
```json
{
  "colors":["#16baaa","#16b777"],
  "arr[]":["3","4","5","6","7","8","9","10","11","10.00","13"],
  "select-city":"上海",
  "textarea":"151515151515"
}
```
<img width="395" height="505" alt="image" src="https://github.com/user-attachments/assets/a76992cc-e690-4317-b888-d93cf4a2a629" />

### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [ ] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [ ] 已对每一项的改动均测试通过
- [ ] 已提供具体的变化内容说明


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 表单提交时，重复字段会自动汇总为数组，字段值展示更完整。
  * 支持更稳定地处理多选下拉框、复选框和单选项的提交结果。

* **Bug Fixes**
  * 跳过禁用的表单项，避免无效内容进入提交数据。
  * 文本域和输入字段的提交名称与结果更一致。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->