### PR TITLE
feat(core): 新增 lay.parseDataset 方法，用于解析元素 dataset 上的配置信息

### DIFF
--- a/src/components/breadcrumb.js
+++ b/src/components/breadcrumb.js
@@ -12,12 +12,15 @@ export class Breadcrumb extends Component {
   // 默认配置项
   static options = {
     elem: '.lay-breadcrumb',
+
+    // 分隔符
+    separator: '/',
   };
 
   static get CONST() {
     return {
       ...super.CONST,
-      ATTR_SEPARATOR: 'lay-separator',
+      ELEM_SEPARATOR: 'lay-breadcrumb-separator',
     };
   }
 
@@ -25,16 +28,16 @@ export class Breadcrumb extends Component {
   render() {
     const options = this.options;
     const $elem = options.$elem;
-
-    const ATTR_SEPARATOR = CONST.ATTR_SEPARATOR;
-    const separator = $elem.attr(ATTR_SEPARATOR) || '/';
     const $aElem = $elem.children('a');
 
-    if ($aElem.next('span[' + ATTR_SEPARATOR + ']')[0]) return;
-
-    $aElem.each(function (index) {
+    $aElem.each((index, elem) => {
       if (index === $aElem.length - 1) return;
-      $(this).after(`<span ${ATTR_SEPARATOR}>${separator}</span>`);
+      const $this = $(elem);
+      const $separator = $(`<span class="${CONST.ELEM_SEPARATOR}"></span>`);
+
+      $separator[0].innerHTML = options.separator;
+      $this.next(`span.${CONST.ELEM_SEPARATOR}`).remove();
+      $this.after($separator);
     });
 
     $elem.css('visibility', 'visible');

--- a/src/components/carousel.js
+++ b/src/components/carousel.js
@@ -75,7 +75,7 @@ export class Carousel extends Component {
       });
     }
 
-    $elem.attr('lay-anim', options.anim);
+    $elem.attr('data-lay-anim', options.anim);
 
     // 初始焦点状态
     this.$itemElem
@@ -190,7 +190,7 @@ export class Carousel extends Component {
     );
 
     // 预设基础属性
-    $elem.attr('lay-arrow', options.arrow);
+    $elem.attr('data-lay-arrow', options.arrow);
 
     // 避免重复插入
     if ($elem.find(`.${CONST.ELEM_ARROW}`)[0]) {
@@ -230,7 +230,7 @@ export class Carousel extends Component {
     ));
 
     // 预设基础属性
-    $elem.attr('lay-indicator', options.indicator);
+    $elem.attr('data-lay-indicator', options.indicator);
 
     // 避免重复插入
     if ($elem.find(`.${CONST.ELEM_IND}`)[0]) {

--- a/src/components/collapse.js
+++ b/src/components/collapse.js
@@ -1,6 +1,6 @@
 /**
  * collapse
- * 折叠面板组件
+ * 折叠面板
  */
 
 import { lay } from '../core/lay.js';
@@ -13,16 +13,22 @@ export class Collapse extends Component {
   // 默认配置
   static options = {
     elem: '.lay-collapse',
+
+    // 是否开启手风琴模式
+    accordion: false,
   };
 
-  // 渲染
+  /**
+   * 渲染
+   * @returns {void}
+   */
   render() {
     const options = this.options;
     const $items = options.$elem.find('.lay-collapse-item');
     const eventNamespace = CONST.EVENT_NAMESPACE;
 
-    $items.each(function () {
-      const $this = $(this);
+    $items.each((index, itemElem) => {
+      const $this = $(itemElem);
       const $title = $this.find('.lay-collapse-title');
       const $content = $this.find('.lay-collapse-content');
       const isNone = $content.css('display') === 'none';
@@ -36,18 +42,21 @@ export class Collapse extends Component {
       $this[isNone ? 'removeClass' : 'addClass'](CONST.CLASS_SHOW);
 
       // 点击标题
-      $title.off(clickEventName).on(clickEventName, events.titleClick);
+      $title.off(clickEventName).on(clickEventName, (e) => {
+        this.#titleClick($(e.currentTarget));
+      });
     });
   }
-}
 
-// 基础事件体
-const events = {
-  // 点击面板标题项
-  titleClick() {
-    const $this = $(this);
-    const wrapper = $this.closest('.lay-collapse');
-    const filter = wrapper.attr('lay-filter');
+  /**
+   * 点击面板标题项的事件处理函数
+   * @param {JQuery<HTMLElement>} $this - 当前点击的标题元素
+   * @return {void}
+   */
+  #titleClick($this) {
+    const options = this.options;
+    const $elem = options.$elem;
+    const filter = $elem.attr('lay-filter');
 
     const ANIM_MS = 200; // 动画过渡毫秒数
     const CLASS_ITEM = '.lay-collapse-item';
@@ -56,11 +65,11 @@ const events = {
     const thisItemElem = $this.parent(CLASS_ITEM);
     const thisContentElem = $this.siblings(CLASS_CONTENT);
     const isNone = thisContentElem.css('display') === 'none';
-    const isAccordion = typeof wrapper.attr('lay-accordion') === 'string';
 
     // 动画执行完成后的操作
     const complete = function () {
-      $(this).css('display', ''); // 剔除动画生成的 style display，以适配外部样式的状态重置
+      // 剔除动画生成的 style display，以适配外部样式的状态重置
+      $(this).css('display', '');
     };
 
     // 是否正处于动画中的状态
@@ -78,7 +87,7 @@ const events = {
     }
 
     // 是否开启手风琴
-    if (isAccordion) {
+    if (options.accordion) {
       const itemSiblings = thisItemElem.siblings(`.${CONST.CLASS_SHOW}`);
       itemSiblings.removeClass(CONST.CLASS_SHOW);
       itemSiblings.children(CLASS_CONTENT).show().slideUp(ANIM_MS, complete);
@@ -90,8 +99,8 @@ const events = {
       content: thisContentElem,
       show: isNone,
     });
-  },
-};
+  }
+}
 
 const CONST = Collapse.CONST;
 

--- a/src/components/laypage.js
+++ b/src/components/laypage.js
@@ -1,6 +1,6 @@
 /**
  * laypage
- * 分页组件
+ * 分页
  */
 
 import { lay } from '../core/lay.js';
@@ -332,7 +332,10 @@ export class Laypage extends Component {
     return $rootElem;
   }
 
-  // 为根容器应用额外的类名和样式
+  /**
+   * 为根容器应用额外的类名和样式
+   * @return {void}
+   */
   #applyRootElemStyles() {
     const options = this.options;
     const $rootElem = this.$rootElem;
@@ -344,7 +347,7 @@ export class Laypage extends Component {
 
     // 组件尺寸
     if (['sm', 'md', 'lg'].includes(options.size)) {
-      $rootElem.addClass(`lay-size-${options.size}`);
+      $rootElem.attr('data-lay-size', options.size);
     }
 
     // 内置主题风格

--- a/src/components/menu.js
+++ b/src/components/menu.js
@@ -211,7 +211,7 @@ export class Menu extends Component {
   }
 
   /**
-   * 应用菜单 data-* 属性
+   * 应用菜单 dataset 属性
    * @param {JQuery} $elem - 菜单元素
    * @param {Object} options - 菜单配置项
    * @returns {void}
@@ -228,25 +228,25 @@ export class Menu extends Component {
 
     // 设置「菜单模式」属性
     if (['vertical', 'horizontal'].includes(options.mode)) {
-      $elem.attr('data-mode', options.mode);
+      $elem.attr('data-lay-mode', options.mode);
     }
 
     // 设置「子菜单展示方式」属性
     if (['inline', 'popup'].includes(options.submenuMode)) {
-      $elem.attr('data-submenu-mode', options.submenuMode);
+      $elem.attr('data-lay-submenu-mode', options.submenuMode);
     }
 
     // 设置「收起状态」属性
-    toggleDataAttr('data-collapsed', options.collapsed);
+    toggleDataAttr('data-lay-collapsed', options.collapsed);
 
     // 设置尺寸属性
     if (['sm', 'md', 'lg'].includes(options.size)) {
-      $elem.attr('data-size', options.size);
+      $elem.attr('data-lay-size', options.size);
     }
 
     // 设置主题属性
     if (['light', 'dark'].includes(options.theme)) {
-      $elem.attr('data-theme', options.theme);
+      $elem.attr('data-lay-theme', options.theme);
     }
   }
 
@@ -673,9 +673,9 @@ export class Menu extends Component {
     // 克隆子菜单元素
     const $subClone = $sub.clone(true).attr('class', CONST.ELEM);
 
-    // 非默认尺寸，预设 data-size 属性
+    // 非默认尺寸，预设 size 属性
     if (options.size !== 'md') {
-      $subClone.attr('data-size', options.size);
+      $subClone.attr('data-lay-size', options.size);
     }
 
     // 菜单容器

--- a/src/components/popup.js
+++ b/src/components/popup.js
@@ -399,7 +399,7 @@ export class Popup extends Component {
     $rootElem.attr('style', options.style);
 
     // 设置主题
-    $rootElem.attr('data-theme', options.theme);
+    $rootElem.attr('data-lay-theme', options.theme);
   }
 
   /**

--- a/src/components/progress.js
+++ b/src/components/progress.js
@@ -1,6 +1,6 @@
 /**
  * progress
- * 进度条组件
+ * 进度条
  */
 
 import { $ } from 'jquery';
@@ -24,13 +24,27 @@ export class Progress extends Component {
   // 默认配置
   static options = {
     elem: '.lay-progress',
+
+    // 进度值
+    percent: 0,
+
+    // 是否显示进度值
+    showPercent: false,
+
+    // 进度条颜色
+    // color: '',
+
+    // 轨道颜色
+    // railColor: '',
+
+    // 尺寸；可选值: xs|sm|md(默认)|lg|xl
+    // size: ''
   };
 
   static get CONST() {
     return {
       ...super.CONST,
       ELEM: 'lay-progress',
-      ATTR_PERCENT: 'lay-percent',
     };
   }
 
@@ -39,13 +53,14 @@ export class Progress extends Component {
     this.delegateInstanceMethods(['setValue']);
   }
 
+  /**
+   * 渲染
+   * @returns {void}
+   */
   render() {
     const options = this.options;
     const $elem = options.$elem;
-    const value = $elem.attr(CONST.ATTR_PERCENT);
-    const percent = normalizePercent(value);
-    const progressColor = $elem.attr(`${CONST.ELEM}-color`);
-    const progressRailColor = $elem.attr(`${CONST.ELEM}-rail-color`);
+    const percent = normalizePercent(options.percent);
     const $progressRail = (this.$progressRail = $('<div>').addClass(
       `${CONST.ELEM}-rail`,
     ));
@@ -53,20 +68,25 @@ export class Progress extends Component {
       `${CONST.ELEM}-bar`,
     ));
 
+    // 设置 size 属性
+    if (['xs', 'sm', 'md', 'lg', 'xl'].includes(options.size)) {
+      $elem.attr('data-lay-size', options.size);
+    }
+
     // 设置轨道和进度条样式
     $progressRail.css({
-      'background-color': progressRailColor || '',
+      'background-color': options.railColor || '',
     });
     $progressBar.css({
       width: `${percent}%`,
-      'background-color': progressColor || '',
+      'background-color': options.color || '',
     });
 
     // 插入进度条结构
     $elem.empty().append($progressRail.append($progressBar));
 
     // 是否显示进度值
-    if ($elem.is('[lay-show-percent]')) {
+    if (options.showPercent) {
       const $progressInfo = (this.$progressInfo = $('<div>')
         .addClass(`${CONST.ELEM}-info`)
         .text(`${percent}%`));
@@ -76,19 +96,18 @@ export class Progress extends Component {
 
   /**
    * 动态改变进度条
-   * @param {string} id - 组件实例 id
    * @param {string|number} value - 进度值
-   * @returns {typeof Progress}
+   * @returns {void}
    */
   setValue(value) {
     const options = this.options;
-    const $elem = options.$elem;
     const $progressBar = this.$progressBar;
     const $progressInfo = this.$progressInfo;
     const percent = normalizePercent(value);
 
-    $elem.attr(CONST.ATTR_PERCENT, percent);
-    $progressBar.css('width', `${percent}%`);
+    options.percent = percent;
+    options.$elem.attr('data-lay-percent', percent);
+    $progressBar?.css('width', `${percent}%`);
     $progressInfo?.text(`${percent}%`);
   }
 }

--- a/src/components/upload.js
+++ b/src/components/upload.js
@@ -340,7 +340,7 @@ export class Upload extends Component {
   <div class="${CONST.ELEM_LIST}-item-status"></div>
   <div class="${CONST.ELEM_LIST}-item-content">
     <div class="${CONST.ELEM_LIST}-item-name lay-ellipsis"></div>
-    <div class="lay-progress lay-size-xs"></div>
+    <div class="lay-progress" data-lay-size="xs"></div>
   </div>
 </div>
         `);

--- a/src/core/component.js
+++ b/src/core/component.js
@@ -251,14 +251,8 @@ export class Component {
 
     // 仅来自 render 的调用
     if (!isReload) {
-      // 合并 lay-options 属性上的配置信息
-      // WIP: 鉴于 CSP 策略，后续将移除 `lay.options` 方法，改用 dataset 方案
-      const layOptions = lay.options($elem[0]);
-      $.extend(this.options, layOptions);
-
       // 合并 dataset 上的配置信息
-      // WIP: 临时实现，后续将支持嵌套等功能
-      const dataset = { ...$elem[0]?.dataset };
+      const dataset = lay.parseDataset($elem[0]);
       $.extend(this.options, dataset);
 
       // 若对目标元素重复渲染，则视为 reload 处理

--- a/src/core/lay.js
+++ b/src/core/lay.js
@@ -878,6 +878,11 @@ lay.position = function (target, elem, opts) {
 
 /**
  * 获取元素上的属性配置项
+ *
+ * @deprecated 鉴于 CSP 策略，该方法已弃用。
+ * 将统一使用 dataset 方案获取元素上的 `data-*` 配置信息。
+ * 因当前 table 组件仍有依赖，该方法暂不移除，待 table 重写完成后将正式移除。
+ *
  * @param {string | HTMLElement | JQuery} elem - HTML 元素
  * @param {{attr: string} | string} [opts="lay-options"] - 可配置的选项，string 类型指定属性名
  * @returns {Object.<string, any>} 返回元素上的属性配置项
@@ -918,6 +923,145 @@ lay.options = function (elem, opts) {
     );
     return {};
   }
+};
+
+/**
+ * 解析元素 dataset 上的配置信息
+ * @param {string | HTMLElement | JQuery} elem - 目标元素
+ * @param {Object} [opts] - 配置对象
+ * @param {string} [opts.prefix='lay'] - 约定读取的 dataset 前缀；
+ *  默认只解析 `data-lay-*` 属性；若要解析所有 `data-*` 属性，可将 prefix 设置为 `''`
+ * @param {string} [opts.connector='.'] - 嵌套属性的连接符
+ * @param {Function} [opts.beforeParseValue] - 值类型转换前的回调；
+ *  接收 {rawKey: string, rawValue: string} 参数；返回 false 则不转换
+ * @returns {Object} 返回 options 对象
+ * @example
+ * ```html
+ * <div id="testEl"
+ *   data-lay-size="xl"
+ *   data-lay-index="0"
+ *   data-lay-default-open="true"
+ *   data-lay-colors='["red", "green", "blue"]'
+ *   data-lay-tree.flag="null"
+ * ></div>
+ * ```
+ * ```js
+ * const datasetOptions = lay.parseDataset('#testEl');
+ * console.log(datasetOptions);
+ * // {
+ * //   size: 'xl',
+ * //   index: 0,
+ * //   defaultOpen: true,
+ * //   colors: ['red', 'green', 'blue'],
+ * //   tree: {
+ * //     flag: null
+ * //   }
+ * // }
+ * ```
+ */
+lay.parseDataset = function (elem, opts) {
+  const targetElem = getElement(elem);
+  const dataset = targetElem?.dataset;
+
+  if (!dataset) return {};
+
+  opts = {
+    prefix: 'lay',
+    connector: '.',
+    // beforeParseValue: null,
+    ...opts,
+  };
+
+  // 根据 JSON 规范进行值类型转换
+  // 如：`"true"` -> `true`, `"123"` -> `123`, `"[1,2,3]"` -> `[1,2,3]`
+  const parseValue = ({ rawKey, rawValue }) => {
+    // 值类型转换前的回调；返回 false 则不转换
+    const beforeParseResult = opts.beforeParseValue?.({
+      rawKey,
+      rawValue,
+    });
+
+    if (beforeParseResult === false || !rawValue.trim()) {
+      return rawValue;
+    }
+
+    try {
+      return JSON.parse(rawValue);
+    } catch {
+      return rawValue;
+    }
+  };
+
+  // 嵌套解析
+  const parseNested = (target, rawKey, rawValue) => {
+    const keys = rawKey.split(opts.connector).filter(Boolean);
+    if (!keys.length) return;
+
+    let current = target;
+    const value = parseValue({ rawKey, rawValue });
+
+    // 逐级创建选项
+    for (const [index, key] of keys.entries()) {
+      // 最后一级直接赋值
+      if (index === keys.length - 1) {
+        // 若目标位置已存在对象值（如先由嵌套属性创建），覆盖前打印提示
+        if (lay.isPlainObject(current[key])) {
+          log(
+            `parseDataset: Property "data-${rawKey}" overwrites the existing object at "data-${keys
+              .slice(0, index + 1)
+              .join(opts.connector)}"`,
+          );
+        }
+        current[key] = value;
+        continue;
+      }
+
+      // 初始化父级对象
+      if (!lay.hasOwn(current, key)) {
+        current[key] = {};
+      } else if (!lay.isPlainObject(current[key])) {
+        // 若父级已存在非对象值，则视为无效嵌套
+        log(
+          `parseDataset: Cannot set nested property "data-${rawKey}" on non-object value at "data-${keys
+            .slice(0, index + 1)
+            .join(opts.connector)}"`,
+        );
+        return;
+      }
+
+      current = current[key];
+    }
+  };
+
+  // 获取特定前缀后的属性 Key
+  const getKey = (rawKey) => {
+    // 无任何前缀，即表示读取 `data-*` 配置信息
+    if (!opts.prefix) {
+      return rawKey;
+    }
+
+    const key = rawKey.slice(opts.prefix.length);
+
+    // 若移除前缀后的属性名不以大写字母开头，则视为无效属性
+    // 该逻辑为避免匹配到 data-lay* ，有效的属性名应为 data-lay-*
+    if (!rawKey.startsWith(opts.prefix) || !/^[A-Z]/.test(key)) {
+      return '';
+    }
+
+    return key.charAt(0).toLowerCase() + key.slice(1);
+  };
+
+  const dataOptions = {};
+
+  Object.entries(dataset).forEach(([rawKey, rawValue]) => {
+    const key = getKey(rawKey);
+
+    if (key) {
+      parseNested(dataOptions, key, rawValue);
+    }
+  });
+
+  return dataOptions;
 };
 
 /**

--- a/src/css/modules/carousel.css
+++ b/src/css/modules/carousel.css
@@ -65,14 +65,14 @@
   left: auto !important;
   right: 10px;
 }
-.lay-carousel[lay-arrow='always'] .lay-carousel-arrow {
+.lay-carousel[data-lay-arrow='always'] .lay-carousel-arrow {
   opacity: 1;
   left: 20px;
 }
-.lay-carousel[lay-arrow='always'] .lay-carousel-arrow[lay-type='add'] {
+.lay-carousel[data-lay-arrow='always'] .lay-carousel-arrow[lay-type='add'] {
   right: 20px;
 }
-.lay-carousel[lay-arrow='none'] .lay-carousel-arrow {
+.lay-carousel[data-lay-arrow='none'] .lay-carousel-arrow {
   display: none;
 }
 .lay-carousel-arrow:hover,
@@ -94,16 +94,16 @@
   text-align: center;
   font-size: 0;
 }
-.lay-carousel[lay-indicator='outside'] {
+.lay-carousel[data-lay-indicator='outside'] {
   margin-bottom: 30px;
 }
-.lay-carousel[lay-indicator='outside'] .lay-carousel-ind {
+.lay-carousel[data-lay-indicator='outside'] .lay-carousel-ind {
   top: 10px;
 }
-.lay-carousel[lay-indicator='outside'] .lay-carousel-ind ul {
+.lay-carousel[data-lay-indicator='outside'] .lay-carousel-ind ul {
   background-color: rgba(0, 0, 0, 0.5);
 }
-.lay-carousel[lay-indicator='none'] .lay-carousel-ind {
+.lay-carousel[data-lay-indicator='none'] .lay-carousel-ind {
   display: none;
 }
 .lay-carousel-ind ul {
@@ -165,61 +165,61 @@
 }
 
 /* 上下切换 */
-.lay-carousel[lay-anim='updown'] .lay-carousel-arrow {
+.lay-carousel[data-lay-anim='updown'] .lay-carousel-arrow {
   left: 50% !important;
   top: 20px;
   margin: 0 0 0 -18px;
 }
-.lay-carousel[lay-anim='updown'] .lay-carousel-arrow[lay-type='add'] {
+.lay-carousel[data-lay-anim='updown'] .lay-carousel-arrow[lay-type='add'] {
   top: auto !important;
   bottom: 20px;
 }
-.lay-carousel[lay-anim='updown'] .lay-carousel-ind {
+.lay-carousel[data-lay-anim='updown'] .lay-carousel-ind {
   position: absolute;
   top: 50%;
   right: 20px;
   width: auto;
   height: auto;
 }
-.lay-carousel[lay-anim='updown'] .lay-carousel-ind ul {
+.lay-carousel[data-lay-anim='updown'] .lay-carousel-ind ul {
   padding: 3px 5px;
 }
-.lay-carousel[lay-anim='updown'] .lay-carousel-ind li {
+.lay-carousel[data-lay-anim='updown'] .lay-carousel-ind li {
   display: block;
   margin: 6px 0;
 }
 
-.lay-carousel[lay-anim='updown'] > *[carousel-item] > * {
+.lay-carousel[data-lay-anim='updown'] > *[carousel-item] > * {
   left: 0 !important;
 }
-.lay-carousel[lay-anim='updown'] > *[carousel-item] > .lay-this {
+.lay-carousel[data-lay-anim='updown'] > *[carousel-item] > .lay-this {
   -webkit-transform: translateY(0);
   transform: translateY(0);
 }
-.lay-carousel[lay-anim='updown'] > *[carousel-item] > .lay-carousel-prev {
+.lay-carousel[data-lay-anim='updown'] > *[carousel-item] > .lay-carousel-prev {
   -webkit-transform: translateY(-100%);
   transform: translateY(-100%);
 }
-.lay-carousel[lay-anim='updown'] > *[carousel-item] > .lay-carousel-next {
+.lay-carousel[data-lay-anim='updown'] > *[carousel-item] > .lay-carousel-next {
   -webkit-transform: translateY(100%);
   transform: translateY(100%);
 }
-.lay-carousel[lay-anim='updown']
+.lay-carousel[data-lay-anim='updown']
   > *[carousel-item]
   > .lay-carousel-prev.lay-carousel-right,
-.lay-carousel[lay-anim='updown']
+.lay-carousel[data-lay-anim='updown']
   > *[carousel-item]
   > .lay-carousel-next.lay-carousel-left {
   -webkit-transform: translateY(0);
   transform: translateY(0);
 }
-.lay-carousel[lay-anim='updown']
+.lay-carousel[data-lay-anim='updown']
   > *[carousel-item]
   > .lay-this.lay-carousel-left {
   -webkit-transform: translateY(-100%);
   transform: translateY(-100%);
 }
-.lay-carousel[lay-anim='updown']
+.lay-carousel[data-lay-anim='updown']
   > *[carousel-item]
   > .lay-this.lay-carousel-right {
   -webkit-transform: translateY(100%);
@@ -227,24 +227,26 @@
 }
 
 /* 渐显切换 */
-.lay-carousel[lay-anim='fade'] > *[carousel-item] > * {
+.lay-carousel[data-lay-anim='fade'] > *[carousel-item] > * {
   -webkit-transform: translateX(0) !important;
   transform: translateX(0) !important;
 }
-.lay-carousel[lay-anim='fade'] > *[carousel-item] > .lay-carousel-prev,
-.lay-carousel[lay-anim='fade'] > *[carousel-item] > .lay-carousel-next {
+.lay-carousel[data-lay-anim='fade'] > *[carousel-item] > .lay-carousel-prev,
+.lay-carousel[data-lay-anim='fade'] > *[carousel-item] > .lay-carousel-next {
   opacity: 0;
 }
-.lay-carousel[lay-anim='fade']
+.lay-carousel[data-lay-anim='fade']
   > *[carousel-item]
   > .lay-carousel-prev.lay-carousel-right,
-.lay-carousel[lay-anim='fade']
+.lay-carousel[data-lay-anim='fade']
   > *[carousel-item]
   > .lay-carousel-next.lay-carousel-left {
   opacity: 1;
 }
-.lay-carousel[lay-anim='fade'] > *[carousel-item] > .lay-this.lay-carousel-left,
-.lay-carousel[lay-anim='fade']
+.lay-carousel[data-lay-anim='fade']
+  > *[carousel-item]
+  > .lay-this.lay-carousel-left,
+.lay-carousel[data-lay-anim='fade']
   > *[carousel-item]
   > .lay-this.lay-carousel-right {
   opacity: 0;

--- a/src/css/modules/laypage.css
+++ b/src/css/modules/laypage.css
@@ -94,14 +94,14 @@
 }
 
 /* 组件尺寸 */
-.lay-pagination.lay-size-sm {
+.lay-pagination[data-lay-size='sm'] {
   --lay-height: 24px;
   --lay-input-width: 38px;
   --lay-btn-spacing: 8px;
 
   font-size: 0.75rem;
 }
-.lay-pagination.lay-size-lg {
+.lay-pagination[data-lay-size='lg'] {
   --lay-height: 38px;
   --lay-input-width: 55px;
 

--- a/src/css/modules/menu.css
+++ b/src/css/modules/menu.css
@@ -135,8 +135,9 @@
 }
 
 /* 子菜单展开状态 / 子菜单打开状态@水平菜单 */
-.lay-menu:not([data-submenu-mode='popup']) .lay-menu-submenu.lay-is-expanded,
-.lay-menu[data-mode='horizontal'] .lay-menu-submenu.lay-is-open {
+.lay-menu:not([data-lay-submenu-mode='popup'])
+  .lay-menu-submenu.lay-is-expanded,
+.lay-menu[data-lay-mode='horizontal'] .lay-menu-submenu.lay-is-open {
   > .lay-menu-title {
     color: var(--lay-menu-open-color);
 
@@ -154,7 +155,9 @@
 }
 
 /* 子菜单展开状态 @垂直菜单 */
-.lay-menu:not([data-mode='horizontal']):not([data-submenu-mode='popup']) {
+.lay-menu:not([data-lay-mode='horizontal']):not(
+    [data-lay-submenu-mode='popup']
+  ) {
   .lay-menu-submenu.lay-is-expanded {
     > .lay-menu-sub {
       display: block;
@@ -163,7 +166,7 @@
 }
 
 /* 子菜单 popup 模式 */
-.lay-menu:not([data-mode='horizontal'])[data-submenu-mode='popup'] {
+.lay-menu:not([data-lay-mode='horizontal'])[data-lay-submenu-mode='popup'] {
   .lay-menu-title-arrow .lay-icon {
     transform: rotate(-90deg);
   }
@@ -171,7 +174,7 @@
 
 /* 选中的菜单项 */
 .lay-menu-item.lay-is-active,
-.lay-menu[data-submenu-mode='popup']
+.lay-menu[data-lay-submenu-mode='popup']
   .lay-menu-submenu:has(.lay-menu-item.lay-is-active) {
   > .lay-menu-title {
     color: var(--lay-menu-active-color);
@@ -203,7 +206,7 @@
 }
 
 /* 水平菜单 */
-.lay-menu[data-mode='horizontal'] {
+.lay-menu[data-lay-mode='horizontal'] {
   display: flex;
   gap: var(--lay-spacing-sm);
   margin: 0;
@@ -234,7 +237,7 @@
 }
 
 /* 收起模式 @垂直菜单 */
-.lay-menu[data-collapsed]:not([data-mode='horizontal']) {
+.lay-menu[data-lay-collapsed]:not([data-lay-mode='horizontal']) {
   .lay-menu-title {
     height: calc(
       var(--lay-menu-line-height) + 2 * var(--lay-menu-title-padding-y)
@@ -249,20 +252,20 @@
   }
 }
 /* 收起模式 @水平菜单 (WIP) */
-.lay-menu[data-collapsed][data-mode='horizontal'] {
+.lay-menu[data-lay-collapsed][data-lay-mode='horizontal'] {
   display: none;
 }
 
 /* 尺寸 */
-.lay-menu[data-size='sm'] {
+.lay-menu[data-lay-size='sm'] {
   --lay-menu-line-height: 26px;
 }
-.lay-menu[data-size='lg'] {
+.lay-menu[data-lay-size='lg'] {
   --lay-menu-line-height: 38px;
 }
 
 /* 主题·深色模式 */
-.lay-menu[data-theme='dark'] {
+.lay-menu[data-lay-theme='dark'] {
   --lay-menu-color: rgba(255, 255, 255, 0.8);
   --lay-menu-active-color: rgba(255, 255, 255, 1);
   --lay-menu-active-bg: var(--lay-color-primary);
@@ -285,19 +288,19 @@
   background-color: var(--lay-color-light, #fff);
   transition: all var(--lay-anim-duration);
 }
-.lay-menu-container:has(.lay-menu[data-theme='dark']) {
+.lay-menu-container:has(.lay-menu[data-lay-theme='dark']) {
   background-color: var(--lay-color-dark, #2f363c);
 }
 /* 外层容器 @垂直菜单 收起模式 */
 .lay-menu-container:has(
-  .lay-menu:not([data-mode='horizontal'])[data-collapsed]
+  .lay-menu:not([data-lay-mode='horizontal'])[data-lay-collapsed]
 ) {
   --lay-menu-collapsed-width: 65px;
 
   width: var(--lay-menu-collapsed-width) !important;
 }
 /* 外层容器 @水平菜单 */
-.lay-menu-container:has(.lay-menu[data-mode='horizontal']) {
+.lay-menu-container:has(.lay-menu[data-lay-mode='horizontal']) {
   flex-direction: row;
   height: var(--lay-menu-horizontal-height);
   padding-inline: var(--lay-spacing);
@@ -355,15 +358,15 @@
   border-left-width: var(--lay-menu-border-width);
 }
 /* 线条风格 @垂直菜单（常用于右侧目录） */
-.lay-menu-is-line:has(.lay-menu:not([data-mode='horizontal'])) {
+.lay-menu-is-line:has(.lay-menu:not([data-lay-mode='horizontal'])) {
   .lay-menu-submenu:has(.lay-menu-item.lay-is-active).lay-is-expanded
     > .lay-menu-title::after {
     display: none;
   }
 }
 /* 线条风格 @水平菜单 */
-.lay-menu-is-line:has(.lay-menu[data-mode='horizontal']) {
-  .lay-menu[data-mode='horizontal'] li {
+.lay-menu-is-line:has(.lay-menu[data-lay-mode='horizontal']) {
+  .lay-menu[data-lay-mode='horizontal'] li {
     align-items: normal;
   }
 
@@ -376,7 +379,7 @@
     border-bottom-width: var(--lay-menu-active-border-width);
   }
 }
-.lay-menu-is-line:has(.lay-menu[data-mode='horizontal'])::after {
+.lay-menu-is-line:has(.lay-menu[data-lay-mode='horizontal'])::after {
   top: auto;
   bottom: 0;
   width: 100%;
@@ -392,7 +395,7 @@
 .lay-menu-popup + .lay-menu-popup {
   box-shadow: 1px 5px 32px rgb(0 0 0 / 16%);
 }
-.lay-menu-popup:has(.lay-menu[data-theme='dark']) {
+.lay-menu-popup:has(.lay-menu[data-lay-theme='dark']) {
   border-color: var(--lay-menu-border-color, rgba(200, 200, 200, 0.08));
 }
 .lay-menu-popup .lay-menu-container {

--- a/src/css/modules/nav.css
+++ b/src/css/modules/nav.css
@@ -260,7 +260,7 @@
   color: #5f5f5f;
   font-style: normal;
 }
-.lay-breadcrumb span[lay-separator] {
-  margin: 0 10px;
+.lay-breadcrumb-separator {
+  padding: 0 10px;
   color: #999;
 }

--- a/src/css/modules/popup.css
+++ b/src/css/modules/popup.css
@@ -53,7 +53,7 @@
 }
 
 /* 主题 */
-.lay-popup[data-theme='dark'] {
+.lay-popup[data-lay-theme='dark'] {
   background-color: var(--lay-color-dark, #2f363c);
   color: rgba(255, 255, 255, 0.9);
   border: none;
@@ -75,6 +75,6 @@
 .lay-popup-tooltip {
   box-shadow: 1px 5px 32px rgb(0 0 0 / 16%);
 }
-.lay-popup-tooltip[data-theme='dark'] {
+.lay-popup-tooltip[data-lay-theme='dark'] {
   box-shadow: 1px 5px 32px rgb(0 0 0 / 32%);
 }

--- a/src/css/modules/progress.css
+++ b/src/css/modules/progress.css
@@ -31,22 +31,22 @@
   -webkit-transition: all 0.3s;
   transition: all 0.3s;
 }
-.lay-progress:not(.lay-size-xl) .lay-progress-info {
+.lay-progress:not([data-lay-size='xl']) .lay-progress-info {
   font-size: 0.75rem;
 }
 
 /* 不同尺寸 */
-.lay-progress.lay-size-xs {
+.lay-progress[data-lay-size='xs'] {
   --lay-progress-border-radius: 0;
 
   height: 2px;
 }
-.lay-progress.lay-size-sm {
+.lay-progress[data-lay-size='sm'] {
   height: 5px;
 }
-.lay-progress.lay-size-lg {
+.lay-progress[data-lay-size='lg'] {
   height: 11px;
 }
-.lay-progress.lay-size-xl {
+.lay-progress[data-lay-size='xl'] {
   height: var(--lay-progress-size-xl);
 }

--- a/tests/visual/assets/modules/test/test.js
+++ b/tests/visual/assets/modules/test/test.js
@@ -39,7 +39,7 @@ class Test {
       class: 'test-wrapper',
     });
     const sideElem = (this.sideElem = lay.createElement('div', {
-      class: 'lay-panel test-side',
+      class: 'lay-menu-container lay-panel test-side',
     }));
     const mainElem = (this.mainElem = lay.createElement('div', {
       class: 'test-main',
@@ -251,7 +251,7 @@ class Test {
     const codeInst = layCode({
       elem: $(itemElem).find('.lay-code')[0],
       theme: 'dark',
-      encode: false,
+      // encode: false,
     });
 
     // 代码高亮

--- a/tests/visual/base.html
+++ b/tests/visual/base.html
@@ -27,6 +27,7 @@
               { title: 'sort' },
               { title: 'type' },
               { title: 'isArray' },
+              { title: 'parseDataset' },
               { title: 'treeToFlat' },
               { title: 'flatToTree' },
             ],
@@ -317,6 +318,99 @@ console.log(arr);
           title: '{}',
           code: `console.log(lay.isArray({}))`,
           expected: false,
+        });
+      });
+
+      tester.describe('lay.parseDataset', (it) => {
+        it({
+          title: '普通扁平 dataset',
+          code: `
+const $elem = $('<div data-lay-string="abc123" data-lay-number="123" data-lay-boolean="true" data-lay-null="null" data-lay-array="[1,2,3]" data-lay-camel-case="camelCaseValue"></div>');
+
+const dataset = lay.parseDataset($elem[0]);
+console.log(dataset);
+          `,
+          expected: JSON.stringify({
+            string: 'abc123',
+            number: 123,
+            boolean: true,
+            null: null,
+            array: [1, 2, 3],
+            camelCase: 'camelCaseValue',
+          }),
+        });
+
+        it({
+          title: '复杂嵌套 dataset',
+          code: `
+const $elem = $('<div data-lay-flat="string" data-lay-tree.boolean="true" data-lay-tree.array="[1,2,3]" data-lay-tree.user.name="username" data-lay-number="123" data-lay-color-picker.color="#16b777"  data-lay-color-picker.user-id="111" data-lay-flat.test="invalid" data-lay-flat.test.a="invalid" data-lay-number.test="invalid"></div>');
+
+const dataset = lay.parseDataset($elem[0]);
+console.log(dataset);
+          `,
+          expected: JSON.stringify({
+            flat: 'string',
+            tree: {
+              boolean: true,
+              array: [1, 2, 3],
+              user: {
+                name: 'username',
+              },
+            },
+            number: 123,
+            colorPicker: {
+              color: '#16b777',
+              userId: 111,
+            },
+          }),
+        });
+
+        it({
+          title: '忽略无约定前缀的 dataset',
+          code: `
+const $elem = $('<div data-lay-theme="light" data-lay="ignore" data-layer="ignore" data-theme="ignore"></div>');
+
+// 只读取 data-lay-* 前缀的 dataset
+const dataset = lay.parseDataset($elem[0]);
+console.log(dataset);
+          `,
+          expected: JSON.stringify({ theme: 'light' }),
+        });
+
+        it({
+          title: '获取自定义前缀的 dataset',
+          code: `
+const $elem = $('<div data-theme="light" data-size="xl"></div>');
+
+const dataset = lay.parseDataset($elem[0], {
+  prefix: '' // 读取 data-*
+});
+console.log(dataset);
+          `,
+          expected: JSON.stringify({
+            theme: 'light',
+            size: 'xl',
+          }),
+        });
+
+        it({
+          title: '阻止值类型转换',
+          code: `
+const $elem = $('<div data-lay-uid="1111111111111111111" data-lay-online="true"></div>');
+
+const dataset = lay.parseDataset($elem[0], {
+  beforeParseValue({ rawKey, rawValue }) {
+    if (rawKey === 'uid') {
+      return false; // 返回 false 阻止值类型转换
+    }
+  }
+});
+console.log(dataset);
+          `,
+          expected: JSON.stringify({
+            uid: '1111111111111111111',
+            online: true,
+          }),
         });
       });
 

--- a/tests/visual/collapse.html
+++ b/tests/visual/collapse.html
@@ -27,7 +27,7 @@
     <br />
     <h2>开启手风琴：</h2>
     <br />
-    <div class="lay-collapse" lay-accordion>
+    <div class="lay-collapse" data-lay-accordion="true">
       <div class="lay-collapse-item lay-show">
         <h3 class="lay-collapse-title">item 1</h3>
         <div class="lay-collapse-content">content 1</div>

--- a/tests/visual/colorPicker.html
+++ b/tests/visual/colorPicker.html
@@ -49,9 +49,9 @@
       </div>
 
       <div class="test-box">
-        <div class="test-more" lay-options="{color: '#FF0000'}"></div>
-        <div class="test-more" lay-options="{color: '#008000'}"></div>
-        <div class="test-more" lay-options="{color: '#0000FF'}"></div>
+        <div class="test-more" data-lay-color="#ff0000"></div>
+        <div class="test-more" data-lay-color="#008000"></div>
+        <div class="test-more" data-lay-color="#0000ff"></div>
       </div>
     </div>
 

--- a/tests/visual/i18n.html
+++ b/tests/visual/i18n.html
@@ -52,7 +52,7 @@
       <fieldset class="lay-elem-field">
         <legend>code</legend>
         <div class="lay-field-box">
-          <pre id="demo-code" class="lay-code" lay-options="{}">
+          <pre id="demo-code" class="lay-code">
             <textarea>
               code content
             </textarea>

--- a/tests/visual/loader.html
+++ b/tests/visual/loader.html
@@ -20,16 +20,16 @@
         elem: '#root',
         items: [
           {
-            name: 'loader.config',
+            title: 'loader.config',
           },
           {
-            name: 'loader.script',
+            title: 'loader.script',
           },
           {
-            name: 'loader.css',
+            title: 'loader.css',
           },
           {
-            name: 'loader.image',
+            title: 'loader.image',
           },
         ],
       });

--- a/tests/visual/menu.html
+++ b/tests/visual/menu.html
@@ -9,7 +9,9 @@
       body {
         --demo-sidebar-width: 232px;
       }
-      body:has(.demo-sidebar .lay-menu[data-mode='vertical'][data-collapsed]) {
+      body:has(
+        .demo-sidebar .lay-menu[data-lay-mode='vertical'][data-lay-collapsed]
+      ) {
         --demo-sidebar-width: var(--lay-menu-collapsed-width, 65px);
       }
 
@@ -421,7 +423,7 @@
           <ul
             class="lay-menu"
             id="demo-horizontal-menu-1"
-            data-mode="horizontal"
+            data-lay-mode="horizontal"
           >
             <script>
               document.write(getMenuTemplate());
@@ -434,9 +436,9 @@
           <ul
             class="lay-menu"
             id="demo-horizontal-menu-2"
-            data-mode="horizontal"
-            data-theme="dark"
-            data-popup-offset="18"
+            data-lay-mode="horizontal"
+            data-lay-theme="dark"
+            data-lay-popup-offset="18"
           >
             <script>
               document.write(getMenuTemplate());
@@ -449,7 +451,7 @@
           <ul
             class="lay-menu"
             id="demo-horizontal-menu-3"
-            data-mode="horizontal"
+            data-lay-mode="horizontal"
           >
             <script>
               document.write(getMenuTemplate());
@@ -465,9 +467,9 @@
           <ul
             class="lay-menu"
             id="demo-horizontal-menu-4"
-            data-mode="horizontal"
-            data-theme="dark"
-            data-submenu-theme="light"
+            data-lay-mode="horizontal"
+            data-lay-theme="dark"
+            data-lay-submenu-theme="light"
           >
             <script>
               document.write(getMenuTemplate());

--- a/tests/visual/nav.html
+++ b/tests/visual/nav.html
@@ -253,7 +253,7 @@
 
       <br /><br />
 
-      <span class="lay-breadcrumb" lay-separator="|">
+      <span class="lay-breadcrumb" data-lay-separator="|">
         <a href="">娱乐</a>
         <a href="">八卦</a>
         <a href="">体育</a>

--- a/tests/visual/progress.html
+++ b/tests/visual/progress.html
@@ -13,61 +13,65 @@
     <div class="lay-padding-5">
       <h2>常规用法</h2>
       <br />
-      <div class="lay-progress" lay-percent="33" lay-show-percent="true"></div>
+      <div
+        class="lay-progress"
+        data-lay-percent="33"
+        data-lay-show-percent="true"
+      ></div>
 
       <br />
 
       <h2>不同尺寸</h2>
       <br />
-      <div class="lay-progress lay-size-xs" lay-percent="33"></div>
+      <div class="lay-progress" data-lay-size="xs" data-lay-percent="33"></div>
       <br />
-      <div class="lay-progress lay-size-sm" lay-percent="33"></div>
+      <div class="lay-progress" data-lay-size="sm" data-lay-percent="33"></div>
       <br />
-      <div class="lay-progress" lay-percent="33"></div>
+      <div class="lay-progress" data-lay-percent="33"></div>
       <br />
-      <div class="lay-progress lay-size-lg" lay-percent="33"></div>
+      <div class="lay-progress" data-lay-size="lg" data-lay-percent="33"></div>
       <br />
-      <div class="lay-progress lay-size-xl" lay-percent="33"></div>
+      <div class="lay-progress" data-lay-size="xl" data-lay-percent="33"></div>
       <br />
 
       <h2>不同颜色</h2>
       <br />
       <div
         class="lay-progress"
-        lay-percent="20"
-        lay-progress-color="var(--lay-color-red)"
+        data-lay-percent="20"
+        data-lay-color="var(--lay-color-red)"
       ></div>
 
       <br />
 
       <div
         class="lay-progress"
-        lay-percent="30"
-        lay-progress-color="var(--lay-color-orange)"
+        data-lay-percent="30"
+        data-lay-color="var(--lay-color-orange)"
       ></div>
 
       <br />
 
       <div
         class="lay-progress"
-        lay-percent="40"
-        lay-progress-color="var(--lay-color-green)"
+        data-lay-percent="40"
+        data-lay-color="var(--lay-color-green)"
       ></div>
 
       <br />
 
       <div
         class="lay-progress"
-        lay-percent="50"
-        lay-progress-color="var(--lay-color-blue)"
+        data-lay-percent="50"
+        data-lay-color="var(--lay-color-blue)"
       ></div>
 
       <br />
 
       <div
         class="lay-progress"
-        lay-percent="60"
-        lay-progress-color="var(--lay-color-accent)"
+        data-lay-percent="60"
+        data-lay-color="var(--lay-color-accent)"
       ></div>
 
       <br />
@@ -75,12 +79,13 @@
       <h2>动态操作</h2>
       <br />
       <div
-        class="lay-progress lay-size-xl"
+        class="lay-progress"
         id="LAY-progress-demo-set"
-        lay-percent="15"
-        lay-show-percent="true"
-        lay-progress-color="var(--lay-color-primary)"
-        lay-progress-rail-color="#d9d9d9"
+        data-lay-size="xl"
+        data-lay-percent="15"
+        data-lay-show-percent="true"
+        data-lay-color="var(--lay-color-primary)"
+        data-lay-rail-color="#d9d9d9"
       ></div>
 
       <br />

--- a/tests/visual/tabs.html
+++ b/tests/visual/tabs.html
@@ -12,7 +12,8 @@
       <div
         class="lay-tabs lay-hide-v"
         id="demoTabs1"
-        lay-options="{closable: true, headerMode:'scroll'}"
+        data-lay-closable="true"
+        data-lay-header-mode="scroll"
       >
         <ul class="lay-tabs-header">
           <li lay-id="aaa" lay-closable="false">Tab1</li>
@@ -52,7 +53,7 @@
       <div id="demoTabs2"></div>
 
       <h2>卡片风格</h2>
-      <div class="lay-tabs lay-tabs-card" lay-options="{index: 1}">
+      <div class="lay-tabs lay-tabs-card" data-lay-index="1">
         <ul class="lay-tabs-header">
           <li>标题1</li>
           <li>标题2</li>
@@ -103,7 +104,7 @@
       </div>
 
       <h2>打乱标签顺序：</h2>
-      <div class="lay-tabs" lay-options="{closable: true}">
+      <div class="lay-tabs" data-lay-closable="true">
         <ul class="lay-tabs-header">
           <li lay-id="fff">Tab6</li>
           <li lay-id="eee">Tab5</li>
@@ -139,7 +140,7 @@
       </div>
 
       <h2>标签嵌套</h2>
-      <div class="lay-tabs lay-tabs-card" lay-options="{headerMode:'normal'}">
+      <div class="lay-tabs lay-tabs-card" data-lay-header-mode="normal">
         <ul class="lay-tabs-header">
           <li class="lay-this">标题1</li>
           <li>标题2</li>
@@ -147,7 +148,7 @@
         </ul>
         <div class="lay-tabs-body" style="padding: 16px">
           <div class="lay-tabs-item lay-show">
-            <div class="lay-tabs" lay-options="{headerMode:'normal'}">
+            <div class="lay-tabs" data-lay-header-mode="normal">
               <ul class="lay-tabs-header">
                 <li class="lay-this">标题 1-1</li>
                 <li>标题 1-2</li>
@@ -159,7 +160,7 @@
             </div>
           </div>
           <div class="lay-tabs-item">
-            <div class="lay-tabs" lay-options="{headerMode:'normal'}">
+            <div class="lay-tabs" data-lay-header-mode="normal">
               <ul class="lay-tabs-header">
                 <li class="lay-this">标题 2-1</li>
                 <li>标题 2-2</li>


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [x] 功能新增
- [ ] 问题修复
- [x] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- 新增 `lay.parseDataset` 方法，以替代 `lay.options` 方法
  - 支持自定义 dataset 属性前缀过滤（组件强制使用默认 `lay` 前缀）或不使用前缀
  - 支持自定义嵌套属性连接符（组件强制使用默认 `.`）
  - 支持根据 JSON 规范进行值类型转换；可通过 `beforeParseValue` 回调按需阻止值类型转换
- 移除 Component 中对 `lay-options` 属性配置信息的解析，采用 dataset 方案
- 迁移 `lay-options` 和零散的 `lay-*` 属性配置至统一的 `data-lay-*` 属性配置方式
- 统一 组件的 size 定义方式为 `data-lay-size=""`
- 添加 `lay.options` 方法弃用说明
- 更新 测试用例

**备注：**
- 该 PR 是对 #3109 的正式完善
- docs、dist 目录无需参与 Review，文档会在后续统一重写。

### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [ ] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [ ] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增基于 `data-lay-*` 属性的统一配置解析，支持嵌套配置、类型转换及自定义前缀。
  * 折叠面板新增手风琴模式。
  * 进度条支持配置进度、尺寸、颜色和百分比显示，并可安全更新进度。

* **改进**
  * 轮播、菜单、弹窗、分页、面包屑等组件统一更新配置属性格式。
  * 优化面包屑分隔符渲染，自动清理相邻旧分隔符。
  * 同步更新相关样式与示例，保持外观和交互一致。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->