### PR TITLE
fix: 同步 2.13.3 到 2.13.9 区间的若干优化

### DIFF
--- a/src/components/colorPicker.js
+++ b/src/components/colorPicker.js
@@ -321,6 +321,8 @@ export class ColorPicker extends Popup {
 
         // 颜色更改的回调
         options.onChange?.({
+          instance: this,
+          options,
           color: this.$rootElem
             .find(`.${CONST.PICKER_INPUT} input`)
             .val()
@@ -560,6 +562,12 @@ export class ColorPicker extends Popup {
     // 颜色选择器表单
     const elemPickerInput = $rootElem.find(`.${CONST.PICKER_INPUT} input`);
 
+    // 传递给回调函数的基础参数对象
+    const baseParams = {
+      instance: this,
+      options,
+    };
+
     // 事件
     const pickerEvents = {
       // 清空
@@ -571,15 +579,18 @@ export class ColorPicker extends Popup {
           .addClass(CONST.ICON_PICKER_CLOSE);
         this.color = '';
 
-        options.done?.({ color: '' });
+        options.done?.({ ...baseParams, color: '' });
         this.close();
       },
 
       // 确认
       confirm: (othis, change) => {
-        let value = elemPickerInput.val().trim(),
-          colorValue,
-          hsb;
+        let value = elemPickerInput.val().trim();
+        let type = elemColorBoxSpan.attr('lay-type');
+        let colorValue;
+        let hsb;
+        let rgb;
+        let alpha;
 
         if (value.indexOf(',') > -1) {
           hsb = RGBToHSB(RGBSTo(value));
@@ -589,11 +600,14 @@ export class ColorPicker extends Popup {
 
           if (
             (value.match(/[0-9]{1,3}/g) || []).length > 3 &&
-            elemColorBoxSpan.attr('lay-type') === 'rgba'
+            type === 'rgba'
           ) {
-            const left =
-              value.slice(value.lastIndexOf(',') + 1, value.length - 1) * 280;
-            $rootElem.find(`.${CONST.PICKER_ALPHA_SLIDER}`).css('left', left);
+            alpha = parseFloat(
+              value.slice(value.lastIndexOf(',') + 1, value.length - 1),
+            );
+            $rootElem
+              .find(`.${CONST.PICKER_ALPHA_SLIDER}`)
+              .css('left', alpha * 280);
             elemColorBoxSpan[0].style.background = value;
             colorValue = value;
           }
@@ -607,14 +621,38 @@ export class ColorPicker extends Popup {
             .addClass(CONST.ICON_PICKER_DOWN);
         }
 
+        // 按 format 规范化输出颜色值
+        if (value) {
+          rgb = HSBToRGB(hsb);
+          if (type === 'rgba') {
+            colorValue = `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${
+              alpha === undefined ? 1 : alpha
+            })`;
+          } else if (type === 'torgb') {
+            colorValue = `rgb(${rgb.r}, ${rgb.g}, ${rgb.b})`;
+          } else {
+            colorValue = `#${HSBToHEX(hsb)}`;
+          }
+        } else {
+          // 空输入时保持返回空字符串
+          colorValue = '';
+        }
+
+        const params = {
+          ...baseParams,
+          color: colorValue,
+          rawColor: value,
+        };
+
         if (change === 'change') {
           this.#select(hsb.h, hsb.s, hsb.b, change);
-          options.onChange?.({ color: colorValue });
+          options.onChange?.(params);
           return;
         }
-        this.color = value;
 
-        options.done?.({ color: value });
+        this.color = colorValue;
+
+        options.done?.(params);
         this.close();
       },
     };

--- a/src/core/lay.js
+++ b/src/core/lay.js
@@ -1647,6 +1647,8 @@ lay.treeToFlat = function (data, options) {
  * @param {string} [options.childrenKey='children'] - 子节点字段名
  * @param {string} [options.idKey='id'] - 节点 id 字段名
  * @param {string} [options.parentKey='parentId'] - 父节点 id 字段名
+ * @param {boolean} [options.keepParentId=true] - 是否保留父节点 id 字段
+ * @returns {Array} 返回树状数据
  */
 lay.flatToTree = function (data, options) {
   options = Object.assign(
@@ -1654,6 +1656,7 @@ lay.flatToTree = function (data, options) {
       childrenKey: 'children',
       idKey: 'id',
       parentKey: 'parentId',
+      keepParentId: true,
     },
     options,
   );
@@ -1664,7 +1667,10 @@ lay.flatToTree = function (data, options) {
   var map = data.reduce(function (acc, currNode) {
     var id = currNode[options.idKey];
     acc[id] = currNode;
-    acc[id][options.childrenKey] = [];
+    // 给当前节点已有的 childrenKey 初始化为空数组
+    if (options.childrenKey in currNode) {
+      acc[id][options.childrenKey] = [];
+    }
     return acc;
   }, {});
 
@@ -1673,12 +1679,23 @@ lay.flatToTree = function (data, options) {
     var id = currNode[options.idKey];
     var parentId = currNode[options.parentKey];
 
-    // 根节点
+    if (!options.keepParentId) {
+      delete currNode[options.parentKey];
+    }
+
+    // 若为根节点，则直接添加到结果数组；
     if (parentId === null || !map[parentId]) {
       acc.push(map[id]);
     } else {
-      // 子节点
-      map[parentId][options.childrenKey].push(currNode);
+      // 若为子节点，则添加到对应父节点的 childrenKey 中
+      var parentNode = map[parentId];
+
+      // 若父节点的 childrenKey 不是数组，则初设一个空数组
+      if (!Array.isArray(parentNode[options.childrenKey])) {
+        parentNode[options.childrenKey] = [];
+      }
+
+      parentNode[options.childrenKey].push(currNode);
     }
 
     return acc;

--- a/src/core/logger.js
+++ b/src/core/logger.js
@@ -3,6 +3,7 @@
  */
 
 let warned = Object.create(null);
+let warnedCount = 0;
 
 /**
  * 控制台日志消息提示
@@ -25,13 +26,13 @@ export function log(message, level = 'warn') {
 export function logOnce(...args) {
   const [message] = args;
 
-  if (warned._size > 100) {
+  if (warnedCount > 100) {
     warned = Object.create(null);
-    warned._size = 0;
+    warnedCount = 0;
   }
   if (!warned[message]) {
     warned[message] = true;
-    warned._size = (warned._size || 0) + 1;
+    warnedCount++;
     log(...args);
   }
 }

--- a/tests/visual/colorPicker.html
+++ b/tests/visual/colorPicker.html
@@ -88,6 +88,9 @@
           onChange: ({ color }) => {
             console.log(color);
           },
+          done({ options, color }) {
+            console.log(`${options.id} → done → `, color);
+          },
         });
 
         colorPicker.render({


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [ ] 功能新增
- [x] 问题修复
- [x] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- **colorPicker**:
  - 同步 #3041
  - 修复 `done`、`onChange` 在空输入时错误返回 `#000000` 的问题
  - 新增 回调参数的 `instance`、`options` 基础成员
- **lay**:
  - 同步 #3039 
  - 同步 #3060
- **logger**:
  - 同步 #3097
  
 #### 备注：
 
 docs、dist 目录无需参与 Review，文档会在后续统一重写。

### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [ ] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [ ] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 颜色选择器回调参数更加统一，支持获取组件实例、配置及标准化颜色值。
  - 确认颜色时可按配置自动转换为 HEX、RGB 或 RGBA 格式，并同步透明度滑块。
  - 支持配置是否保留树形节点的父级标识。
- **错误修复**
  - 改善树形数据组装，提升非标准子节点数据下的兼容性。
  - 优化重复警告记录限制，避免达到上限后继续异常累积。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->