### PR TITLE
fix(core): 修复 hint() 中 error 方法的 type 显示及优化 errorOnce 封装

### DIFF
--- a/docs/base.md
+++ b/docs/base.md
@@ -129,6 +129,43 @@ if(device.MYAPP){
 }
 ```
 
+<h2 id="hint" lay-toc="">控制台提示</h2>
+
+`layui.hint()` 用于向浏览器控制台输出异常或警告信息，返回一个包含 `error` 和 `errorOnce` 方法的对象。
+
+```
+var hint = layui.hint();
+```
+
+### error(msg, type)
+
+- **msg** <sup> string</sup> — 要输出的提示文本
+- **type** <sup> string</sup> — 提示类型，可选值：`warn`（默认）、`error`，分别对应 `console.warn()` 和 `console.error()` 输出
+
+```
+var hint = layui.hint();
+hint.error('配置项异常');            // console.warn() 输出（默认 type）：[Layui warn]: 配置项异常
+hint.error('操作失败', 'error');     // console.error() 输出：[Layui error]: 操作失败
+```
+
+> 输出到控制台的格式为 `[Layui type]: 消息内容`，其中 `type` 即传入的提示类型。
+
+### errorOnce(msg, type) <sup>2.9+</sup>
+
+参数与 `error` 方法完全一致，但增加了**消息去重**机制：在同一 `hint()` 实例的作用域内，相同的 `msg` 文本只会向控制台输出一次，再次调用将被静默忽略，避免短时间内的重复干扰。
+
+```
+var hint = layui.hint();
+hint.errorOnce('配置项缺失，将采用默认值');
+// 再次调用相同的消息将被忽略
+hint.errorOnce('配置项缺失，将采用默认值'); // 不再输出
+```
+
+> `errorOnce` 内部维护了一个缓存，在累计达到 100 条去重消息后会自动清空，以释放内存。
+
+<!-- 注：errorOnce 的去重缓存是 hint() 实例级别的，不同 hint() 实例互不影响。 -->
+
+
 <h2 id="api" lay-toc="{hot: true}">API 列表</span></h2>
 
 前面我们特别介绍了几个相对特殊的基础方法，而以下是 Layui 提供的全部基础 API：
@@ -152,7 +189,7 @@ if(device.MYAPP){
 | layui.data(table, settings) | 持久化存储。[#用法](#data) |
 | layui.sessionData(table, settings) | 会话性存储。[#用法](#data) |
 | layui.device(key) | 获取浏览器信息。[#用法](#device) |
-| layui.hint() | 向控制台打印一些异常信息，目前只返回了 error 方法，如： <br>`var hint = layui.hint();` <br> `hint.error('出错啦');` |
+| layui.hint() | 获取控制台提示对象，包含 error 和 errorOnce 两个方法。[#用法](#hint) |
 | layui.stope(e) | 阻止事件冒泡 |
 | layui.onevent(modName, events, callback) | 增加自定义模块事件，一般在内置组件中使用。 |
 | layui.event(modName, events, params) | 执行自定义模块事件，搭配 onevent 使用。注<sup>2.8+</sup>：当 events 参数中未设定 filter 时则可重复执行该事件，否则只会执行一次最新添加的事件。 |

--- a/docs/base.md
+++ b/docs/base.md
@@ -2,7 +2,7 @@
 title: 底层方法
 toc: true
 ---
- 
+
 # 底层方法
 
 > Layui 提供了一系列基础 API，以更好地辅助组件的使用。
@@ -29,7 +29,7 @@ layui.config({
 特别地，若你对 `layui.js` 本身进行了动态加载或是其他特殊场景中使用，那么上述 `layui.config()` 所设定的 `dir` 属性会因此失效，此时你可以在动态加载 <code>layui.js</code> 之前预先定义一个我们约定好的全局对象，如：
 
 ```
-<script>  
+<script>
 var LAYUI_GLOBAL = {
   dir: '/res/layui/' // layui.js 所在目录
 };
@@ -50,7 +50,7 @@ var LAYUI_GLOBAL = {
 ```
 // 假设当前页面 url 为： https://domain.com/docs/base.html?a=1&c=3#/user/set/id=123/
 var url = layui.url();
- 
+
 // url 返回结果为：
 {
   "pathname": ["docs","base.html"], // 路径
@@ -82,16 +82,16 @@ layui.data('test', {
   key: 'nickname',
   value: '张三'
 });
- 
+
 // 【删】：删除 test 表的 nickname 字段
 layui.data('test', {
   key: 'nickname',
   remove: true
 });
 layui.data('test', null); // 删除 test 表
-  
+
 // 【改】：同【增】，会覆盖已经存储的数据
-  
+
 // 【查】：向 test 表读取全部的数据
 var localTest = layui.data('test');
 console.log(localTest.nickname); // 获得“张三”
@@ -131,39 +131,38 @@ if(device.MYAPP){
 
 <h2 id="hint" lay-toc="">控制台提示</h2>
 
-`layui.hint()` 用于向浏览器控制台输出异常或警告信息，返回一个包含 `error` 和 `errorOnce` 方法的对象。
+`var hint = layui.hint();`
 
-```
-var hint = layui.hint();
-```
+用于向浏览器控制台输出异常或警告信息，返回一个包含 `error` 和 `errorOnce` 方法的对象。
 
 ### error(msg, type)
 
-- **msg** <sup> string</sup> — 要输出的提示文本
-- **type** <sup> string</sup> — 提示类型，可选值：`warn`（默认）、`error`，分别对应 `console.warn()` 和 `console.error()` 输出
+- 参数 **msg** <sup> string</sup> — 要输出的提示文本
+- 参数 **type** <sup> string</sup> — 提示类型，可选值：`warn`（默认）、`error`，分别对应 `console.warn()` 和 `console.error()` 输出
 
-```
+```js
 var hint = layui.hint();
-hint.error('配置项异常');            // console.warn() 输出（默认 type）：[Layui warn]: 配置项异常
-hint.error('操作失败', 'error');     // console.error() 输出：[Layui error]: 操作失败
+// 输出：[Layui warn]: Invalid configuration
+hint.error('Invalid configuration');
+// 输出：[Layui error]: Operation failed
+hint.error('Operation failed', 'error');
 ```
-
-> 输出到控制台的格式为 `[Layui type]: 消息内容`，其中 `type` 即传入的提示类型。
 
 ### errorOnce(msg, type) <sup>2.9+</sup>
 
-参数与 `error` 方法完全一致，但增加了**消息去重**机制：在同一 `hint()` 实例的作用域内，相同的 `msg` 文本只会向控制台输出一次，再次调用将被静默忽略，避免短时间内的重复干扰。
+参数与 `error` 方法完全一致，但增加了「消息去重」机制，即：在同一 `hint()` 实例的作用域内，相同的 `msg` 文本只会向控制台输出一次，再次调用将被忽略。不同 `hint()` 实例互不影响
 
 ```
 var hint = layui.hint();
-hint.errorOnce('配置项缺失，将采用默认值');
-// 再次调用相同的消息将被忽略
-hint.errorOnce('配置项缺失，将采用默认值'); // 不再输出
+
+// 首次输出
+hint.errorOnce('Missing configuration, using defaults');
+
+// 再次调用相同的消息将被忽略，不再输出
+hint.errorOnce('Missing configuration, using defaults');
 ```
 
-> `errorOnce` 内部维护了一个缓存，在累计达到 100 条去重消息后会自动清空，以释放内存。
-
-<!-- 注：errorOnce 的去重缓存是 hint() 实例级别的，不同 hint() 实例互不影响。 -->
+`errorOnce` 内部维护了一个缓存，在累计达到 100 条去重消息后会自动清空，以释放内存。
 
 
 <h2 id="api" lay-toc="{hot: true}">API 列表</span></h2>

--- a/src/layui.js
+++ b/src/layui.js
@@ -59,14 +59,14 @@
 
   // 异常提示
   var error = function (msg, type) {
-    type = type || 'warn';
-    msg = '[Layui ' + type + ']: ' + msg;
+    type = String(type || 'warn').replace(/^\s+|\s+$/g, '');
 
     // 仅允许 error 或 warn 两种类型的提示
-    if (!/^(?:warn|error)$/.test(String(type).trim())) {
+    if (!/^(?:warn|error)$/.test(type)) {
       type = 'warn';
     }
 
+    msg = '[Layui ' + type + ']: ' + msg;
     window.console[type](msg);
   };
 

--- a/src/layui.js
+++ b/src/layui.js
@@ -60,27 +60,14 @@
   // 异常提示
   var error = function (msg, type) {
     type = type || 'warn';
-    msg = '[Layui warn]: ' + msg;
+    msg = '[Layui ' + type + ']: ' + msg;
 
     // 仅允许 error 或 warn 两种类型的提示
-    if (/warn|error/.test(String(type).replace(/^\s+|\s+$/g, ''))) {
+    if (!/^(?:warn|error)$/.test(String(type).trim())) {
       type = 'warn';
     }
 
     window.console[type](msg);
-  };
-  var warned = Object.create(null);
-
-  var errorOnce = function (msg, type) {
-    if (warned._size && warned._size > 100) {
-      warned = Object.create(null);
-      warned._size = 0;
-    }
-    if (!warned[msg]) {
-      warned[msg] = true;
-      warned._size = (warned._size || 0) + 1;
-      error(msg, type);
-    }
   };
 
   // 内置模块
@@ -789,9 +776,21 @@
 
   // 提示
   Class.prototype.hint = function () {
+    var warned = Object.create(null);
+    var warnedCount = 0;
     return {
       error: error,
-      errorOnce: errorOnce
+      errorOnce: function (msg, type) {
+        if (warnedCount > 100) {
+          warned = Object.create(null);
+          warnedCount = 0;
+        }
+        if (!warned[msg]) {
+          warned[msg] = true;
+          warnedCount++;
+          error(msg, type);
+        }
+      }
     };
   };
 


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [x] 问题修复
- [x] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- **src/layui.js**: 修复 `error()` 方法的 `type` 参数无效问题
  - 此前消息格式为硬编码 `[Layui warn]:`，无论传入什么 type 都显示 warn
  - 此后改为动态 `[Layui type]:`，正确反映传入的提示类型
  - 修复 type 校验正则：从 `/warn|error/` 部分匹配改为 `/^(?:warn|error)$/` 精确匹配
- **src/layui.js**: 优化 `errorOnce()` 方法，将去重缓存从模块级全局单例改为 `hint()` 实例级别，不同调用获得独立去重上下文，避免跨模块干扰
- **docs/base.md**: 为 `layui.hint()` 补充完整的 API 文档，包含 `error` 和 `errorOnce` 方法的使用说明和代码示例

### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [ ] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [ ] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 控制台提示相关说明已补充，新增 `errorOnce` 的使用指引与示例说明。
  * `hint()` 现在明确返回包含 `error` 和 `errorOnce` 的提示对象。

* **Bug 修复**
  * 错误提示输出更一致，异常类型会自动回退到安全的警告输出。
  * `errorOnce` 的去重与缓存清理逻辑已优化，同一提示不会重复刷屏。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->