### PR TITLE
feat(form): 新增 filterDisabled 配置，并恢复提交取值时 `disabled` 表单项的旧行为

### DIFF
--- a/src/modules/form.js
+++ b/src/modules/form.js
@@ -80,7 +80,12 @@ layui.define(['lay', 'i18n', 'layer', 'util'], function (exports) {
           }
         }
       },
-      autocomplete: null // 全局 autocomplete 状态。 null 表示不干预
+
+      // 全局 autocomplete 状态。 null 表示不干预
+      autocomplete: null,
+
+      // 表单取值和提交时，是否过滤 disabled 状态的表单域
+      filterDisabled: false
     };
   };
 
@@ -156,8 +161,15 @@ layui.define(['lay', 'i18n', 'layer', 'util'], function (exports) {
   };
 
   // 取值
-  Form.prototype.getValue = function (filter, itemForm) {
+  Form.prototype.getValue = function (filter, itemForm, opts) {
     itemForm = itemForm || this.getFormElem(filter);
+
+    opts = $.extend(
+      {
+        filterDisabled: this.config.filterDisabled
+      },
+      opts
+    );
 
     // 获取所有表单域
     var fieldElem = itemForm.find('input,select,textarea');
@@ -196,7 +208,7 @@ layui.define(['lay', 'i18n', 'layer', 'util'], function (exports) {
       if (/^(checkbox|radio)$/.test(item.type) && !item.checked) return;
 
       // 排除 disabled 表单域
-      if (item.disabled) return;
+      if (opts.filterDisabled && item.disabled) return;
 
       // select 多选用 jQuery 方式取值，未选中 option 时，
       // jQuery v2.2.4 及以下版本返回 null，以上(3.x) 返回 []。

--- a/src/modules/form.js
+++ b/src/modules/form.js
@@ -85,6 +85,7 @@ layui.define(['lay', 'i18n', 'layer', 'util'], function (exports) {
       autocomplete: null,
 
       // 表单取值和提交时，是否过滤 disabled 状态的表单域
+      // 默认 false 以兼容旧版本；getValue 的 opts.filterDisabled 优先于此全局配置
       filterDisabled: false
     };
   };
@@ -207,8 +208,8 @@ layui.define(['lay', 'i18n', 'layer', 'util'], function (exports) {
       // 复选框和单选框未选中，不记录字段
       if (/^(checkbox|radio)$/.test(item.type) && !item.checked) return;
 
-      // 排除 disabled 表单域
-      if (opts.filterDisabled && item.disabled) return;
+      // 排除 disabled 状态的表单项
+      if (opts.filterDisabled && othis.is(':disabled')) return;
 
       // select 多选用 jQuery 方式取值，未选中 option 时，
       // jQuery v2.2.4 及以下版本返回 null，以上(3.x) 返回 []。


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [x] 问题修复
- [x] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

上个版本对 `getValue` 的取值优化（见  #3083）中，无意中带来了一个「破坏性变更」：表单提交和取值时，会排除 disabled 表单项，尽管在行为上属于向原生逻辑对齐，但在实际使用场景中，由于早期版本没有排除 disabled 表单项，提交表单时行为与 readonly 相同（即都包含在提交值中），导致对业务层面产生兼容性破坏。该 PR 属于一个折中方案：默认恢复 disabled 状态表单项的旧版本行为，并通过开启 `filterDisabled` 来遵循原生行为。

- resolves #3098
- resolves #3113

### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [ ] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [ ] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增全局配置项 `filterDisabled`，默认关闭。
  - 获取表单值时可通过配置选择是否过滤已禁用的表单域。
  - 支持在调用获取表单值时传入额外选项进行控制。

- **行为调整**
  - 默认情况下，获取表单值不再过滤已禁用的表单域。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->