### PR TITLE
fix(treeTable): 修复 addNodes 根节点 LAY_INDEX 重复的问题

### DIFF
--- a/src/modules/treeTable.js
+++ b/src/modules/treeTable.js
@@ -1892,6 +1892,10 @@ layui.define(['table'], function (exports) {
       }
 
       var newNodesHtml = table.getTrHtml(id, newNodes);
+      // 确保根节点的 LAY_INDEX 与数组实际位置一致
+      layui.each(table.cache[id], function (idx, item) {
+        item[table.config.indexName] = idx;
+      });
       var newNodesHtmlObj = {
         trs: $(newNodesHtml.trs.join('')),
         trs_fixed: $(newNodesHtml.trs_fixed.join('')),


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [x] 问题修复
- [ ] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- **src/modules/treeTable.js**: 修复 addNodes() 在添加根级节点时 LAY_INDEX 始终为 0 导致与已有索引重复的问题
  - 原因：getTrHtml() 仅接收 newNodes 子集渲染，循环索引从 0 开始
  - 修复：在 HTML 生成后根据实际位置校正根节点的 LAY_INDEX
  - resolves #3034

### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [ ] 已提供在线演示地址（如：codepen, stackblitz）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复了树形表格在向根节点新增数据后，顶层行索引可能不同步的问题。
  * 提升了根节点的定位与新增稳定性，减少了后续操作中出现的显示或位置错误。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->