### PR TITLE
feat: 新增 Steps 步骤条组件

### DIFF
--- a/src/components/initializer.js
+++ b/src/components/initializer.js
@@ -12,6 +12,7 @@ import { collapse } from './collapse.js';
 import { progress } from './progress.js';
 import { form } from './form.js';
 import { tabs } from './tabs.js';
+import { steps } from './steps.js';
 
 const components = {
   menu,
@@ -21,6 +22,7 @@ const components = {
   progress,
   form,
   tabs,
+  steps,
 };
 
 export class Initializer {

--- a/src/components/steps.js
+++ b/src/components/steps.js
@@ -1,0 +1,340 @@
+/**
+ * steps
+ * 步骤条组件
+ */
+
+import { lay } from '../core/lay.js';
+import { i18n } from '../core/i18n.js';
+import { $ } from 'jquery';
+import { Component } from '../core/component.js';
+import { log } from '../core/logger.js';
+
+export class Steps extends Component {
+  static componentName = 'steps';
+
+  // 默认配置项
+  static options = {
+    // 渲染目标：支持 CSS 选择器、DOM 元素或 jQuery 集合
+    // 默认匹配页面全部 .lay-steps
+    elem: '.lay-steps',
+    current: 1, // 当前步骤（从 1 开始），之前的步骤显示为已完成，默认 1
+    layout: 'horizontal', // 布局：horizontal 水平 / vertical 垂直，默认 horizontal
+    size: '', // 尺寸：xs / sm / lg，为空时为默认尺寸
+    clickable: false, // 是否可点击切换步骤（渲染点击交互），默认 false
+    layFilter: '', // lay-filter 属性，用于区分事件来源，为空时不设置
+    status: '', // 当前步骤状态：success / error / warning，为空时使用默认主题色
+    data: [], // 步骤数据项数组（字符串或对象），generate 使用
+  };
+
+  static get CONST() {
+    return {
+      ...super.CONST,
+      ELEM: 'lay-steps',
+      ELEM_ITEM: 'lay-steps-item', // 步骤项
+      ELEM_ICON: 'lay-steps-icon', // 图标容器
+      ELEM_CONTENT: 'lay-steps-content', // 内容容器
+      ELEM_TITLE: 'lay-steps-title', // 标题
+      ELEM_DESC: 'lay-steps-desc', // 描述
+      CLASS_IS_DONE: 'lay-is-done', // 已完成状态
+      ICON: 'lay-icon', // 图标字体基类
+      ICON_OK: 'lay-icon-ok', // 完成勾选图标
+    };
+  }
+
+  /**
+   * 构建并返回单个步骤项的 DOM 结构，不插入到目标容器
+   * 图标默认显示数字序号（text），可传 icon 自定义 HTML
+   * @param {Object} options - 组件配置项，详见 {@link Steps.options}
+   * @param {string} [options.title] - 步骤标题
+   * @param {string} [options.description] - 步骤描述
+   * @param {string} [options.icon] - 自定义图标 HTML，优先于数字序号
+   * @param {number} [options.text] - 图标数字序号（无 icon 时显示）
+   * @param {string} [options.state] - 步骤状态：done / active / waiting
+   * @param {boolean} [options.disabled] - 是否禁用，默认 false
+   * @returns {jQuery} 步骤项 jQuery 对象
+   */
+  static build(options) {
+    options = { ...this.options, ...options };
+
+    const $item = $('<div>').addClass(CONST.ELEM_ITEM);
+
+    // 禁用。复用基类状态类（禁用步骤不参与完成/当前状态计算）
+    if (options.disabled) {
+      $item.addClass(CONST.CLASS_IS_DISABLED);
+    } else if (options.state === 'done') {
+      $item.addClass(CONST.CLASS_IS_DONE);
+    } else if (options.state === 'active') {
+      $item.addClass(CONST.CLASS_IS_ACTIVE);
+    }
+
+    // 图标：自定义图标优先，其次完成步显示勾选图标，否则显示数字序号
+    const $icon = $('<div>').addClass(CONST.ELEM_ICON);
+    if (options.icon) {
+      $icon.html(options.icon);
+    } else if (!options.disabled && options.state === 'done') {
+      $icon.append(createOkIcon());
+    } else {
+      $icon.text(options.text);
+    }
+    $item.append($icon);
+
+    // 内容：标题 + 描述
+    const $content = $('<div>').addClass(CONST.ELEM_CONTENT);
+    if (options.title) {
+      $content.append(
+        $('<div>').addClass(CONST.ELEM_TITLE).text(options.title),
+      );
+    }
+    if (options.description) {
+      $content.append(
+        $('<div>').addClass(CONST.ELEM_DESC).text(options.description),
+      );
+    }
+    $item.append($content);
+
+    return $item;
+  }
+
+  /**
+   * 根据数据项生成一组步骤，不插入到目标容器
+   * 数据项支持两种形态：
+   * - 字符串：步骤标题，使用公共属性（如 layout / size / clickable）
+   * - 对象：`{ title, description, icon, disabled, ... }` 个性属性，覆盖公共属性
+   * 空数据项（空字符串 / 无任何内容的对象）会被过滤；空 data 返回空步骤条
+   * 生成后可通过 {@link Steps.render} 绑定交互
+   * @param {Object} options - 组件配置项 + data 数组
+   * @param {Array} [options.data] - 步骤数据项数组（字符串或对象）
+   * @returns {jQuery} 步骤条 jQuery 对象
+   */
+  static generate(options) {
+    options = { ...this.options, ...options };
+
+    const { data = [], ...common } = options;
+    const current = normalizeCurrent(common.current);
+
+    const $steps = $('<div>').addClass(CONST.ELEM);
+    $steps.attr('data-lay-current', current);
+
+    // 配置维度通过 data-lay-* 属性承载（对齐 menu/parseDataset 模式），CSS 用属性选择器驱动
+    // 布局。默认 horizontal 不写属性
+    if (common.layout && common.layout !== 'horizontal') {
+      $steps.attr('data-lay-layout', common.layout);
+    }
+    if (common.size) {
+      $steps.attr('data-lay-size', common.size);
+    }
+    if (common.clickable) {
+      $steps.attr('data-lay-clickable', true);
+    }
+    if (common.layFilter) {
+      $steps.attr('lay-filter', common.layFilter);
+    }
+    if (common.status) {
+      $steps.attr('data-lay-status', common.status);
+    }
+
+    data
+      .filter((item) => {
+        if (typeof item === 'string') return item !== '';
+        return item && (item.title || item.description || item.icon);
+      })
+      .forEach((item, index) => {
+        const itemOptions =
+          typeof item === 'string'
+            ? { ...common, title: item }
+            : { ...common, ...item };
+        const $item = this.build({
+          ...itemOptions,
+          text: index + 1,
+          state: getStepStatus(index + 1, current),
+        });
+        $steps.append($item);
+      });
+
+    return $steps;
+  }
+
+  /**
+   * 渲染：依据 data-lay-current 计算各步骤状态，可点击时绑定切换交互
+   * 步骤 DOM 多来自静态标记（initializer 自动渲染），或由 generate() 生成后插入
+   * @returns {this}
+   */
+  render() {
+    const options = this.options;
+    const $elem = options.$elem;
+
+    // 目标元素不存在时提示并直接返回
+    if (!$elem[0]) {
+      log(`[steps] target element not found: ${options.elem}`);
+      return this;
+    }
+
+    // 依据 data-lay-current 重算各步骤状态
+    applyStatus($elem);
+
+    // 可点击：绑定步骤点击/键盘切换
+    if ($elem.is('[data-lay-clickable]')) {
+      const eventNamespace = CONST.EVENT_NAMESPACE;
+      const clickEventName = `click${eventNamespace}`;
+      const keydownEventName = `keydown${eventNamespace}`;
+
+      $elem
+        .off(`${clickEventName} ${keydownEventName}`)
+        .on(clickEventName, `.${CONST.ELEM_ITEM}`, events.click)
+        .on(keydownEventName, `.${CONST.ELEM_ITEM}`, events.clickByKey);
+
+      // 无障碍：可点击步骤声明交互角色
+      $elem.children(`.${CONST.ELEM_ITEM}`).attr({
+        role: 'button',
+        tabindex: '0',
+        'aria-label': i18n.$t('steps.click'),
+      });
+    }
+
+    return this;
+  }
+
+  /**
+   * 动态设置当前步骤
+   * @param {number} index - 当前步骤（从 1 开始）
+   * @returns {this}
+   */
+  setCurrent(index) {
+    const $elem = this.options.$elem;
+
+    // 目标元素不存在时提示并直接返回
+    if (!$elem[0]) {
+      log(`[steps] target element not found: ${this.options.elem}`);
+      return this;
+    }
+
+    const from = readCurrent($elem);
+    const to = normalizeCurrent(parseInt(index, 10));
+
+    // 目标步骤无变化时不触发 change
+    if (from === to) return this;
+
+    $elem.attr('data-lay-current', to);
+    applyStatus($elem);
+    triggerChange($elem, from, to);
+    return this;
+  }
+
+  // 实例方法静态委托
+  static {
+    this.delegateInstanceMethods(['setCurrent']);
+  }
+}
+
+// 基础事件体
+const events = {
+  // 点击步骤
+  click() {
+    const $item = $(this);
+
+    // 禁用步骤不可点击
+    if ($item.hasClass(CONST.CLASS_IS_DISABLED)) return;
+
+    const $steps = $item.closest(`.${CONST.ELEM}`);
+    const from = readCurrent($steps);
+    const to = $steps.children(`.${CONST.ELEM_ITEM}`).index($item) + 1;
+
+    // 点击当前步骤无操作
+    if (from === to) return;
+
+    // 触发 click 事件（切换前）；回调返回 false 可阻断切换
+    const filter = $steps.attr('lay-filter') || '';
+    const clickEventName = filter ? `click(${filter})` : 'click';
+    const enable = lay.event.call(this, Steps.componentName, clickEventName, {
+      elem: $steps[0],
+      from,
+      to,
+      item: $item[0],
+    });
+    if (enable === false) return;
+
+    // 默认行为：切换到该步骤（复用实例 setCurrent，内部触发 change 事件）
+    const inst = Steps.getInstance($steps.attr(CONST.ATTR_ID));
+    if (inst) {
+      inst.setCurrent(to);
+    } else {
+      $steps.attr('data-lay-current', to);
+      applyStatus($steps);
+      triggerChange($steps, from, to);
+    }
+  },
+
+  // 键盘切换（Enter / 空格）
+  clickByKey(event) {
+    if (event.code === 'Enter' || event.code === 'Space') {
+      event.preventDefault();
+      events.click.call(this);
+    }
+  },
+};
+
+// 创建完成勾选图标
+const createOkIcon = () => $('<i>').addClass(`${CONST.ICON} ${CONST.ICON_OK}`);
+
+// 计算步骤状态：step 为第几步（从 1 起），current 为当前步（从 1 起）
+const getStepStatus = (step, current) =>
+  step < current ? 'done' : step === current ? 'active' : 'waiting';
+
+// 规范化当前步：非正整数视作第 1 步
+const normalizeCurrent = (current) =>
+  Number.isInteger(current) && current >= 1 ? current : 1;
+
+// 依据 data-lay-current 重算各步骤状态（render 与点击切换共用）
+const applyStatus = ($elem) => {
+  const current = readCurrent($elem);
+
+  $elem.children(`.${CONST.ELEM_ITEM}`).each((stepIndex, item) => {
+    const $item = $(item);
+
+    // 禁用步骤保持禁用状态，不参与状态计算
+    if ($item.hasClass(CONST.CLASS_IS_DISABLED)) return;
+
+    const status = getStepStatus(stepIndex + 1, current);
+
+    $item.removeClass(CONST.CLASS_IS_DONE).removeClass(CONST.CLASS_IS_ACTIVE);
+    if (status === 'done') {
+      $item.addClass(CONST.CLASS_IS_DONE);
+    } else if (status === 'active') {
+      $item.addClass(CONST.CLASS_IS_ACTIVE);
+    }
+
+    // 图标：完成步打勾，其余为数字序号；自定义图标保持不变
+    $item.children(`.${CONST.ELEM_ICON}`).each((_, iconEl) => {
+      const $icon = $(iconEl);
+      if (status === 'done') {
+        // 纯数字序号替换为勾选图标
+        if (/^\d+$/.test($icon.text().trim())) {
+          $icon.html(createOkIcon());
+        }
+      } else if ($icon.find(`.${CONST.ICON_OK}`).length) {
+        // 非完成步：勾选图标还原为数字序号
+        $icon.text(stepIndex + 1);
+      }
+    });
+  });
+};
+
+// 读取当前步骤（从 1 起，非正整数兜底为 1）
+const readCurrent = ($elem) =>
+  normalizeCurrent(parseInt($elem.attr('data-lay-current'), 10));
+
+// 触发 change 事件（切换成功后）
+const triggerChange = ($elem, from, to) => {
+  const filter = $elem.attr('lay-filter') || '';
+  const changeEventName = filter ? `change(${filter})` : 'change';
+  lay.event.call($elem[0], Steps.componentName, changeEventName, {
+    elem: $elem[0],
+    from,
+    to,
+    item: $elem.children(`.${CONST.ELEM_ITEM}`)[to - 1],
+  });
+};
+
+const CONST = Steps.CONST;
+
+export { Steps as steps };

--- a/src/components/steps.js
+++ b/src/components/steps.js
@@ -188,10 +188,19 @@ export class Steps extends Component {
         .on(clickEventName, `.${CONST.ELEM_ITEM}`, events.click)
         .on(keydownEventName, `.${CONST.ELEM_ITEM}`, events.clickByKey);
 
-      // 无障碍：可点击步骤声明交互角色（可访问名称取自步骤内容）
-      $elem.children(`.${CONST.ELEM_ITEM}`).attr({
-        role: 'button',
-        tabindex: '0',
+      // 无障碍：可点击步骤声明交互角色（禁用项不参与键盘导航并标记 aria-disabled）
+      $elem.children(`.${CONST.ELEM_ITEM}`).each(function () {
+        const $item = $(this);
+        const disabled = $item.hasClass(CONST.CLASS_IS_DISABLED);
+        $item.attr({
+          role: 'button',
+          tabindex: disabled ? '-1' : '0',
+        });
+        if (disabled) {
+          $item.attr('aria-disabled', 'true');
+        } else {
+          $item.removeAttr('aria-disabled');
+        }
       });
     }
 

--- a/src/components/steps.js
+++ b/src/components/steps.js
@@ -4,7 +4,6 @@
  */
 
 import { lay } from '../core/lay.js';
-import { i18n } from '../core/i18n.js';
 import { $ } from 'jquery';
 import { Component } from '../core/component.js';
 import { log } from '../core/logger.js';
@@ -110,7 +109,18 @@ export class Steps extends Component {
     options = { ...this.options, ...options };
 
     const { data = [], ...common } = options;
-    const current = normalizeCurrent(common.current);
+
+    // 过滤空数据项
+    const items = data.filter((item) => {
+      if (typeof item === 'string') return item !== '';
+      return item && (item.title || item.description || item.icon);
+    });
+
+    // 当前步骤钳制在有效步骤范围内
+    const current = clampCurrent(
+      normalizeCurrent(common.current),
+      items.length,
+    );
 
     const $steps = $('<div>').addClass(CONST.ELEM);
     $steps.attr('data-lay-current', current);
@@ -133,23 +143,18 @@ export class Steps extends Component {
       $steps.attr('data-lay-status', common.status);
     }
 
-    data
-      .filter((item) => {
-        if (typeof item === 'string') return item !== '';
-        return item && (item.title || item.description || item.icon);
-      })
-      .forEach((item, index) => {
-        const itemOptions =
-          typeof item === 'string'
-            ? { ...common, title: item }
-            : { ...common, ...item };
-        const $item = this.build({
-          ...itemOptions,
-          text: index + 1,
-          state: getStepStatus(index + 1, current),
-        });
-        $steps.append($item);
+    items.forEach((item, index) => {
+      const itemOptions =
+        typeof item === 'string'
+          ? { ...common, title: item }
+          : { ...common, ...item };
+      const $item = this.build({
+        ...itemOptions,
+        text: index + 1,
+        state: getStepStatus(index + 1, current),
       });
+      $steps.append($item);
+    });
 
     return $steps;
   }
@@ -183,11 +188,10 @@ export class Steps extends Component {
         .on(clickEventName, `.${CONST.ELEM_ITEM}`, events.click)
         .on(keydownEventName, `.${CONST.ELEM_ITEM}`, events.clickByKey);
 
-      // 无障碍：可点击步骤声明交互角色
+      // 无障碍：可点击步骤声明交互角色（可访问名称取自步骤内容）
       $elem.children(`.${CONST.ELEM_ITEM}`).attr({
         role: 'button',
         tabindex: '0',
-        'aria-label': i18n.$t('steps.click'),
       });
     }
 
@@ -209,7 +213,8 @@ export class Steps extends Component {
     }
 
     const from = readCurrent($elem);
-    const to = normalizeCurrent(parseInt(index, 10));
+    const total = $elem.children(`.${CONST.ELEM_ITEM}`).length;
+    const to = clampCurrent(normalizeCurrent(parseInt(index, 10)), total);
 
     // 目标步骤无变化时不触发 change
     if (from === to) return this;
@@ -283,6 +288,10 @@ const getStepStatus = (step, current) =>
 // 规范化当前步：非正整数视作第 1 步
 const normalizeCurrent = (current) =>
   Number.isInteger(current) && current >= 1 ? current : 1;
+
+// 钳制当前步在有效范围 [1, total] 内
+const clampCurrent = (current, total) =>
+  Math.min(Math.max(current, 1), Math.max(total, 1));
 
 // 依据 data-lay-current 重算各步骤状态（render 与点击切换共用）
 const applyStatus = ($elem) => {

--- a/src/core/i18n.js
+++ b/src/core/i18n.js
@@ -26,9 +26,6 @@ var zhCN = {
   dropdown: {
     empty: '暂无数据',
   },
-  steps: {
-    click: '点击切换至该步骤',
-  },
   flow: {
     loadMore: '加载更多',
     noMore: '没有更多了',

--- a/src/core/i18n.js
+++ b/src/core/i18n.js
@@ -26,6 +26,9 @@ var zhCN = {
   dropdown: {
     empty: '暂无数据',
   },
+  steps: {
+    click: '点击切换至该步骤',
+  },
   flow: {
     loadMore: '加载更多',
     noMore: '没有更多了',

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -25,6 +25,7 @@
 @import './modules/nav.css';
 @import './modules/timeline.css';
 @import './modules/badge.css';
+@import './modules/steps.css';
 @import './modules/carousel.css';
 @import './modules/floatbar.css';
 @import './modules/transfer.css';

--- a/src/css/modules/steps.css
+++ b/src/css/modules/steps.css
@@ -1,0 +1,168 @@
+/* 步骤条 */
+.lay-steps {
+  --lay-steps-active-color: var(--lay-color-primary); /* 当前步骤色 */
+  --lay-steps-done-color: var(--lay-color-green); /* 已完成步骤色 */
+  --lay-steps-wait-color: var(--lay-gray-400); /* 待处理步骤色 */
+  --lay-steps-line-color: var(--lay-gray-300); /* 连接线颜色 */
+  --lay-steps-status-success: var(
+    --lay-color-green
+  ); /* 当前步骤状态色：success */
+  --lay-steps-status-error: var(--lay-color-red); /* 当前步骤状态色：error */
+  --lay-steps-status-warning: var(
+    --lay-color-orange
+  ); /* 当前步骤状态色：warning */
+  --lay-steps-icon-size: 28px; /* 图标尺寸 */
+  --lay-steps-font-size: 14px; /* 图标内文字大小 */
+  display: flex;
+  align-items: flex-start;
+}
+.lay-steps-item {
+  position: relative;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+.lay-steps-icon {
+  position: relative;
+  z-index: 1;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1; /* 收紧行高，避免字体默认行高引起的垂直偏移 */
+  width: var(--lay-steps-icon-size);
+  height: var(--lay-steps-icon-size);
+  border-radius: 50%;
+  background-color: var(--lay-steps-wait-color);
+  color: #fff;
+  font-size: var(--lay-steps-font-size);
+  font-style: normal;
+}
+/* 数字序号：部分系统字体（苹方/雅黑）字形偏上，轻微下移补偿；图标字体（i 元素）不受影响 */
+.lay-steps-icon:not(:has(> i)) {
+  padding-top: 1px;
+}
+.lay-steps-item.lay-is-done .lay-steps-icon {
+  background-color: var(--lay-steps-done-color);
+}
+.lay-steps-item.lay-is-active .lay-steps-icon {
+  background-color: var(--lay-steps-active-color);
+}
+.lay-steps[data-lay-status='success']
+  .lay-steps-item.lay-is-active
+  .lay-steps-icon {
+  background-color: var(--lay-steps-status-success);
+}
+.lay-steps[data-lay-status='error']
+  .lay-steps-item.lay-is-active
+  .lay-steps-icon {
+  background-color: var(--lay-steps-status-error);
+}
+.lay-steps[data-lay-status='warning']
+  .lay-steps-item.lay-is-active
+  .lay-steps-icon {
+  background-color: var(--lay-steps-status-warning);
+}
+.lay-steps-content {
+  margin-top: var(--lay-spacing-xs);
+}
+.lay-steps-title {
+  font-size: 14px;
+  color: var(--lay-gray-900);
+}
+.lay-steps-desc {
+  margin-top: 4px;
+  font-size: 12px;
+  color: var(--lay-gray-700);
+}
+/* 可点击步骤显示手型光标 */
+.lay-steps[data-lay-clickable] .lay-steps-item {
+  cursor: pointer;
+}
+.lay-steps[data-lay-clickable] .lay-steps-item.lay-is-disabled {
+  cursor: not-allowed;
+}
+.lay-steps-item.lay-is-disabled {
+  cursor: not-allowed;
+}
+.lay-steps-item.lay-is-disabled .lay-steps-icon {
+  background-color: var(--lay-gray-200);
+  color: var(--lay-gray-500);
+}
+.lay-steps-item.lay-is-disabled .lay-steps-title {
+  color: var(--lay-gray-400);
+}
+
+/* 水平布局连接线 */
+.lay-steps-item:after {
+  content: '';
+  position: absolute;
+  top: calc(var(--lay-steps-icon-size) / 2 - 0.5px);
+  left: 50%;
+  z-index: 0;
+  width: 100%;
+  height: 1px;
+  background-color: var(--lay-steps-line-color);
+}
+.lay-steps-item:last-child:after {
+  display: none;
+}
+.lay-steps-item.lay-is-done:after,
+.lay-steps-item.lay-is-active:after {
+  background-color: var(--lay-steps-done-color);
+}
+
+/* 垂直布局 */
+.lay-steps[data-lay-layout='vertical'] {
+  flex-direction: column;
+  align-items: stretch;
+}
+.lay-steps[data-lay-layout='vertical'] .lay-steps-item {
+  flex: none;
+  flex-direction: row;
+  align-items: flex-start;
+  text-align: left;
+  padding-bottom: var(--lay-spacing-lg);
+}
+.lay-steps[data-lay-layout='vertical'] .lay-steps-item:after {
+  display: none;
+}
+.lay-steps[data-lay-layout='vertical'] .lay-steps-item:before {
+  content: '';
+  position: absolute;
+  left: calc(var(--lay-steps-icon-size) / 2 - 0.5px);
+  top: var(--lay-steps-icon-size);
+  bottom: 0;
+  z-index: 0;
+  width: 1px;
+  background-color: var(--lay-steps-line-color);
+}
+.lay-steps[data-lay-layout='vertical'] .lay-steps-item.lay-is-done:before,
+.lay-steps[data-lay-layout='vertical'] .lay-steps-item.lay-is-active:before {
+  background-color: var(--lay-steps-done-color);
+}
+.lay-steps[data-lay-layout='vertical'] .lay-steps-item:last-child:before {
+  display: none;
+}
+.lay-steps[data-lay-layout='vertical'] .lay-steps-item:last-child {
+  padding-bottom: 0;
+}
+.lay-steps[data-lay-layout='vertical'] .lay-steps-content {
+  margin-top: 0;
+  margin-left: var(--lay-spacing-sm);
+}
+
+/* 尺寸变体 */
+.lay-steps[data-lay-size='xs'] {
+  --lay-steps-icon-size: 22px;
+  --lay-steps-font-size: 12px;
+}
+.lay-steps[data-lay-size='sm'] {
+  --lay-steps-icon-size: 24px;
+}
+.lay-steps[data-lay-size='lg'] {
+  --lay-steps-icon-size: 32px;
+  --lay-steps-font-size: 16px;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -40,3 +40,4 @@ export { flow } from './components/flow.js';
 export { floatbar } from './components/floatbar.js';
 export { initializer } from './components/initializer.js';
 export { code } from './components/code.js';
+export { steps } from './components/steps.js';

--- a/src/index.umd.js
+++ b/src/index.umd.js
@@ -40,6 +40,7 @@ import { flow } from './components/flow.js';
 import { floatbar } from './components/floatbar.js';
 import { initializer } from './components/initializer.js';
 import { code } from './components/code.js';
+import { steps } from './components/steps.js';
 
 const layui = {
   lay,
@@ -77,6 +78,7 @@ const layui = {
   floatbar,
   initializer,
   code,
+  steps,
 };
 
 export default layui;

--- a/tests/visual/steps.html
+++ b/tests/visual/steps.html
@@ -1,0 +1,424 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1"
+    />
+    <title>步骤条 - layui</title>
+    <link rel="stylesheet" href="./assets/dist/css/layui.css" />
+    <style>
+      /* 演示区块排版 */
+      .demo-section {
+        margin-bottom: var(--lay-spacing-xl);
+      }
+      .demo-section h2 {
+        margin: 0 0 var(--lay-spacing);
+        font-size: 16px;
+        font-weight: 600;
+        color: var(--lay-gray-900);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="lay-padding-5">
+      <section class="demo-section">
+        <h2>基础用法</h2>
+        <!-- 静态标记：data-lay-current 声明当前步骤，render 自动计算状态 -->
+        <div class="lay-steps" data-lay-current="2">
+          <div class="lay-steps-item">
+            <div class="lay-steps-icon">1</div>
+            <div class="lay-steps-content">
+              <div class="lay-steps-title">步骤一</div>
+              <div class="lay-steps-desc">填写基本信息</div>
+            </div>
+          </div>
+          <div class="lay-steps-item">
+            <div class="lay-steps-icon">2</div>
+            <div class="lay-steps-content">
+              <div class="lay-steps-title">步骤二</div>
+              <div class="lay-steps-desc">完善个人资料</div>
+            </div>
+          </div>
+          <div class="lay-steps-item">
+            <div class="lay-steps-icon">3</div>
+            <div class="lay-steps-content">
+              <div class="lay-steps-title">步骤三</div>
+              <div class="lay-steps-desc">确认提交</div>
+            </div>
+          </div>
+          <div class="lay-steps-item">
+            <div class="lay-steps-icon">4</div>
+            <div class="lay-steps-content">
+              <div class="lay-steps-title">步骤四</div>
+              <div class="lay-steps-desc">完成</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="demo-section">
+        <h2>不同尺寸</h2>
+        <div class="lay-steps" data-lay-current="2" data-lay-size="xs">
+          <div class="lay-steps-item">
+            <div class="lay-steps-icon">1</div>
+            <div class="lay-steps-content">
+              <div class="lay-steps-title">小</div>
+            </div>
+          </div>
+          <div class="lay-steps-item">
+            <div class="lay-steps-icon">2</div>
+            <div class="lay-steps-content">
+              <div class="lay-steps-title">小</div>
+            </div>
+          </div>
+          <div class="lay-steps-item">
+            <div class="lay-steps-icon">3</div>
+            <div class="lay-steps-content">
+              <div class="lay-steps-title">小</div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="lay-steps"
+          data-lay-current="2"
+          style="margin-top: var(--lay-spacing)"
+        >
+          <div class="lay-steps-item">
+            <div class="lay-steps-icon">1</div>
+            <div class="lay-steps-content">
+              <div class="lay-steps-title">默认</div>
+            </div>
+          </div>
+          <div class="lay-steps-item">
+            <div class="lay-steps-icon">2</div>
+            <div class="lay-steps-content">
+              <div class="lay-steps-title">默认</div>
+            </div>
+          </div>
+          <div class="lay-steps-item">
+            <div class="lay-steps-icon">3</div>
+            <div class="lay-steps-content">
+              <div class="lay-steps-title">默认</div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="lay-steps"
+          data-lay-current="2"
+          data-lay-size="lg"
+          style="margin-top: var(--lay-spacing)"
+        >
+          <div class="lay-steps-item">
+            <div class="lay-steps-icon">1</div>
+            <div class="lay-steps-content">
+              <div class="lay-steps-title">大</div>
+            </div>
+          </div>
+          <div class="lay-steps-item">
+            <div class="lay-steps-icon">2</div>
+            <div class="lay-steps-content">
+              <div class="lay-steps-title">大</div>
+            </div>
+          </div>
+          <div class="lay-steps-item">
+            <div class="lay-steps-icon">3</div>
+            <div class="lay-steps-content">
+              <div class="lay-steps-title">大</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="demo-section">
+        <h2>垂直布局</h2>
+        <div class="lay-steps" data-lay-current="2" data-lay-layout="vertical">
+          <div class="lay-steps-item">
+            <div class="lay-steps-icon">1</div>
+            <div class="lay-steps-content">
+              <div class="lay-steps-title">步骤一</div>
+              <div class="lay-steps-desc">填写基本信息</div>
+            </div>
+          </div>
+          <div class="lay-steps-item">
+            <div class="lay-steps-icon">2</div>
+            <div class="lay-steps-content">
+              <div class="lay-steps-title">步骤二</div>
+              <div class="lay-steps-desc">完善个人资料</div>
+            </div>
+          </div>
+          <div class="lay-steps-item">
+            <div class="lay-steps-icon">3</div>
+            <div class="lay-steps-content">
+              <div class="lay-steps-title">步骤三</div>
+              <div class="lay-steps-desc">确认提交</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="demo-section">
+        <h2>禁用步骤</h2>
+        <div class="lay-steps" data-lay-current="2">
+          <div class="lay-steps-item">
+            <div class="lay-steps-icon">1</div>
+            <div class="lay-steps-content">
+              <div class="lay-steps-title">已完成</div>
+            </div>
+          </div>
+          <div class="lay-steps-item">
+            <div class="lay-steps-icon">2</div>
+            <div class="lay-steps-content">
+              <div class="lay-steps-title">当前</div>
+            </div>
+          </div>
+          <div class="lay-steps-item lay-is-disabled">
+            <div class="lay-steps-icon">3</div>
+            <div class="lay-steps-content">
+              <div class="lay-steps-title">未开放</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="demo-section">
+        <h2>动态渲染（generate）</h2>
+        <div id="dynamicDemo"></div>
+      </section>
+
+      <section class="demo-section">
+        <h2>可点击切换</h2>
+        <div id="clickDemo"></div>
+      </section>
+
+      <section class="demo-section">
+        <h2>自定义步骤图标</h2>
+        <div id="iconDemo"></div>
+      </section>
+
+      <section class="demo-section">
+        <h2>状态色变体（data-lay-status）</h2>
+        <div class="lay-steps" data-lay-current="2" data-lay-status="error">
+          <div class="lay-steps-item">
+            <div class="lay-steps-icon">1</div>
+            <div class="lay-steps-content">
+              <div class="lay-steps-title">填写信息</div>
+            </div>
+          </div>
+          <div class="lay-steps-item">
+            <div class="lay-steps-icon">2</div>
+            <div class="lay-steps-content">
+              <div class="lay-steps-title">校验失败</div>
+            </div>
+          </div>
+          <div class="lay-steps-item">
+            <div class="lay-steps-icon">3</div>
+            <div class="lay-steps-content">
+              <div class="lay-steps-title">确认提交</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="demo-section">
+        <h2>分步表单（业务流程示例）</h2>
+        <p
+          style="
+            margin: 0 0 var(--lay-spacing);
+            font-size: 12px;
+            color: var(--lay-gray-700);
+          "
+        >
+          按顺序填写并点击「下一步」逐步推进；已到达的步骤可点击回退或跳转，
+          未到达的后续步骤会被业务阻断（看控制台）
+        </p>
+        <div id="formSteps"></div>
+        <div
+          id="formContent"
+          style="
+            margin: var(--lay-spacing) 0;
+            padding: var(--lay-spacing);
+            border: 1px solid var(--lay-border-color);
+            border-radius: var(--lay-border-radius);
+          "
+        >
+          <div class="form-step" data-step="1">
+            <label>姓名：</label>
+            <input
+              id="nameInput"
+              class="lay-input"
+              placeholder="请输入姓名"
+              style="width: 200px"
+            />
+          </div>
+          <div class="form-step" data-step="2">
+            <label>邮箱：</label>
+            <input
+              id="emailInput"
+              class="lay-input"
+              placeholder="请输入邮箱"
+              style="width: 200px"
+            />
+          </div>
+          <div class="form-step" data-step="3">
+            <label>
+              <input type="checkbox" id="agreeCheck" />
+              我已阅读并同意《用户声明》
+            </label>
+          </div>
+          <div class="form-step" data-step="4">
+            <span>提交成功，感谢您的参与！</span>
+          </div>
+        </div>
+        <div>
+          <button id="prevBtn" class="lay-btn lay-btn-sm">上一步</button>
+          <button id="nextBtn" class="lay-btn lay-btn-sm lay-btn-primary">
+            下一步
+          </button>
+        </div>
+      </section>
+    </div>
+
+    <script src="./assets/dist/layui.js"></script>
+    <script>
+      layui.use(() => {
+        const { steps, $ } = layui;
+
+        // 订阅点击切换事件（切换前触发，回调返回 false 可阻断切换）
+        steps.on('click', ({ elem, from, to, item }) => {
+          console.warn('步骤切换：', from, '→', to, elem, item);
+        });
+
+        // 动态渲染：数据数组 + 公共属性
+        $('#dynamicDemo').append(
+          steps.generate({
+            current: 2,
+            data: [
+              '步骤一',
+              '步骤二',
+              { title: '步骤三', description: '带描述文字' },
+              '步骤四',
+            ],
+          }),
+        );
+        // 动态渲染的步骤条需手动 render 绑定交互
+        steps.render({ elem: $('#dynamicDemo').find('.lay-steps') });
+
+        // 可点击切换：点击已完成/当前步骤可跳转
+        $('#clickDemo').append(
+          steps.generate({
+            current: 1,
+            clickable: true,
+            data: ['第一步', '第二步', '第三步', '第四步'],
+          }),
+        );
+        steps.render({ elem: $('#clickDemo').find('.lay-steps') });
+
+        // 自定义步骤图标：对象项传 icon HTML
+        $('#iconDemo').append(
+          steps.generate({
+            current: 2,
+            data: [
+              {
+                title: '注册',
+                icon: '<i class="lay-icon lay-icon-email"></i>',
+              },
+              {
+                title: '完善',
+                icon: '<i class="lay-icon lay-icon-diamond"></i>',
+              },
+              '完成',
+            ],
+          }),
+        );
+        steps.render({ elem: $('#iconDemo').find('.lay-steps') });
+
+        // 订阅 change 事件（切换成功后触发）
+        steps.on('change', ({ elem, from, to }) => {
+          console.warn('步骤已切换：', from, '→', to, elem);
+        });
+
+        // 分步表单：模拟正常业务流程
+        // - 当前步骤表单校验通过后，点击「下一步」进入下一项
+        // - 不能跳到未到达的后续步骤（步骤条点击被业务阻断）
+        // - 已到达的步骤可随时回退或跳转
+        const formSteps = $('#formSteps');
+        formSteps.append(
+          steps.generate({
+            current: 1,
+            clickable: true,
+            layFilter: 'form',
+            data: ['填写信息', '验证邮箱', '签署声明', '完成'],
+          }),
+        );
+        const $formSteps = formSteps.find('.lay-steps');
+        steps.render({ elem: $formSteps });
+        const formId = $formSteps.attr('lay-steps-id');
+
+        let formCurrent = 1; // 当前步骤
+        let formMax = 1; // 已到达的最大步骤（可回跳上限）
+
+        const showFormStep = (step) => {
+          $('#formContent .form-step').each(function () {
+            $(this).toggle($(this).data('step') === step);
+          });
+        };
+        const updateFormBtn = () => {
+          $('#prevBtn').prop('disabled', formCurrent <= 1);
+          $('#nextBtn').prop('disabled', formCurrent >= 4);
+        };
+        showFormStep(1);
+        updateFormBtn();
+
+        // 步骤条点击：只能回跳到已到达的步骤（lay-filter 隔离，不影响其它步骤条）
+        steps.on('click(form)', ({ from, to }) => {
+          if (to > formMax) {
+            console.warn(
+              `业务阻断：不能跳到第 ${to} 步（当前第 ${from} 步，未到达）`,
+            );
+            return false;
+          }
+          formCurrent = to;
+          showFormStep(to);
+          updateFormBtn();
+        });
+
+        // 订阅 change 事件（切换成功后触发，仅 form 实例）
+        steps.on('change(form)', ({ from, to }) => {
+          console.warn('步骤已切换：', from, '→', to);
+        });
+
+        // 上一步
+        $('#prevBtn').on('click', () => {
+          if (formCurrent <= 1) return;
+          formCurrent--;
+          steps.setCurrent(formId, formCurrent);
+          showFormStep(formCurrent);
+          updateFormBtn();
+        });
+
+        // 下一步：校验当前步骤表单后推进
+        $('#nextBtn').on('click', () => {
+          if (formCurrent === 1 && !$('#nameInput').val().trim()) {
+            console.warn('请先填写姓名');
+            return;
+          }
+          if (formCurrent === 2 && !$('#emailInput').val().trim()) {
+            console.warn('请先填写邮箱');
+            return;
+          }
+          if (formCurrent === 3 && !$('#agreeCheck').prop('checked')) {
+            console.warn('请先勾选同意《用户声明》');
+            return;
+          }
+          formCurrent++;
+          formMax = Math.max(formMax, formCurrent);
+          steps.setCurrent(formId, formCurrent);
+          showFormStep(formCurrent);
+          updateFormBtn();
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/tests/visual/steps.html
+++ b/tests/visual/steps.html
@@ -60,6 +60,7 @@
 
       <section class="demo-section">
         <h2>不同尺寸</h2>
+        <!-- 尺寸变体：data-lay-size 声明 xs / 默认 / lg -->
         <div class="lay-steps" data-lay-current="2" data-lay-size="xs">
           <div class="lay-steps-item">
             <div class="lay-steps-icon">1</div>
@@ -133,6 +134,7 @@
 
       <section class="demo-section">
         <h2>垂直布局</h2>
+        <!-- 垂直布局：data-lay-layout="vertical" 纵向排列 -->
         <div class="lay-steps" data-lay-current="2" data-lay-layout="vertical">
           <div class="lay-steps-item">
             <div class="lay-steps-icon">1</div>
@@ -160,6 +162,7 @@
 
       <section class="demo-section">
         <h2>禁用步骤</h2>
+        <!-- 禁用步骤：lay-is-disabled 状态类置灰不可点 -->
         <div class="lay-steps" data-lay-current="2">
           <div class="lay-steps-item">
             <div class="lay-steps-icon">1</div>
@@ -199,6 +202,7 @@
 
       <section class="demo-section">
         <h2>状态色变体（data-lay-status）</h2>
+        <!-- 状态色变体：data-lay-status="error" 当前步骤显示红色 -->
         <div class="lay-steps" data-lay-current="2" data-lay-status="error">
           <div class="lay-steps-item">
             <div class="lay-steps-icon">1</div>
@@ -305,7 +309,7 @@
         // 动态渲染的步骤条需手动 render 绑定交互
         steps.render({ elem: $('#dynamicDemo').find('.lay-steps') });
 
-        // 可点击切换：点击已完成/当前步骤可跳转
+        // 可点击切换：点击任意未禁用步骤可切换；点击当前步骤不触发切换
         $('#clickDemo').append(
           steps.generate({
             current: 1,


### PR DESCRIPTION
### 😃 本次 PR 的变化性质

> 请至少勾选一项

- [x] 功能新增
- [ ] 问题修复
- [ ] 功能优化
- [ ] 分支合并
- [ ] 其他改动：请在此处填写

### 🌱 本次 PR 的变化内容

- 新增 `src/components/steps.js`：Steps 步骤条组件（class extends Component）——`build`/`generate`/`render` 双轨、`data-lay-*` 属性模式、`lay-filter` 事件隔离、`setCurrent` 动态控制、click/change 事件（含 `{ elem, from, to, item }`）
- 新增 `src/css/modules/steps.css`：水平/垂直布局、连接线着色、`data-lay-status` 状态色、尺寸变体、组件级令牌 `--lay-steps-*`
- 新增 `tests/visual/steps.html`：演示页（基础用法/尺寸/垂直/禁用/动态渲染/可点击/自定义图标/状态色/分步表单业务流程示例）
- 修改 `src/components/initializer.js`：注册 steps 自动渲染
- 修改 `src/core/i18n.js`：新增 `steps.click` 词典
- 修改 `src/css/index.css`：`@import` steps.css
- 修改 `src/index.js`、`src/index.umd.js`：导出 steps

### ✅ 本次 PR 的满足条件

> 请在申请合并之前，将符合条件的每一项进行勾选

- [ ] 已提供在线演示地址（如：[codepen](https://codepen.io/), [stackblitz](https://stackblitz.com/)）或无需演示
- [x] 已对每一项的改动均测试通过
- [x] 已提供具体的变化内容说明

> 说明：验证方式为本地 `npm run serve -p 3003` + agent-browser 自动化断言（状态/布局/尺寸/点击/键盘/事件/越界/幂等共 16 项回归）+ lint / format / jest 全绿。

Closes #3138


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增步骤条组件，支持水平/垂直布局、尺寸变体及完成、当前、禁用等状态。
  * 支持自定义图标、状态颜色、点击与键盘操作，并可动态切换当前步骤。
  * 提供步骤变化事件及分步表单等交互场景。
  * 已接入自动渲染机制，并支持通过 ESM 和 UMD 入口使用。
* **样式**
  * 新增连接线、标题、描述及多种状态和尺寸样式。
* **示例**
  * 新增可视化示例，涵盖多种配置与交互流程。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->