### PR TITLE
refactor(components): 统一事件命名空间

### DIFF
--- a/src/components/carousel.js
+++ b/src/components/carousel.js
@@ -315,15 +315,19 @@ export class Carousel extends Component {
     const options = this.options;
     const $elem = options.$elem;
 
-    if ($elem.data('haveEvents')) return;
+    // 事件命名空间
+    const eventNamespace = CONST.EVENT_NAMESPACE;
+
+    // 解绑事件，避免重复绑定
+    $elem.off(eventNamespace);
 
     // 移入移出容器
     $elem
-      .on('mouseenter touchstart', () => {
+      .on(`mouseenter${eventNamespace} touchstart${eventNamespace}`, () => {
         if (this.options.autoplay === 'always') return;
         clearInterval(this.timer);
       })
-      .on('mouseleave touchend', () => {
+      .on(`mouseleave${eventNamespace} touchend${eventNamespace}`, () => {
         if (this.options.autoplay === 'always') return;
         this.#autoplay();
       });
@@ -344,8 +348,6 @@ export class Carousel extends Component {
         }
       }.bind(this),
     });
-
-    $elem.data('haveEvents', true);
   }
 }
 

--- a/src/components/collapse.js
+++ b/src/components/collapse.js
@@ -15,28 +15,28 @@ export class Collapse extends Component {
     elem: '.lay-collapse',
   };
 
+  // 渲染
   render() {
     const options = this.options;
-    const elemItem = options.$elem.find('.lay-collapse-item');
+    const $items = options.$elem.find('.lay-collapse-item');
+    const eventNamespace = CONST.EVENT_NAMESPACE;
 
-    elemItem.each(function () {
+    $items.each(function () {
       const $this = $(this);
-      const elemTitle = $this.find('.lay-collapse-title');
-      const elemCont = $this.find('.lay-collapse-content');
-      const isNone = elemCont.css('display') === 'none';
-      const clickEventName = 'click.lay_collapse_click';
+      const $title = $this.find('.lay-collapse-title');
+      const $content = $this.find('.lay-collapse-content');
+      const isNone = $content.css('display') === 'none';
+      const clickEventName = `click${eventNamespace}`;
 
       // 初始状态
-      elemTitle.find('.lay-collapse-icon').remove();
-      elemTitle.append(
+      $title.find('.lay-collapse-icon').remove();
+      $title.append(
         '<i class="lay-icon lay-icon-right lay-collapse-icon"></i>',
       );
       $this[isNone ? 'removeClass' : 'addClass'](CONST.CLASS_SHOW);
 
       // 点击标题
-      elemTitle
-        .off(clickEventName, events.titleClick)
-        .on(clickEventName, events.titleClick);
+      $title.off(clickEventName).on(clickEventName, events.titleClick);
     });
   }
 }

--- a/src/components/colorpicker.js
+++ b/src/components/colorpicker.js
@@ -704,8 +704,7 @@ export class Colorpicker extends Component {
    * 窗口大小变化时自动更新位置
    */
   #autoUpdatePosition() {
-    const RESIZE_EVENT_NAME = 'resize.lay_colorpicker_resize';
-    // var options = that.config;
+    const eventNamespace = CONST.EVENT_NAMESPACE;
 
     this.stopResizeEvent();
 
@@ -713,10 +712,10 @@ export class Colorpicker extends Component {
       this.#position();
     };
 
-    $win.on(RESIZE_EVENT_NAME, windowResizeHandler);
+    $win.on(`resize${eventNamespace}`, windowResizeHandler);
 
     this.stopResizeEvent = () => {
-      $win.off(RESIZE_EVENT_NAME, windowResizeHandler);
+      $win.off(`resize${eventNamespace}`, windowResizeHandler);
       this.stopResizeEvent = $.noop;
     };
   }

--- a/src/components/dropdown.js
+++ b/src/components/dropdown.js
@@ -429,7 +429,7 @@ export class Dropdown extends Component {
 
     // 是否鼠标移入时触发
     const isMouseEnter = options.trigger === 'mouseenter';
-    const eventNamespace = '.lay_dropdown_render';
+    const eventNamespace = CONST.EVENT_NAMESPACE;
     const trigger = `${options.trigger}${eventNamespace}`;
 
     // 始终先解除上一个触发元素的事件（如重载时改变 elem 的情况）
@@ -513,6 +513,7 @@ export class Dropdown extends Component {
    */
   #autoUpdatePosition() {
     const options = this.options;
+    const eventNamespace = CONST.EVENT_NAMESPACE;
 
     this.stopResizeEvent();
 
@@ -528,7 +529,7 @@ export class Dropdown extends Component {
         this.#position();
       }
     };
-    $(window).on('resize.lay_dropdown_resize', windowResizeHandler);
+    $(window).on(`resize${eventNamespace}`, windowResizeHandler);
 
     const shouldObserveResize =
       resizeObserver && options.trigger !== 'contextmenu';
@@ -541,7 +542,7 @@ export class Dropdown extends Component {
     }
 
     this.stopResizeEvent = () => {
-      $(window).off('resize.lay_dropdown_resize', windowResizeHandler);
+      $(window).off(`resize${eventNamespace}`, windowResizeHandler);
       if (shouldObserveResize) {
         resizeObserver.unobserve(triggerEl);
         resizeObserver.unobserve(contentEl);

--- a/src/components/floatbar.js
+++ b/src/components/floatbar.js
@@ -25,6 +25,7 @@ export class Floatbar extends Component {
     };
   }
 
+  // 渲染
   render() {
     const options = this.options;
     const Constructor = this.constructor;
@@ -137,8 +138,8 @@ export class Floatbar extends Component {
 
     // 根据 scrollbar 设置 floatbar 相关状态
     let timer;
-    const scrollEventName = 'scroll.lay_floatbar_scroll';
-    $scroll.off(scrollEventName).on(scrollEventName, function () {
+    const scrollEventName = `scroll${CONST.EVENT_NAMESPACE}`;
+    $scroll.off(scrollEventName).on(scrollEventName, () => {
       if (!setTopBar) return;
       clearTimeout(timer);
       timer = setTimeout(() => {

--- a/src/components/flow.js
+++ b/src/components/flow.js
@@ -17,8 +17,6 @@ export class Flow extends Component {
       ELEM_LOAD:
         '<i class="lay-anim lay-anim-rotate lay-anim-loop lay-icon lay-icon-loading-1"></i>',
       ELEM_MORE: 'lay-flow-more',
-      FLOW_SCROLL_EVENTS: 'scroll.lay_flow_scroll',
-      LAZYIMG_SCROLL_EVENTS: 'scroll.lay_flow_lazyimg_scroll',
     };
   }
 
@@ -108,10 +106,13 @@ export class Flow extends Component {
 
     if (!isAuto) return this;
 
+    // 实例级事件命名空间
+    const scopedNamespace = `${CONST.EVENT_NAMESPACE}_${options.id}`;
+
     // 滚动条滚动事件
     let timer;
-    const FLOW_SCROLL_EVENTS = `${CONST.FLOW_SCROLL_EVENTS}_${options.id}`;
-    scrollElem.off(FLOW_SCROLL_EVENTS).on(FLOW_SCROLL_EVENTS, function () {
+    const scrollEventName = `scroll${scopedNamespace}`;
+    scrollElem.off(scrollEventName).on(scrollEventName, function () {
       const $this = $(this);
       const top = $this.scrollTop();
 
@@ -218,15 +219,15 @@ export class Flow extends Component {
     // 滚动事件
     let timer;
     const id = options.id || '';
-    const LAZYIMG_SCROLL_EVENTS = `${CONST.LAZYIMG_SCROLL_EVENTS}_${id}`;
-    scrollElem
-      .off(LAZYIMG_SCROLL_EVENTS)
-      .on(LAZYIMG_SCROLL_EVENTS, function () {
-        if (timer) clearTimeout(timer);
-        timer = setTimeout(function () {
-          render();
-        }, 50);
-      });
+    const scopedNamespace = `${CONST.EVENT_NAMESPACE}_lazyimg_${id}`;
+    const scrollEventName = `scroll${scopedNamespace}`;
+
+    scrollElem.off(scrollEventName).on(scrollEventName, function () {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(function () {
+        render();
+      }, 50);
+    });
 
     return render;
   }

--- a/src/components/nav.js
+++ b/src/components/nav.js
@@ -102,26 +102,33 @@ export class Nav extends Component {
       }
     };
 
-    const bar = $(`<span class="${CONST.NAV_BAR}"></span>`);
+    const isTree = $elem.hasClass(CONST.NAV_TREE);
     const itemElem = $elem.find(`.${CONST.NAV_ITEM}`);
+    const itemSelector = isTree
+      ? `.${CONST.NAV_ITEM} dd, .${CONST.NAV_ITEM} >.${NAV_TITLE}`
+      : `.${CONST.NAV_ITEM}`;
 
-    // hover 滑动效果
+    // 事件命名空间
+    const eventNamespace = CONST.EVENT_NAMESPACE;
+
+    // 解绑事件，避免重复绑定
+    $elem.off(eventNamespace);
+
+    // 生成滑动条
+    const bar = $(`<span class="${CONST.NAV_BAR}"></span>`);
     const hasBarElem = $elem.find(`.${CONST.NAV_BAR}`);
-    if (hasBarElem[0]) hasBarElem.remove();
+    if (hasBarElem[0]) {
+      hasBarElem.remove();
+    }
     $elem.append(bar);
-    ($elem.hasClass(CONST.NAV_TREE)
-      ? itemElem.find(`dd,>.${CONST.NAV_TITLE}`)
-      : itemElem
-    )
-      .off('mouseenter.lay_nav')
-      .on('mouseenter.lay_nav', function () {
+
+    // 鼠标移入移出滑动效果
+    $elem
+      .on(`mouseenter${eventNamespace}`, itemSelector, function () {
         follow.call(this, bar, $elem, 0);
       })
-      .off('mouseleave.lay_nav')
-      .on('mouseleave.lay_nav', function () {
-        // 鼠标移出
-        // 是否为垂直导航
-        if ($elem.hasClass(CONST.NAV_TREE)) {
+      .on(`mouseleave${eventNamespace}`, itemSelector, function () {
+        if (isTree) {
           bar.css({
             height: 0,
             opacity: 0,
@@ -137,10 +144,10 @@ export class Nav extends Component {
       });
 
     // 鼠标离开当前菜单时
-    $elem.off('mouseleave.lay_nav').on('mouseleave.lay_nav', function () {
+    $elem.on(`mouseleave${eventNamespace}`, function () {
       clearTimeout(timer[0]);
       timeEnd[0] = setTimeout(function () {
-        if (!$elem.hasClass(CONST.NAV_TREE)) {
+        if (!isTree) {
           bar.css({
             width: 0,
             left: bar.position().left + bar.width() / 2,
@@ -150,24 +157,25 @@ export class Nav extends Component {
       }, TIME);
     });
 
-    // 展开子菜单
+    // 初始化父级菜单图标
     itemElem.find('a').each(function () {
-      const thisA = $(this);
-      const child = thisA.siblings(`.${CONST.NAV_CHILD}`);
-      const clickEventName = 'click.lay_nav_click';
+      const $thisA = $(this);
+      const child = $thisA.siblings(`.${CONST.NAV_CHILD}`);
 
       // 输出小箭头
-      if (child[0] && !thisA.children(`.${CONST.NAV_MORE}`)[0]) {
-        thisA.append(
+      if (child[0] && !$thisA.children(`.${CONST.NAV_MORE}`)[0]) {
+        $thisA.append(
           `<i class="lay-icon ${CONST.NAV_DOWN} ${CONST.NAV_MORE}"></i>`,
         );
       }
-
-      // 点击菜单
-      thisA
-        .off(clickEventName, events.clickThis)
-        .on(clickEventName, events.clickThis);
     });
+
+    // 点击菜单
+    $elem.on(
+      `click${eventNamespace}`,
+      `.${CONST.NAV_ITEM} a`,
+      events.clickThis,
+    );
   }
 }
 

--- a/src/components/tabs.js
+++ b/src/components/tabs.js
@@ -765,18 +765,23 @@ export class Tabs extends Component {
   #events() {
     const options = this.options;
     const container = this.getContainer();
-    const Constructor = this.constructor;
     const delegatedElement = this.documentElem
       ? container.header.elem
       : options.$elem;
 
+    // 事件命名空间
+    const eventNamespace = CONST.EVENT_NAMESPACE;
+
+    // 避免重复绑定事件
+    delegatedElement.off(eventNamespace);
+
     // 标签头部事件
-    const trigger = `${options.trigger}.lay_${Constructor.componentName}_trigger`;
+    const trigger = `${options.trigger}${eventNamespace}`;
     const elemHeaderItem = this.documentElem
       ? this.headerElem[1]
       : this.headerElem.join('');
 
-    delegatedElement.off(trigger).on(trigger, elemHeaderItem, (e) => {
+    delegatedElement.on(trigger, elemHeaderItem, (e) => {
       this.change($(e.currentTarget).index());
     });
   }


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [x] 问题修复
- [x] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- 将 `carousel / collapse / colorpicker / dropdown / floatbar / flow / nav / tabs` 组件内部散乱的事件命名空间统一为 `CONST.EVENT_NAMESPACE`（即 `.lay_{componentName}_events`），以提升代码一致性与可维护性。
- 优化 nav 事件绑定机制，采用事件委托
- 修复 tabs.reload 时当 `options.trigger` 变化而导致旧 trigger 事件未被解绑的隐性问题

### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [ ] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [ ] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **功能更新**
  * 统一优化了多个组件的事件绑定方式，改用命名空间管理，提升重复初始化时的稳定性。
  * 部分交互组件的滚动、悬停、点击与窗口尺寸变化监听更可靠，自动轮播、懒加载和位置更新行为保持一致。

* **Bug 修复**
  * 减少了事件重复绑定与残留监听问题。
  * 提高了导航、折叠、标签页、下拉等交互在多次渲染后的表现一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->